### PR TITLE
fix(cdss): make the live CDSS dashboard work on real backend data

### DIFF
--- a/frontend/src/__tests__/pages-CDSSDashboard-render.test.js
+++ b/frontend/src/__tests__/pages-CDSSDashboard-render.test.js
@@ -1,0 +1,183 @@
+/**
+ * Render smoke test for pages/CDSS/CDSSDashboard.jsx.
+ *
+ * Why: the dashboard service layer is unit-tested (services-cdssService-adapters),
+ * but the live "حدث خطأ غير متوقع" boundary is a RENDER error — the one thing a
+ * static read can't rule out under MUI v9 / recharts v3 / framer-motion v12. This
+ * test executes the full render path (loading → data → all six tabs mounted) and
+ * asserts the page reaches its header without throwing, for BOTH a populated
+ * response and the empty-instance case (prod DB currently has zero CDSS rows, so
+ * empty-but-rendered is the real production state — it must not crash).
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// jsdom lacks the browser APIs the dashboard's KPI counter (IntersectionObserver)
+// and recharts ResponsiveContainer (ResizeObserver) touch on mount.
+beforeAll(() => {
+  class NoopObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+  }
+  global.IntersectionObserver = NoopObserver;
+  global.ResizeObserver = NoopObserver;
+  if (!window.matchMedia) {
+    window.matchMedia = () => ({
+      matches: false,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    });
+  }
+});
+
+// Keep the real constants (ALERT_SEVERITIES / RULE_CATEGORIES the component reads),
+// override only the data-fetching functions so no network is touched.
+const mockData = {
+  stats: null,
+  alerts: [],
+  rules: [],
+  suggestions: [],
+  drugs: [],
+  decisionLog: [],
+};
+
+jest.mock('services/cdssService', () => {
+  const actual = jest.requireActual('services/cdssService');
+  return {
+    __esModule: true,
+    ...actual,
+    getStats: jest.fn(() => Promise.resolve(mockData.stats)),
+    getAlerts: jest.fn(() => Promise.resolve(mockData.alerts)),
+    getRules: jest.fn(() => Promise.resolve(mockData.rules)),
+    getRehabSuggestions: jest.fn(() => Promise.resolve(mockData.suggestions)),
+    getDrugLibrary: jest.fn(() => Promise.resolve(mockData.drugs)),
+    getDecisionLog: jest.fn(() => Promise.resolve(mockData.decisionLog)),
+  };
+});
+
+import CDSSDashboard from 'pages/CDSS/CDSSDashboard';
+
+const POPULATED = {
+  stats: {
+    activeAlerts: 23,
+    criticalAlerts: 4,
+    pendingSuggestions: 11,
+    rulesActive: 58,
+    rulesTriggeredToday: 9,
+    trend: { alerts: [18, 22, 15, 28, 23, 19, 23], riskScores: [38, 41, 45, 39, 44, 40, 42] },
+  },
+  alerts: [
+    {
+      _id: 'a1',
+      severity: 'critical',
+      type: 'drug_interaction',
+      message: 'تفاعل دوائي خطير',
+      beneficiaryName: 'أحمد العتيبي',
+      beneficiaryId: 'b1',
+      triggeredAt: new Date().toISOString(),
+      status: 'active',
+      ruleCode: 'DR-INT-001',
+    },
+  ],
+  rules: [
+    {
+      _id: 'r1',
+      code: 'DR-INT-001',
+      name: 'تفاعل دوائي',
+      category: 'medication',
+      severity: 'critical',
+      condition: 'a AND b',
+      action: 'إشعار فوري',
+      isActive: true,
+      triggerCount: 3,
+      evidenceLevel: 'A',
+    },
+  ],
+  suggestions: [
+    {
+      _id: 's1',
+      beneficiaryName: 'فاطمة الشهري',
+      beneficiaryId: 'b2',
+      diagnosis: 'إصابة نخاع شوكي',
+      suggestedPlan: {
+        sessions: 3,
+        frequency: 'أسبوعياً',
+        modalities: ['تدريب القوة'],
+        goals: ['تحسين الحركة'],
+        duration: '8 أسابيع',
+        evidenceBased: true,
+        referencedGuideline: 'SCIRE 2024',
+      },
+      confidenceScore: 88,
+      status: 'pending',
+    },
+  ],
+  drugs: [
+    {
+      _id: 'd1',
+      code: 'BACLO',
+      name: 'باكلوفين',
+      category: 'مرخيات العضلات',
+      interactions: ['بنزوديازيبين'],
+      contraindications: ['فشل كلوي'],
+      highRisk: true,
+    },
+  ],
+  decisionLog: [
+    {
+      _id: 'l1',
+      action: 'override',
+      alertCode: 'SESS-ABS-002',
+      clinician: 'د. هاني',
+      reason: 'إجازة طارئة',
+      timestamp: new Date().toISOString(),
+    },
+  ],
+};
+
+const EMPTY = {
+  stats: { activeAlerts: 0, criticalAlerts: 0, pendingSuggestions: 0, rulesActive: 0 },
+  alerts: [],
+  rules: [],
+  suggestions: [],
+  drugs: [],
+  decisionLog: [],
+};
+
+afterEach(() => {
+  Object.assign(mockData, {
+    stats: null,
+    alerts: [],
+    rules: [],
+    suggestions: [],
+    drugs: [],
+    decisionLog: [],
+  });
+});
+
+describe('CDSSDashboard renders without throwing', () => {
+  test('populated backend data → header + critical banner render', async () => {
+    Object.assign(mockData, POPULATED);
+    render(<CDSSDashboard />);
+    // Reaching the header proves it got past loading and rendered the full tree.
+    expect(await screen.findByText('نظام دعم القرار السريري')).toBeTruthy();
+    // critical-alert banner (stats.criticalAlerts > 0) renders without crashing
+    await waitFor(() => expect(screen.getByText(/تنبيه حرج يستوجب/)).toBeTruthy());
+  });
+
+  test('empty instance (prod state: zero CDSS rows) → still renders, no crash', async () => {
+    Object.assign(mockData, EMPTY);
+    render(<CDSSDashboard />);
+    expect(await screen.findByText('نظام دعم القرار السريري')).toBeTruthy();
+    // overview tab panels render (KPIs + severity breakdown), not an error boundary
+    expect(await screen.findByText('توزيع التنبيهات')).toBeTruthy();
+  });
+});

--- a/frontend/src/__tests__/services-cdssService-adapters.test.js
+++ b/frontend/src/__tests__/services-cdssService-adapters.test.js
@@ -1,0 +1,245 @@
+/**
+ * Behavioral tests for services/cdssService.js — backend→frontend adapters.
+ *
+ * The canonical backend (66666 `/api/v1/cdss`) returns paginated envelopes
+ * ({ data: [...] }) and a nested stats object ({ stats: { X: { value } } }),
+ * with field/enum names that differ from what CDSSDashboard renders. These
+ * tests lock the normalization so the dashboard shows REAL data (not the
+ * silent demo-data fallback) and never receives a shape it would crash on.
+ */
+
+jest.mock('utils/logger', () => ({
+  __esModule: true,
+  default: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+}));
+
+const mockApi = { get: jest.fn(), post: jest.fn(), patch: jest.fn(), put: jest.fn() };
+jest.mock('../services/api.client', () => ({ __esModule: true, default: mockApi }));
+
+const svc = require('../services/cdssService');
+
+const ok = data => Promise.resolve({ data });
+const fail = () => Promise.reject(new Error('boom'));
+
+beforeEach(() => {
+  Object.values(mockApi).forEach(fn => fn.mockReset());
+});
+
+describe('getStats — nested envelope → flat numbers', () => {
+  test('unwraps { stats: { X: { value } } } into flat KPI numbers', async () => {
+    mockApi.get.mockReturnValueOnce(
+      ok({
+        stats: {
+          activeAlerts: { title: 'x', value: 23, icon: 'bell' },
+          criticalAlerts: { value: 4 },
+          pendingSuggestions: { value: 11 },
+          activeRules: { value: 58 },
+          highRiskPatients: { value: 6 },
+        },
+      })
+    );
+    const s = await svc.getStats();
+    expect(s.activeAlerts).toBe(23);
+    expect(s.criticalAlerts).toBe(4);
+    expect(s.pendingSuggestions).toBe(11);
+    expect(s.rulesActive).toBe(58); // activeRules → rulesActive
+    expect(s.highRiskPatients).toBe(6);
+  });
+
+  test('falls back to demo stats when the request throws', async () => {
+    mockApi.get.mockImplementationOnce(fail);
+    const s = await svc.getStats();
+    expect(typeof s.activeAlerts).toBe('number');
+  });
+});
+
+describe('getAlerts — paginated envelope + populated refs + severity map', () => {
+  test('reads { data: [...] } and normalizes each alert', async () => {
+    mockApi.get.mockReturnValueOnce(
+      ok({
+        data: [
+          {
+            _id: 'a1',
+            severity: 'emergency', // → critical
+            alertType: 'drug_interaction',
+            message: 'EN',
+            messageAr: 'تنبيه',
+            beneficiaryId: { _id: 'b1', fullNameAr: 'أحمد' },
+            ruleId: { _id: 'r1', code: 'DR-INT-001' },
+            triggeredAt: '2026-05-30T10:00:00Z',
+            status: 'active',
+          },
+        ],
+        total: 1,
+      })
+    );
+    const alerts = await svc.getAlerts();
+    expect(Array.isArray(alerts)).toBe(true);
+    expect(alerts).toHaveLength(1);
+    const a = alerts[0];
+    expect(a.severity).toBe('critical'); // emergency → critical
+    expect(a.message).toBe('تنبيه'); // Arabic preferred
+    expect(a.beneficiaryName).toBe('أحمد'); // from populated ref
+    expect(a.beneficiaryId).toBe('b1'); // id flattened
+    expect(a.ruleCode).toBe('DR-INT-001');
+  });
+});
+
+describe('getRules — Mixed conditions/actions → text + category map', () => {
+  test('stringifies conditions[] and maps backend category', async () => {
+    mockApi.get.mockReturnValueOnce(
+      ok({
+        data: [
+          {
+            _id: 'r1',
+            code: 'C1',
+            nameAr: 'قاعدة',
+            category: 'drug_interaction', // → medication
+            severity: 'critical',
+            conditions: [{ field: 'x', operator: '>', value: 3 }],
+            actions: [{ message: 'إشعار' }],
+            isActive: true,
+          },
+        ],
+      })
+    );
+    const rules = await svc.getRules();
+    expect(rules[0].name).toBe('قاعدة');
+    expect(rules[0].category).toBe('medication');
+    expect(rules[0].condition).toContain('x');
+    expect(rules[0].action).toContain('إشعار');
+    expect(rules[0].triggerCount).toBe(0);
+    expect(rules[0].evidenceLevel).toBeDefined();
+  });
+});
+
+describe('getDrugLibrary — field rename + interaction codes', () => {
+  test('maps genericNameAr→name and drugInteractions→string codes', async () => {
+    mockApi.get.mockReturnValueOnce(
+      ok({
+        data: [
+          {
+            _id: 'd1',
+            code: 'BACLO',
+            genericNameAr: 'باكلوفين',
+            drugClassAr: 'مرخيات',
+            drugInteractions: [{ drug_code: 'DIAZ', severity: 'critical' }],
+            contraindications: ['فشل كلوي'],
+            isControlled: true,
+          },
+        ],
+      })
+    );
+    const drugs = await svc.getDrugLibrary();
+    expect(drugs[0].name).toBe('باكلوفين');
+    expect(drugs[0].category).toBe('مرخيات');
+    expect(drugs[0].interactions).toEqual(['DIAZ']);
+    expect(drugs[0].contraindications).toEqual(['فشل كلوي']);
+    expect(drugs[0].highRisk).toBe(true); // from isControlled
+    expect(drugs[0].code).toBe('BACLO'); // retained for interaction checks
+  });
+});
+
+describe('getRehabSuggestions — 0–1 confidence → percent', () => {
+  test('maps confidenceScore and plan fields', async () => {
+    mockApi.get.mockReturnValueOnce(
+      ok({
+        data: [
+          {
+            _id: 's1',
+            beneficiaryId: { _id: 'b9', fullNameAr: 'فاطمة' },
+            confidenceScore: 0.78,
+            suggestedFrequency: { sessionsPerWeek: 3 },
+            suggestedInterventions: [{ type: 'PT' }],
+            suggestedGoals: [{ goal: 'هدف' }],
+            estimatedDurationWeeks: 8,
+            status: 'pending',
+          },
+        ],
+      })
+    );
+    const sg = await svc.getRehabSuggestions();
+    expect(sg[0].beneficiaryName).toBe('فاطمة');
+    expect(sg[0].confidenceScore).toBe(78); // 0.78 → 78%
+    expect(sg[0].suggestedPlan.sessions).toBe(3);
+    expect(sg[0].suggestedPlan.modalities).toEqual(['PT']);
+    expect(sg[0].suggestedPlan.goals).toEqual(['هدف']);
+    expect(sg[0].suggestedPlan.duration).toContain('8');
+  });
+});
+
+describe('getDecisionLog — decisionType → action', () => {
+  test('maps decision fields the log table renders', async () => {
+    mockApi.get.mockReturnValueOnce(
+      ok({
+        data: [
+          {
+            _id: 'l1',
+            decisionType: 'alert_override',
+            contextType: 'cdss_alert',
+            userId: { name: 'د. هاني' },
+            rationale: 'سبب',
+            decisionAt: '2026-05-30T09:00:00Z',
+          },
+        ],
+      })
+    );
+    const log = await svc.getDecisionLog();
+    expect(log[0].action).toBe('override');
+    expect(log[0].clinician).toBe('د. هاني');
+    expect(log[0].reason).toBe('سبب');
+  });
+});
+
+describe('mutation payloads match backend contract', () => {
+  test('overrideAlert sends { overrideReason }', async () => {
+    mockApi.patch.mockReturnValueOnce(ok({ message: 'ok' }));
+    await svc.overrideAlert('a1', 'مبرر سريري مفصل');
+    expect(mockApi.patch).toHaveBeenCalledWith(expect.stringContaining('/alerts/a1/override'), {
+      overrideReason: 'مبرر سريري مفصل',
+    });
+  });
+
+  test('checkDrugInteractions sends { drugCodes } and derives safe flag', async () => {
+    mockApi.post.mockReturnValueOnce(ok({ interactions: [], hasCritical: false }));
+    const res = await svc.checkDrugInteractions(['BACLO', 'DIAZ']);
+    expect(mockApi.post).toHaveBeenCalledWith(
+      expect.stringContaining('/drugs/check-interactions'),
+      { drugCodes: ['BACLO', 'DIAZ'] }
+    );
+    expect(res.safe).toBe(true);
+  });
+
+  test('checkDrugInteractions reports unsafe when a critical interaction exists', async () => {
+    mockApi.post.mockReturnValueOnce(
+      ok({ interactions: [{ severity: 'critical' }], hasCritical: true })
+    );
+    const res = await svc.checkDrugInteractions(['A', 'B']);
+    expect(res.safe).toBe(false);
+    expect(res.interactions).toHaveLength(1);
+  });
+
+  test('createRule maps the flat form onto the ClinicalRule schema', async () => {
+    mockApi.post.mockReturnValueOnce(ok({ data: { _id: 'new1', nameAr: 'ق', code: 'X' } }));
+    await svc.createRule({
+      name: 'ق',
+      code: 'X',
+      condition: 'a > 1',
+      action: 'do',
+      category: 'medication',
+      severity: 'critical',
+    });
+    const [, body] = mockApi.post.mock.calls[0];
+    expect(body.nameAr).toBe('ق'); // required server-side
+    expect(Array.isArray(body.conditions)).toBe(true);
+    expect(Array.isArray(body.actions)).toBe(true);
+  });
+});
+
+describe('lists never throw on a surprising payload', () => {
+  test('non-array / object payloads degrade to []', async () => {
+    mockApi.get.mockReturnValueOnce(ok('<!DOCTYPE html>')); // e.g. mis-routed HTML
+    const alerts = await svc.getAlerts();
+    expect(alerts).toEqual([]);
+  });
+});

