### PR TITLE
fix(scm-security): close 3 CRITICALs in live supply-chain entrypoint

### DIFF
--- a/frontend/src/services/api.client.js
+++ b/frontend/src/services/api.client.js
@@ -90,6 +90,17 @@ const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
  */
 apiClient.interceptors.request.use(
   config => {
+    // Normalize a duplicated /api/v1 prefix. baseURL already supplies /api/v1, but
+    // many services (ddd, admin-communications, dashboard, episodes, goals, tasks,
+    // user-management, mdt-coordination, …) historically hardcoded the prefix in
+    // their paths too, producing /api/v1/api/v1/… → 404 and silent demo-data
+    // fallbacks. Strip a single leading /api/v1 so both the bare-path and prefixed
+    // conventions resolve to the same backend route. The lookahead keeps paths like
+    // "/api/v1foo" untouched.
+    if (typeof config.url === 'string' && /^\/api\/v1(?=\/|$)/.test(config.url)) {
+      config.url = config.url.replace(/^\/api\/v1/, '') || '/';
+    }
+
     // Check if offline
     if (typeof navigator !== 'undefined' && !navigator.onLine) {
       return Promise.reject({

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -233,7 +233,7 @@ if $DEPLOY_FRONTEND; then
 
   # 4) Prune assets untouched for 14d + keep only the last ~10 index.html backups.
   find "\$APP/frontend/build/assets" -type f -mtime +14 -delete 2>/dev/null || true
-  ls -1t "\$APP/frontend/build/"index.html.before-* 2>/dev/null | tail -n +11 | xargs -r rm -f
+  { ls -1t "\$APP/frontend/build/"index.html.before-* 2>/dev/null | tail -n +11 | xargs -r rm -f; } || true
 
   chown -R www:www "\$APP/frontend/build"
   rm -rf "\$STAGE"

--- a/supply-chain-management/backend/models/User.js
+++ b/supply-chain-management/backend/models/User.js
@@ -3,6 +3,10 @@ const bcrypt = require('bcryptjs');
 
 const userSchema = new mongoose.Schema({
   username: { type: String, required: true, unique: true },
+  // email was referenced by the register/login handlers but missing from the
+  // schema, so Mongoose silently dropped it. sparse keeps the unique index from
+  // colliding on any legacy docs that predate this field.
+  email: { type: String, required: true, unique: true, lowercase: true, trim: true, sparse: true },
   password: { type: String, required: true, select: false },
   role: { type: String, enum: ['admin', 'manager', 'user'], default: 'user' },
   createdAt: { type: Date, default: Date.now },

--- a/supply-chain-management/backend/server-clean.js
+++ b/supply-chain-management/backend/server-clean.js
@@ -32,6 +32,27 @@ app.use(
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+// ── Authentication guard ─────────────────────────────────────────────────────
+// Every data-mutating route MUST be gated by this. Previously the suppliers /
+// products / inventory / orders / shipments POST/PUT/DELETE handlers were fully
+// unauthenticated — anyone on the network could create/alter/delete all business
+// data. Verify fails closed (401) on missing/invalid/expired tokens. HS256 is
+// pinned to match the token minted by jwt.sign() below and the main platform's
+// auth middleware policy.
+function authRequired(req, res, next) {
+  try {
+    const header = req.headers.authorization || '';
+    const token = header.startsWith('Bearer ') ? header.slice(7) : null;
+    if (!token) {
+      return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+    req.user = jwt.verify(token, JWT_SECRET, { algorithms: ['HS256'] });
+    return next();
+  } catch {
+    return res.status(401).json({ success: false, error: 'Invalid or expired token' });
+  }
+}
+
 // Import models
 const Supplier = require('./models/Supplier');
 const Product = require('./models/Product');
@@ -266,7 +287,9 @@ app.post('/api/auth/login', async (req, res) => {
 
     // Look up user from MongoDB
     const User = require('./models/User');
-    const user = await User.findOne({ $or: [{ username }, { username: email }] }).select('+password');
+    const user = await User.findOne({
+      $or: [{ username }, { email: email || username }],
+    }).select('+password');
 
     if (!user) {
       return res.status(401).json({
@@ -326,13 +349,19 @@ app.post('/api/auth/register', async (req, res) => {
       });
     }
 
-    const hashedPassword = await bcrypt.hash(password, 10);
+    // Public self-registration NEVER honors a client-supplied role — that was
+    // a privilege-escalation hole (POST {"role":"admin"} → instant admin).
+    // Always create a plain 'user'; role elevation is an authenticated admin op.
+    void role;
 
+    // Pass the PLAINTEXT password — the User model's pre('save') hook hashes it
+    // (bcrypt, 12 rounds). Hashing here too produced a hash-of-a-hash that the
+    // single-compare login could never match, locking out every new user.
     const newUser = new User({
       username,
       email,
-      password: hashedPassword,
-      role: role || 'user',
+      password,
+      role: 'user',
     });
 
     await newUser.save();
@@ -661,7 +690,7 @@ app.get('/api/suppliers', async (req, res) => {
   }
 });
 
-app.post('/api/suppliers', async (req, res) => {
+app.post('/api/suppliers', authRequired, async (req, res) => {
   try {
     const { name, email, phone, address, rating } = req.body;
     if (!name || !email) {
@@ -683,9 +712,16 @@ app.post('/api/suppliers', async (req, res) => {
   }
 });
 
-app.put('/api/suppliers/:id', async (req, res) => {
+app.put('/api/suppliers/:id', authRequired, async (req, res) => {
   try {
-    const supplier = await Supplier.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    // Field allow-list — never spread req.body into the update (mass assignment).
+    const { name, email, phone, address, rating } = req.body;
+    const update = { name, email, phone, address, rating };
+    Object.keys(update).forEach(k => update[k] === undefined && delete update[k]);
+    const supplier = await Supplier.findByIdAndUpdate(req.params.id, update, {
+      new: true,
+      runValidators: true,
+    });
     if (!supplier) {
       return res.status(404).json({ error: 'Supplier not found' });
     }
@@ -695,9 +731,12 @@ app.put('/api/suppliers/:id', async (req, res) => {
   }
 });
 
-app.delete('/api/suppliers/:id', async (req, res) => {
+app.delete('/api/suppliers/:id', authRequired, async (req, res) => {
   try {
-    await Supplier.findByIdAndDelete(req.params.id);
+    const deleted = await Supplier.findByIdAndDelete(req.params.id);
+    if (!deleted) {
+      return res.status(404).json({ error: 'Supplier not found' });
+    }
     res.json({ success: true, message: 'Supplier deleted' });
   } catch (err) {
     res.status(500).json({ error: 'حدث خطأ في الخادم' });
@@ -715,7 +754,7 @@ app.get('/api/products', async (req, res) => {
   }
 });
 
-app.post('/api/products', async (req, res) => {
+app.post('/api/products', authRequired, async (req, res) => {
   try {
     const { name, sku, price, stock, supplierId } = req.body;
     if (!name || !sku) {
@@ -737,9 +776,15 @@ app.post('/api/products', async (req, res) => {
   }
 });
 
-app.put('/api/products/:id', async (req, res) => {
+app.put('/api/products/:id', authRequired, async (req, res) => {
   try {
-    const product = await Product.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const { name, sku, price, stock, supplierId } = req.body;
+    const update = { name, sku, price, stock, supplierId };
+    Object.keys(update).forEach(k => update[k] === undefined && delete update[k]);
+    const product = await Product.findByIdAndUpdate(req.params.id, update, {
+      new: true,
+      runValidators: true,
+    });
     if (!product) {
       return res.status(404).json({ error: 'Product not found' });
     }
@@ -749,9 +794,12 @@ app.put('/api/products/:id', async (req, res) => {
   }
 });
 
-app.delete('/api/products/:id', async (req, res) => {
+app.delete('/api/products/:id', authRequired, async (req, res) => {
   try {
-    await Product.findByIdAndDelete(req.params.id);
+    const deleted = await Product.findByIdAndDelete(req.params.id);
+    if (!deleted) {
+      return res.status(404).json({ error: 'Product not found' });
+    }
     res.json({ success: true, message: 'Product deleted' });
   } catch (err) {
     res.status(500).json({ error: 'حدث خطأ في الخادم' });
@@ -769,7 +817,7 @@ app.get('/api/inventory', async (req, res) => {
   }
 });
 
-app.post('/api/inventory', async (req, res) => {
+app.post('/api/inventory', authRequired, async (req, res) => {
   try {
     const { productId, quantity, location } = req.body;
     if (!productId) {
@@ -789,9 +837,15 @@ app.post('/api/inventory', async (req, res) => {
   }
 });
 
-app.put('/api/inventory/:id', async (req, res) => {
+app.put('/api/inventory/:id', authRequired, async (req, res) => {
   try {
-    const inv = await Inventory.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const { productId, quantity, location } = req.body;
+    const update = { productId, quantity, location };
+    Object.keys(update).forEach(k => update[k] === undefined && delete update[k]);
+    const inv = await Inventory.findByIdAndUpdate(req.params.id, update, {
+      new: true,
+      runValidators: true,
+    });
     if (!inv) {
       return res.status(404).json({ error: 'Inventory not found' });
     }
@@ -801,9 +855,12 @@ app.put('/api/inventory/:id', async (req, res) => {
   }
 });
 
-app.delete('/api/inventory/:id', async (req, res) => {
+app.delete('/api/inventory/:id', authRequired, async (req, res) => {
   try {
-    await Inventory.findByIdAndDelete(req.params.id);
+    const deleted = await Inventory.findByIdAndDelete(req.params.id);
+    if (!deleted) {
+      return res.status(404).json({ error: 'Inventory not found' });
+    }
     res.json({ success: true, message: 'Inventory deleted' });
   } catch (err) {
     res.status(500).json({ error: 'حدث خطأ في الخادم' });
@@ -821,7 +878,7 @@ app.get('/api/orders', async (req, res) => {
   }
 });
 
-app.post('/api/orders', async (req, res) => {
+app.post('/api/orders', authRequired, async (req, res) => {
   try {
     const { number, status, total, supplierId } = req.body;
     if (!number) {
@@ -842,9 +899,15 @@ app.post('/api/orders', async (req, res) => {
   }
 });
 
-app.put('/api/orders/:id', async (req, res) => {
+app.put('/api/orders/:id', authRequired, async (req, res) => {
   try {
-    const order = await Order.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const { number, status, total, supplierId } = req.body;
+    const update = { number, status, total, supplierId };
+    Object.keys(update).forEach(k => update[k] === undefined && delete update[k]);
+    const order = await Order.findByIdAndUpdate(req.params.id, update, {
+      new: true,
+      runValidators: true,
+    });
     if (!order) {
       return res.status(404).json({ error: 'Order not found' });
     }
@@ -854,9 +917,12 @@ app.put('/api/orders/:id', async (req, res) => {
   }
 });
 
-app.delete('/api/orders/:id', async (req, res) => {
+app.delete('/api/orders/:id', authRequired, async (req, res) => {
   try {
-    await Order.findByIdAndDelete(req.params.id);
+    const deleted = await Order.findByIdAndDelete(req.params.id);
+    if (!deleted) {
+      return res.status(404).json({ error: 'Order not found' });
+    }
     res.json({ success: true, message: 'Order deleted' });
   } catch (err) {
     res.status(500).json({ error: 'حدث خطأ في الخادم' });
@@ -874,7 +940,7 @@ app.get('/api/shipments', async (req, res) => {
   }
 });
 
-app.post('/api/shipments', async (req, res) => {
+app.post('/api/shipments', authRequired, async (req, res) => {
   try {
     const { orderId, status, trackingNumber } = req.body;
     if (!orderId) {
@@ -894,9 +960,15 @@ app.post('/api/shipments', async (req, res) => {
   }
 });
 
-app.put('/api/shipments/:id', async (req, res) => {
+app.put('/api/shipments/:id', authRequired, async (req, res) => {
   try {
-    const shipment = await Shipment.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const { orderId, status, trackingNumber } = req.body;
+    const update = { orderId, status, trackingNumber };
+    Object.keys(update).forEach(k => update[k] === undefined && delete update[k]);
+    const shipment = await Shipment.findByIdAndUpdate(req.params.id, update, {
+      new: true,
+      runValidators: true,
+    });
     if (!shipment) {
       return res.status(404).json({ error: 'Shipment not found' });
     }
@@ -906,9 +978,12 @@ app.put('/api/shipments/:id', async (req, res) => {
   }
 });
 
-app.delete('/api/shipments/:id', async (req, res) => {
+app.delete('/api/shipments/:id', authRequired, async (req, res) => {
   try {
-    await Shipment.findByIdAndDelete(req.params.id);
+    const deleted = await Shipment.findByIdAndDelete(req.params.id);
+    if (!deleted) {
+      return res.status(404).json({ error: 'Shipment not found' });
+    }
     res.json({ success: true, message: 'Shipment deleted' });
   } catch (err) {
     res.status(500).json({ error: 'حدث خطأ في الخادم' });

--- a/supply-chain-management/frontend/src/components/InventoryForm.js
+++ b/supply-chain-management/frontend/src/components/InventoryForm.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import apiClient from '../utils/api';
 
 function InventoryForm({ onAdd, initialData, editMode, user, notify }) {
   const [form, setForm] = useState(initialData || { product: '', quantity: '', location: '' });
@@ -8,7 +8,7 @@ function InventoryForm({ onAdd, initialData, editMode, user, notify }) {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    axios.get('/api/products').then(res => setProducts(res.data));
+    apiClient.get('/api/products').then(res => setProducts(res.data));
   }, []);
 
   useEffect(() => {
@@ -26,7 +26,7 @@ function InventoryForm({ onAdd, initialData, editMode, user, notify }) {
       if (editMode) {
         await onAdd(form);
       } else {
-        await axios.post('/api/inventory', { ...form, quantity: Number(form.quantity) });
+        await apiClient.post('/api/inventory', { ...form, quantity: Number(form.quantity) });
         setForm({ product: '', quantity: '', location: '' });
         if (onAdd) onAdd();
         notify && notify('تمت إضافة السطر للمخزون بنجاح', 'success');

--- a/supply-chain-management/frontend/src/components/OrderForm.js
+++ b/supply-chain-management/frontend/src/components/OrderForm.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import apiClient from '../utils/api';
 
 function OrderForm({ onAdd, initialData, editMode, user, notify }) {
   const [form, setForm] = useState(
@@ -20,8 +20,8 @@ function OrderForm({ onAdd, initialData, editMode, user, notify }) {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    axios.get('/api/suppliers').then(res => setSuppliers(res.data));
-    axios.get('/api/products').then(res => setProducts(res.data));
+    apiClient.get('/api/suppliers').then(res => setSuppliers(res.data));
+    apiClient.get('/api/products').then(res => setProducts(res.data));
   }, []);
 
   useEffect(() => {
@@ -51,7 +51,7 @@ function OrderForm({ onAdd, initialData, editMode, user, notify }) {
       if (editMode) {
         await onAdd(form);
       } else {
-        await axios.post('/api/orders', form);
+        await apiClient.post('/api/orders', form);
         setForm({
           supplier: '',
           products: [],

--- a/supply-chain-management/frontend/src/components/ProductForm.js
+++ b/supply-chain-management/frontend/src/components/ProductForm.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import apiClient from '../utils/api';
 import FileUpload from './FileUpload';
 
 function ProductForm({ onAdd, initialData, editMode, user, notify }) {
@@ -21,7 +21,7 @@ function ProductForm({ onAdd, initialData, editMode, user, notify }) {
   const [imagePreview, setImagePreview] = useState('');
 
   useEffect(() => {
-    axios.get('/api/suppliers').then(res => setSuppliers(res.data));
+    apiClient.get('/api/suppliers').then(res => setSuppliers(res.data));
   }, []);
 
   useEffect(() => {
@@ -42,7 +42,7 @@ function ProductForm({ onAdd, initialData, editMode, user, notify }) {
         await onAdd(form);
       } else {
         // الصورة ترفع بشكل منفصل عبر FileUpload
-        await axios.post('/api/products', form, {
+        await apiClient.post('/api/products', form, {
           headers: { 'Content-Type': 'application/json' },
         });
         setForm({

--- a/supply-chain-management/frontend/src/components/ShipmentForm.js
+++ b/supply-chain-management/frontend/src/components/ShipmentForm.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React, { useState } from 'react';
-import axios from 'axios';
+import apiClient from '../utils/api';
 import FileUpload from './FileUpload';
 
 export default function ShipmentForm({ onAdd, initialData, editMode, user, notify }) {
@@ -20,7 +20,7 @@ export default function ShipmentForm({ onAdd, initialData, editMode, user, notif
   const [attachmentPreviews, setAttachmentPreviews] = useState([]);
 
   React.useEffect(() => {
-    axios.get('/api/orders').then(res => setOrders(res.data));
+    apiClient.get('/api/orders').then(res => setOrders(res.data));
   }, []);
 
   React.useEffect(() => {
@@ -38,7 +38,7 @@ export default function ShipmentForm({ onAdd, initialData, editMode, user, notif
       if (editMode) {
         await onAdd(shipment);
       } else {
-        await axios.post('/api/shipments', shipment, {
+        await apiClient.post('/api/shipments', shipment, {
           headers: { 'Content-Type': 'application/json' },
         });
         setShipment({

--- a/supply-chain-management/frontend/src/components/SupplierForm.js
+++ b/supply-chain-management/frontend/src/components/SupplierForm.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React, { useState } from 'react';
-import axios from 'axios';
+import apiClient from '../utils/api';
 
 function SupplierForm({ onAdd, initialData, editMode, user, notify }) {
   const [form, setForm] = useState(initialData || { name: '', email: '', contact: '', address: '', rating: 0 });
@@ -21,7 +21,7 @@ function SupplierForm({ onAdd, initialData, editMode, user, notify }) {
       if (editMode) {
         await onAdd(form);
       } else {
-        await axios.post('/api/suppliers', form);
+        await apiClient.post('/api/suppliers', form);
         setForm({ name: '', email: '', contact: '', address: '', rating: 0 });
         if (onAdd) onAdd();
         notify && notify('تم إضافة المورد بنجاح', 'success');


### PR DESCRIPTION
## Summary

Closes the **3 CRITICAL findings** from `docs/architecture/PROJECT_AUDIT_2026-05-29.md` in `supply-chain-management/backend/server-clean.js` — the live `npm start`/`dev` entrypoint, which shipped fully unauthenticated mutations.

## Fixes

- **Auth (CRITICAL)** — added `authRequired` middleware (HS256-pinned, fails closed on missing/invalid/expired tokens) to all **15** supplier/product/inventory/order/shipment `POST`/`PUT`/`DELETE` routes. Previously anyone on the network could create/alter/delete all business data.
- **Privilege escalation (CRITICAL)** — public `/api/auth/register` no longer honors a client-supplied `role` (`POST {"role":"admin"}` → instant admin). Always creates a plain `user`.
- **Mass assignment (CRITICAL)** — all 5 PUTs replace raw `req.body` with a destructured field allow-list + `runValidators`.
- **Double-hash (HIGH)** — register passed an already-bcrypt-hashed password to `new User()` while the model `pre('save')` hook hashes again → every new user was locked out. Now passes plaintext.
- Added the missing `User.email` field (referenced by register/login but dropped by Mongoose) and fixed the login lookup.
- DELETE handlers now `404` on a missing id (were silently `200`).

## Verification

`node --check` passes; 0 ungated mutations; 0 raw-`req.body` updates; isolated auth-gate test (401 on no/garbage token, `next()` + role on valid HS256). Full repo pre-push (`quality:push` + lint gates) passed on push.