--- a/frontend/src/pages/CDSS/CDSSDashboard.jsx
+++ b/frontend/src/pages/CDSS/CDSSDashboard.jsx
@@ -342,7 +342,7 @@ export default function CDSSDashboard() {
   const handleCheckInteractions = async () => {
     if (selectedDrugsForCheck.length < 2) return;
     setInteractionLoading(true);
-    const result = await checkDrugInteractions(selectedDrugsForCheck.map(d => d._id));
+    const result = await checkDrugInteractions(selectedDrugsForCheck.map(d => d.code || d._id));
     setInteractionResult(result);
     setInteractionLoading(false);
   };
@@ -1361,7 +1361,7 @@ export default function CDSSDashboard() {
           <Button
             variant="contained"
             color="warning"
-            disabled={!overrideDialog.reason.trim()}
+            disabled={overrideDialog.reason.trim().length < 10}
             onClick={handleOverrideSubmit}
           >
             تجاوز وتسجيل

--- a/frontend/src/services/cdssService.js
+++ b/frontend/src/services/cdssService.js
@@ -419,14 +419,223 @@ const withMock = async (apiFn, mockData) => {
   }
 };
 
+// ─── Backend → Frontend shape adapters ──────────────────────────────────────────
+//
+// The canonical backend (66666 `/api/v1/cdss`) returns a different shape than
+// this dashboard was written against:
+//   • lists    → { data: [...], total, page, limit }   (this file expected bare arrays)
+//   • stats    → { stats: { activeAlerts: { value }, … } } (expected flat numbers)
+//   • severity → enum ['info','warning','critical','emergency'] (UI uses critical/high/medium/low/info)
+//   • field names differ on every entity (messageAr, genericName, drugInteractions, …)
+// These adapters translate the live response into the shape the UI renders, so
+// the page shows REAL data instead of silently falling back to demo data. Each
+// adapter is fully defensive (optional chaining + Array.isArray guards) so a
+// surprising payload can never throw during render.
+
+// Pull the list out of either a bare array or the paginated envelope.
+const pickList = body => {
+  if (Array.isArray(body)) return body;
+  if (body && typeof body === 'object') {
+    for (const key of [
+      'data',
+      'items',
+      'results',
+      'alerts',
+      'rules',
+      'drugs',
+      'suggestions',
+      'logs',
+      'assessments',
+    ]) {
+      if (Array.isArray(body[key])) return body[key];
+    }
+  }
+  return [];
+};
+
+// backend severity enum → UI severity bucket
+const SEVERITY_MAP = {
+  emergency: 'critical',
+  critical: 'critical',
+  warning: 'medium',
+  info: 'info',
+  // pass-through for values the UI already understands
+  high: 'high',
+  medium: 'medium',
+  low: 'low',
+};
+const mapSeverity = s => SEVERITY_MAP[s] || 'info';
+
+// backend rule category enum → UI category bucket (RULE_CATEGORIES keys)
+const CATEGORY_MAP = {
+  drug_interaction: 'medication',
+  contraindication: 'medication',
+  allergy: 'safety',
+  lab_alert: 'assessment',
+  lab_critical: 'assessment',
+  risk_assessment: 'assessment',
+  risk_flag: 'assessment',
+  guideline: 'quality',
+  protocol: 'compliance',
+};
+const mapCategory = c => CATEGORY_MAP[c] || c || 'safety';
+
+const refName = ref =>
+  ref && typeof ref === 'object' ? ref.fullNameAr || ref.fullName || ref.name || '' : '';
+
+const toText = v => {
+  if (v === null || v === undefined) return '';
+  if (typeof v === 'string') return v;
+  if (Array.isArray(v)) {
+    return v
+      .map(x =>
+        x && typeof x === 'object'
+          ? [x.field, x.operator, x.value].filter(p => p !== undefined).join(' ') ||
+            x.message ||
+            x.type ||
+            JSON.stringify(x)
+          : String(x)
+      )
+      .join(' AND ');
+  }
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+};
+
+const toStringArray = v => {
+  if (!v) return [];
+  const arr = Array.isArray(v) ? v : [v];
+  return arr.map(x =>
+    x && typeof x === 'object'
+      ? x.drug_code || x.goal || x.type || x.name || x.label || x.value || JSON.stringify(x)
+      : String(x)
+  );
+};
+
+const adaptStats = body => {
+  const s = body?.stats || body || {};
+  const num = x => {
+    const v = x && typeof x === 'object' ? x.value : x;
+    return typeof v === 'number' ? v : 0;
+  };
+  return {
+    activeAlerts: num(s.activeAlerts),
+    criticalAlerts: num(s.criticalAlerts),
+    pendingSuggestions: num(s.pendingSuggestions),
+    rulesActive: num(s.activeRules ?? s.rulesActive),
+    rulesTriggeredToday: num(s.rulesTriggeredToday),
+    highRiskPatients: num(s.highRiskPatients),
+    riskAssessmentsToday: num(s.riskAssessmentsToday),
+    decisionLogToday: num(s.decisionLogToday),
+    resolvedToday: num(s.resolvedToday),
+    drugChecksToday: num(s.drugChecksToday),
+    avgRiskScore: num(s.avgRiskScore),
+    trend: s.trend, // backend may omit; chart degrades gracefully to zeros
+  };
+};
+
+const adaptAlert = a => ({
+  _id: a?._id || a?.id,
+  severity: mapSeverity(a?.severity),
+  type: a?.alertType || a?.type,
+  message: a?.messageAr || a?.message || '',
+  beneficiaryName: refName(a?.beneficiaryId) || a?.beneficiaryName || '—',
+  beneficiaryId:
+    (a?.beneficiaryId && typeof a.beneficiaryId === 'object'
+      ? a.beneficiaryId._id
+      : a?.beneficiaryId) || '',
+  triggeredAt: a?.triggeredAt || a?.createdAt,
+  status: a?.status || 'active',
+  ruleCode:
+    (a?.ruleId && typeof a.ruleId === 'object' ? a.ruleId.code || a.ruleId.name : a?.ruleCode) ||
+    a?.alertType ||
+    '',
+});
+
+const adaptRule = r => ({
+  _id: r?._id || r?.id,
+  code: r?.code || '',
+  name: r?.nameAr || r?.name || '',
+  category: mapCategory(r?.category),
+  severity: mapSeverity(r?.severity),
+  condition: toText(r?.conditions ?? r?.condition),
+  action: toText(r?.actions ?? r?.action),
+  isActive: r?.isActive !== false,
+  triggerCount: typeof r?.triggerCount === 'number' ? r.triggerCount : 0,
+  evidenceLevel: r?.evidenceLevel || r?.guidelineSource || '—',
+});
+
+const adaptDrug = d => ({
+  _id: d?._id || d?.id,
+  code: d?.code || '',
+  name: d?.genericNameAr || d?.genericName || d?.name || '',
+  category: d?.drugClassAr || d?.drugClass || d?.category || '',
+  interactions: toStringArray(d?.drugInteractions ?? d?.interactions),
+  contraindications: toStringArray(d?.contraindications),
+  highRisk: d?.highRisk !== undefined ? !!d.highRisk : !!d?.isControlled,
+});
+
+const adaptSuggestion = s => {
+  const plan = s?.suggestedPlan || {};
+  const conf = typeof s?.confidenceScore === 'number' ? s.confidenceScore : 0;
+  return {
+    _id: s?._id || s?.id,
+    beneficiaryId:
+      (s?.beneficiaryId && typeof s.beneficiaryId === 'object'
+        ? s.beneficiaryId._id
+        : s?.beneficiaryId) || '',
+    beneficiaryName: refName(s?.beneficiaryId) || s?.beneficiaryName || '—',
+    diagnosis: s?.diagnosis || plan.diagnosis || 'غير محدد',
+    suggestedPlan: {
+      sessions: s?.suggestedFrequency?.sessionsPerWeek ?? plan.sessions ?? 0,
+      frequency: plan.frequency || 'أسبوعياً',
+      modalities: toStringArray(s?.suggestedInterventions ?? plan.modalities),
+      goals: toStringArray(s?.suggestedGoals ?? plan.goals),
+      duration:
+        plan.duration || (s?.estimatedDurationWeeks ? `${s.estimatedDurationWeeks} أسابيع` : ''),
+      evidenceBased:
+        plan.evidenceBased ??
+        !!(Array.isArray(s?.evidenceReferences) && s.evidenceReferences.length),
+      referencedGuideline: plan.referencedGuideline || s?.guidelineSource || '',
+    },
+    // backend stores 0–1; UI renders a percentage
+    confidenceScore: conf > 0 && conf <= 1 ? Math.round(conf * 100) : Math.round(conf),
+    status: s?.status || 'pending',
+  };
+};
+
+const DECISION_ACTION_MAP = {
+  alert_override: 'override',
+  suggestion_accepted: 'accept',
+  suggestion_rejected: 'reject',
+  risk_acknowledged: 'acknowledge',
+  rule_evaluated: 'evaluate',
+};
+const adaptDecision = l => ({
+  _id: l?._id || l?.id,
+  action: DECISION_ACTION_MAP[l?.decisionType] || l?.action || l?.decisionType || '',
+  alertCode: l?.alertCode || l?.contextType || '',
+  clinician: refName(l?.userId) || l?.clinician || '',
+  reason: l?.rationale || l?.outcome || l?.reason || '',
+  timestamp: l?.decisionAt || l?.timestamp || l?.createdAt,
+});
+
+const adaptList = (body, fn) => {
+  try {
+    return pickList(body).map(fn);
+  } catch {
+    return [];
+  }
+};
+
 // ─── Exported API Functions ───────────────────────────────────────────────────
 
 export const getStats = () =>
-  withMock(() => apiClient.get(`${BASE}/stats`).then(r => r.data), MOCK_STATS);
+  withMock(() => apiClient.get(`${BASE}/stats`).then(r => adaptStats(r.data)), MOCK_STATS);
 
 export const getAlerts = (params = {}) =>
   withMock(
-    () => apiClient.get(`${BASE}/alerts`, { params }).then(r => r.data?.alerts || r.data),
+    () => apiClient.get(`${BASE}/alerts`, { params }).then(r => adaptList(r.data, adaptAlert)),
     MOCK_ALERTS
   );
 
@@ -436,9 +645,13 @@ export const acknowledgeAlert = id =>
   });
 
 export const overrideAlert = (id, reason) =>
-  withMock(() => apiClient.patch(`${BASE}/alerts/${id}/override`, { reason }).then(r => r.data), {
-    success: true,
-  });
+  withMock(
+    () =>
+      apiClient
+        .patch(`${BASE}/alerts/${id}/override`, { overrideReason: reason })
+        .then(r => r.data),
+    { success: true }
+  );
 
 export const resolveAlert = id =>
   withMock(() => apiClient.patch(`${BASE}/alerts/${id}/resolve`).then(r => r.data), {
@@ -447,34 +660,55 @@ export const resolveAlert = id =>
 
 export const getRules = (params = {}) =>
   withMock(
-    () => apiClient.get(`${BASE}/rules`, { params }).then(r => r.data?.rules || r.data),
+    () => apiClient.get(`${BASE}/rules`, { params }).then(r => adaptList(r.data, adaptRule)),
     MOCK_RULES
   );
 
+// Map the dashboard's flat rule form back onto the backend ClinicalRule schema
+// (nameAr / conditions / actions are required server-side).
+const toBackendRule = data => ({
+  code: data.code,
+  name: data.name,
+  nameAr: data.nameAr || data.name,
+  category: data.category,
+  severity: data.severity,
+  description: data.action || '',
+  descriptionAr: data.action || '',
+  conditions: data.condition ? [{ expression: data.condition }] : [],
+  actions: data.action ? [{ message: data.action }] : [],
+  isActive: data.isActive !== false,
+});
+
 export const createRule = data =>
-  withMock(() => apiClient.post(`${BASE}/rules`, data).then(r => r.data), {
-    ...data,
-    _id: Date.now().toString(),
-  });
-
-export const updateRule = (id, data) =>
-  withMock(() => apiClient.put(`${BASE}/rules/${id}`, data).then(r => r.data), {
-    ...data,
-    _id: id,
-  });
-
-export const getRiskAssessments = (params = {}) =>
   withMock(
     () =>
       apiClient
-        .get(`${BASE}/risk-assessments`, { params })
-        .then(r => r.data?.assessments || r.data),
+        .post(`${BASE}/rules`, toBackendRule(data))
+        .then(r => adaptRule(r.data?.data || r.data)),
+    { ...data, _id: Date.now().toString() }
+  );
+
+export const updateRule = (id, data) =>
+  withMock(
+    () =>
+      apiClient
+        .put(`${BASE}/rules/${id}`, toBackendRule(data))
+        .then(r => adaptRule(r.data?.data || r.data)),
+    { ...data, _id: id }
+  );
+
+export const getRiskAssessments = (params = {}) =>
+  withMock(
+    () => apiClient.get(`${BASE}/risk-assessments`, { params }).then(r => pickList(r.data)),
     MOCK_RISK_ASSESSMENTS
   );
 
-export const generateAutoRiskAssessment = beneficiaryId =>
+export const generateAutoRiskAssessment = (beneficiaryId, assessmentType = 'fall_risk') =>
   withMock(
-    () => apiClient.post(`${BASE}/risk-assessments/auto`, { beneficiaryId }).then(r => r.data),
+    () =>
+      apiClient
+        .post(`${BASE}/risk-assessments/auto`, { beneficiaryId, assessmentType })
+        .then(r => r.data?.data || r.data),
     MOCK_RISK_ASSESSMENTS[0]
   );
 
@@ -483,7 +717,7 @@ export const getRehabSuggestions = (params = {}) =>
     () =>
       apiClient
         .get(`${BASE}/rehab-suggestions`, { params })
-        .then(r => r.data?.suggestions || r.data),
+        .then(r => adaptList(r.data, adaptSuggestion)),
     MOCK_REHAB_SUGGESTIONS
   );
 
@@ -500,24 +734,36 @@ export const rejectRehabSuggestion = (id, reason) =>
 
 export const getDrugLibrary = (params = {}) =>
   withMock(
-    () => apiClient.get(`${BASE}/drugs`, { params }).then(r => r.data?.drugs || r.data),
+    () => apiClient.get(`${BASE}/drugs`, { params }).then(r => adaptList(r.data, adaptDrug)),
     MOCK_DRUG_LIBRARY
   );
 
-export const checkDrugInteractions = drugIds =>
+// `drugRefs` are the selected drugs' codes (falling back to ids for demo data).
+export const checkDrugInteractions = drugRefs =>
   withMock(
-    () => apiClient.post(`${BASE}/drugs/check-interactions`, { drugIds }).then(r => r.data),
+    () =>
+      apiClient.post(`${BASE}/drugs/check-interactions`, { drugCodes: drugRefs }).then(r => {
+        const interactions = Array.isArray(r.data?.interactions) ? r.data.interactions : [];
+        return { interactions, safe: !r.data?.hasCritical && interactions.length === 0 };
+      }),
     { interactions: [], safe: true }
   );
 
 export const getDecisionLog = (params = {}) =>
   withMock(
-    () => apiClient.get(`${BASE}/decision-log`, { params }).then(r => r.data?.logs || r.data),
+    () =>
+      apiClient.get(`${BASE}/decision-log`, { params }).then(r => adaptList(r.data, adaptDecision)),
     MOCK_DECISION_LOG
   );
 
-export const evaluateRules = beneficiaryId =>
-  withMock(() => apiClient.post(`${BASE}/alerts/evaluate`, { beneficiaryId }).then(r => r.data), {
-    triggered: 2,
-    alerts: MOCK_ALERTS.slice(0, 2),
-  });
+export const evaluateRules = (beneficiaryId, contextType = 'manual', contextData = {}) =>
+  withMock(
+    () =>
+      apiClient
+        .post(`${BASE}/alerts/evaluate`, { beneficiaryId, contextType, contextData })
+        .then(r => ({
+          triggered: r.data?.data?.length ?? 0,
+          alerts: adaptList(r.data, adaptAlert),
+        })),
+    { triggered: 2, alerts: MOCK_ALERTS.slice(0, 2) }
+  );


### PR DESCRIPTION
## Problem
The Clinical Decision Support dashboard (دعم القرار السريري) — the **live legacy frontend UI** — was showing the error boundary in production and, underneath, was silently running on demo data. After the W578 API-path migration it hit the real `/api/v1/cdss` backend (mounted via `features.registry.js`) but **misread every response shape**:

- lists return `{ data:[...] }` envelopes; the UI read `r.data.alerts || r.data`
- stats returns `{ stats:{ X:{ value } } }`; the UI read flat `r.data.activeAlerts`
- severity/category enums differ (`info|warning|critical|emergency` vs UI buckets)
- field renames on every entity (`messageAr`, `genericNameAr`, `drugInteractions[{drug_code}]`, `confidenceScore` 0–1)
- wrong mutation payloads: override sent `{reason}` (backend wants `{overrideReason}`, ≥10 chars), drug check sent `{drugIds}` of `_id` (backend wants `{drugCodes}` of `code`), createRule omitted required `nameAr/conditions/actions`

## Fix (frontend-only, the file that owns the bug)
- Defensive adapter layer in `cdssService.js` (`pickList`/`adaptStats`/`adaptAlert`/`adaptRule`/`adaptDrug`/`adaptSuggestion`/`adaptDecision` + `SEVERITY_MAP`/`CATEGORY_MAP` + `toBackendRule`) — never throws on a surprising payload.
- Component sends drug `code` and enforces the 10-char override minimum.

## Tests (14, green)
- `services-cdssService-adapters.test.js` — 12 behavioral tests mocking `api.client`, locking the backend→frontend contract.
- `pages-CDSSDashboard-render.test.js` — RTL render smoke test under MUI v9 / recharts v3 / framer-motion v12 (populated + empty-instance), proving no render crash.

Lint + build + tests green. **Already deployed to alaweal.org** (frontend-only atomic deploy, verified live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)