### PR TITLE
feat(cdss): surface risk assessments, differential diagnoses & prescription validation

### DIFF
--- a/frontend/src/__tests__/pages-CDSSDashboard-render.test.js
+++ b/frontend/src/__tests__/pages-CDSSDashboard-render.test.js
@@ -11,7 +11,7 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
 // jsdom lacks the browser APIs the dashboard's KPI counter (IntersectionObserver)
 // and recharts ResponsiveContainer (ResizeObserver) touch on mount.
@@ -47,6 +47,8 @@ const mockData = {
   suggestions: [],
   drugs: [],
   decisionLog: [],
+  riskAssessments: [],
+  diagnoses: [],
 };
 
 jest.mock('services/cdssService', () => {
@@ -60,6 +62,8 @@ jest.mock('services/cdssService', () => {
     getRehabSuggestions: jest.fn(() => Promise.resolve(mockData.suggestions)),
     getDrugLibrary: jest.fn(() => Promise.resolve(mockData.drugs)),
     getDecisionLog: jest.fn(() => Promise.resolve(mockData.decisionLog)),
+    getRiskAssessments: jest.fn(() => Promise.resolve(mockData.riskAssessments)),
+    getDifferentialDiagnoses: jest.fn(() => Promise.resolve(mockData.diagnoses)),
   };
 });
 
@@ -141,6 +145,36 @@ const POPULATED = {
       timestamp: new Date().toISOString(),
     },
   ],
+  riskAssessments: [
+    {
+      _id: 'ra1',
+      beneficiaryId: 'b1',
+      beneficiaryName: 'أحمد',
+      assessmentType: 'fall_risk',
+      toolUsed: 'Morse Scale',
+      overallScore: 78,
+      riskLevel: 'very_high',
+      domains: [{ domain: 'سلامة الدواء', score: 92, flag: true }],
+      recommendedInterventions: ['مراقبة مكثفة'],
+      generatedBy: 'AI-Auto',
+      mlAssisted: true,
+      mlConfidenceScore: 0.82,
+      generatedAt: new Date().toISOString(),
+    },
+  ],
+  diagnoses: [
+    {
+      _id: 'dd1',
+      beneficiaryId: 'b2',
+      beneficiaryName: 'نورة',
+      symptoms: ['ضعف عضلي'],
+      clinicalFindings: ['رنح'],
+      candidates: [{ icdCode: 'G35', name: 'التصلب المتعدد', probability: 62, reasoning: 'نمط الأعراض' }],
+      investigations: ['رنين مغناطيسي'],
+      status: 'active',
+      createdAt: new Date().toISOString(),
+    },
+  ],
 };
 
 const EMPTY = {
@@ -150,6 +184,8 @@ const EMPTY = {
   suggestions: [],
   drugs: [],
   decisionLog: [],
+  riskAssessments: [],
+  diagnoses: [],
 };
 
 afterEach(() => {
@@ -160,6 +196,8 @@ afterEach(() => {
     suggestions: [],
     drugs: [],
     decisionLog: [],
+    riskAssessments: [],
+    diagnoses: [],
   });
 });
 
@@ -179,5 +217,24 @@ describe('CDSSDashboard renders without throwing', () => {
     expect(await screen.findByText('نظام دعم القرار السريري')).toBeTruthy();
     // overview tab panels render (KPIs + severity breakdown), not an error boundary
     expect(await screen.findByText('توزيع التنبيهات')).toBeTruthy();
+  });
+
+  test('Risk Assessments tab renders the new surface', async () => {
+    Object.assign(mockData, POPULATED);
+    render(<CDSSDashboard />);
+    await screen.findByText('نظام دعم القرار السريري');
+    fireEvent.click(screen.getByText('تقييمات المخاطر'));
+    // the auto-generate tool + a risk card both prove the new tab mounted
+    expect(await screen.findByText('توليد تقييم مخاطر آلي')).toBeTruthy();
+    expect(await screen.findByText('مراقبة مكثفة')).toBeTruthy();
+  });
+
+  test('Differential Diagnoses tab renders the new surface', async () => {
+    Object.assign(mockData, POPULATED);
+    render(<CDSSDashboard />);
+    await screen.findByText('نظام دعم القرار السريري');
+    fireEvent.click(screen.getByText('التشخيصات التفريقية'));
+    expect(await screen.findByText('التصلب المتعدد')).toBeTruthy();
+    expect(await screen.findByText('G35')).toBeTruthy();
   });
 });

--- a/frontend/src/__tests__/services-cdssService-adapters.test.js
+++ b/frontend/src/__tests__/services-cdssService-adapters.test.js
@@ -243,3 +243,99 @@ describe('lists never throw on a surprising payload', () => {
     expect(alerts).toEqual([]);
   });
 });
+
+describe('getRiskAssessments — totalScore/scoreBreakdown + risk-level map', () => {
+  test('maps backend assessment onto the UI shape', async () => {
+    mockApi.get.mockReturnValueOnce(
+      ok({
+        data: [
+          {
+            _id: 'ra1',
+            beneficiaryId: { _id: 'b1', fullNameAr: 'أحمد' },
+            assessmentType: 'fall_risk',
+            toolUsed: 'Morse',
+            totalScore: 78,
+            riskLevel: 'moderate', // → medium
+            scoreBreakdown: [{ domain: 'تنقل', score: 40, flag: true }],
+            recommendedInterventions: ['مراقبة'],
+            mlAssisted: true,
+            mlConfidenceScore: 0.82,
+            assessmentDate: '2026-05-30T10:00:00Z',
+          },
+        ],
+      })
+    );
+    const ra = await svc.getRiskAssessments();
+    expect(ra[0].beneficiaryName).toBe('أحمد');
+    expect(ra[0].overallScore).toBe(78); // totalScore → overallScore
+    expect(ra[0].riskLevel).toBe('medium'); // moderate → medium
+    expect(ra[0].domains).toEqual([{ domain: 'تنقل', score: 40, flag: true }]);
+    expect(ra[0].recommendedInterventions).toEqual(['مراقبة']);
+    expect(ra[0].generatedBy).toBe('AI-Auto'); // mlAssisted
+  });
+
+  test('generateAutoRiskAssessment sends { beneficiaryId, assessmentType }', async () => {
+    mockApi.post.mockReturnValueOnce(ok({ data: { _id: 'x', totalScore: 14, riskLevel: 'high' } }));
+    await svc.generateAutoRiskAssessment('BNF-1', 'pressure_ulcer');
+    expect(mockApi.post).toHaveBeenCalledWith(expect.stringContaining('/risk-assessments/auto'), {
+      beneficiaryId: 'BNF-1',
+      assessmentType: 'pressure_ulcer',
+    });
+  });
+});
+
+describe('getDifferentialDiagnoses — symptoms + ICD candidates', () => {
+  test('maps presentingSymptoms + suggestedDiagnoses (0–1 probability → %)', async () => {
+    mockApi.get.mockReturnValueOnce(
+      ok({
+        data: [
+          {
+            _id: 'dd1',
+            beneficiaryId: { _id: 'b9', fullNameAr: 'نورة' },
+            presentingSymptoms: ['ضعف عضلي', 'رنح'],
+            suggestedDiagnoses: [
+              { icd_code: 'G35', name: 'التصلب المتعدد', probability: 0.62, reasoning: 'نمط' },
+            ],
+            recommendedInvestigations: ['MRI'],
+            status: 'active',
+          },
+        ],
+      })
+    );
+    const dd = await svc.getDifferentialDiagnoses();
+    expect(dd[0].beneficiaryName).toBe('نورة');
+    expect(dd[0].symptoms).toEqual(['ضعف عضلي', 'رنح']);
+    expect(dd[0].candidates[0].icdCode).toBe('G35'); // icd_code → icdCode
+    expect(dd[0].candidates[0].probability).toBe(62); // 0.62 → 62
+    expect(dd[0].investigations).toEqual(['MRI']);
+  });
+});
+
+describe('validatePrescription — status + hasCritical', () => {
+  test('sends drugCodes and adapts the validation envelope', async () => {
+    mockApi.post.mockReturnValueOnce(
+      ok({
+        data: { status: 'warnings', warnings: [{ type: 'x' }], errors: [], drugInteractionResults: [] },
+        hasCritical: false,
+      })
+    );
+    const res = await svc.validatePrescription({ drugCodes: ['A', 'B'] });
+    expect(mockApi.post).toHaveBeenCalledWith(expect.stringContaining('/prescriptions/validate'), {
+      beneficiaryId: undefined,
+      prescriptionId: undefined,
+      drugCodes: ['A', 'B'],
+    });
+    expect(res.status).toBe('warnings');
+    expect(res.hasCritical).toBe(false);
+    expect(res.warnings).toHaveLength(1);
+  });
+
+  test('failed status when backend reports critical errors', async () => {
+    mockApi.post.mockReturnValueOnce(
+      ok({ data: { status: 'failed', errors: [{ type: 'interaction' }] }, hasCritical: true })
+    );
+    const res = await svc.validatePrescription({ drugCodes: ['A', 'B'] });
+    expect(res.status).toBe('failed');
+    expect(res.hasCritical).toBe(true);
+  });
+});

--- a/frontend/src/pages/CDSS/CDSSDashboard.jsx
+++ b/frontend/src/pages/CDSS/CDSSDashboard.jsx
@@ -74,6 +74,10 @@ import {
   TrendingDown as _RegressionIcon,
   PlayArrow as RunIcon,
   Cancel as CancelIcon,
+  HealthAndSafety as RiskIcon,
+  Biotech as DiagnosisIcon,
+  FactCheck as ValidateIcon,
+  AutoAwesome as AutoIcon,
 } from '@mui/icons-material';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -102,8 +106,16 @@ import {
   getDrugLibrary,
   checkDrugInteractions,
   getDecisionLog,
+  getRiskAssessments,
+  generateAutoRiskAssessment,
+  getDifferentialDiagnoses,
+  confirmDifferentialDiagnosis,
+  validatePrescription,
   ALERT_SEVERITIES,
   RULE_CATEGORIES,
+  RISK_LEVELS,
+  RISK_ASSESSMENT_TYPES,
+  DIAGNOSIS_STATUSES,
 } from 'services/cdssService';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -245,6 +257,8 @@ export default function CDSSDashboard() {
   const [suggestions, setSuggestions] = useState([]);
   const [drugs, setDrugs] = useState([]);
   const [decisionLog, setDecisionLog] = useState([]);
+  const [riskAssessments, setRiskAssessments] = useState([]);
+  const [diagnoses, setDiagnoses] = useState([]);
   const [loading, setLoading] = useState(true);
 
   // filters
@@ -259,19 +273,25 @@ export default function CDSSDashboard() {
   const [interactionResult, setInteractionResult] = useState(null);
   const [selectedDrugsForCheck, setSelectedDrugsForCheck] = useState([]);
   const [interactionLoading, setInteractionLoading] = useState(false);
+  const [riskTypeFilter, setRiskTypeFilter] = useState('all');
+  const [genRisk, setGenRisk] = useState({ loading: false, beneficiaryId: '', type: 'fall_risk' });
+  const [confirmDdDialog, setConfirmDdDialog] = useState({ open: false, id: null, note: '' });
+  const [rxCheck, setRxCheck] = useState({ result: null, loading: false });
 
   // ─── Fetch All ───────────────────────────────────────────────────────────
 
   const fetchAll = useCallback(async () => {
     setLoading(true);
     try {
-      const [s, a, r, sg, d, dl] = await Promise.all([
+      const [s, a, r, sg, d, dl, ra, dd] = await Promise.all([
         getStats(),
         getAlerts(),
         getRules(),
         getRehabSuggestions(),
         getDrugLibrary(),
         getDecisionLog(),
+        getRiskAssessments(),
+        getDifferentialDiagnoses(),
       ]);
       setStats(s);
       setAlerts(Array.isArray(a) ? a : []);
@@ -279,6 +299,8 @@ export default function CDSSDashboard() {
       setSuggestions(Array.isArray(sg) ? sg : []);
       setDrugs(Array.isArray(d) ? d : []);
       setDecisionLog(Array.isArray(dl) ? dl : []);
+      setRiskAssessments(Array.isArray(ra) ? ra : []);
+      setDiagnoses(Array.isArray(dd) ? dd : []);
     } catch (err) {
       console.error('CDSS fetch error', err);
     } finally {
@@ -347,6 +369,38 @@ export default function CDSSDashboard() {
     setInteractionLoading(false);
   };
 
+  // ─── Risk assessment / diagnosis / prescription actions ─────────────────────
+
+  const handleGenerateRisk = async () => {
+    if (!genRisk.beneficiaryId.trim()) return;
+    setGenRisk(p => ({ ...p, loading: true }));
+    const created = await generateAutoRiskAssessment(genRisk.beneficiaryId.trim(), genRisk.type);
+    if (created && created._id) setRiskAssessments(prev => [created, ...prev]);
+    setGenRisk({ loading: false, beneficiaryId: '', type: 'fall_risk' });
+  };
+
+  const handleConfirmDd = async () => {
+    const { id, note } = confirmDdDialog;
+    await confirmDifferentialDiagnosis(id, { clinicianAssessment: note });
+    setDiagnoses(prev =>
+      prev.map(d =>
+        d._id === id
+          ? { ...d, status: 'confirmed', clinicianAssessment: note, confirmedAt: new Date().toISOString() }
+          : d
+      )
+    );
+    setConfirmDdDialog({ open: false, id: null, note: '' });
+  };
+
+  const handleValidateRx = async () => {
+    if (selectedDrugsForCheck.length < 1) return;
+    setRxCheck({ result: null, loading: true });
+    const result = await validatePrescription({
+      drugCodes: selectedDrugsForCheck.map(d => d.code || d._id),
+    });
+    setRxCheck({ result, loading: false });
+  };
+
   // ─── Derived data ─────────────────────────────────────────────────────────
 
   const filteredAlerts = alerts.filter(a => {
@@ -360,6 +414,15 @@ export default function CDSSDashboard() {
 
   const filteredRules =
     ruleCategory === 'all' ? rules : rules.filter(r => r.category === ruleCategory);
+
+  const filteredRisk =
+    riskTypeFilter === 'all'
+      ? riskAssessments
+      : riskAssessments.filter(r => r.assessmentType === riskTypeFilter);
+  const highRiskCount = riskAssessments.filter(
+    r => r.riskLevel === 'very_high' || r.riskLevel === 'high'
+  ).length;
+  const activeDdCount = diagnoses.filter(d => d.status === 'active').length;
 
   const alertCountBySeverity = alerts.reduce((acc, a) => {
     acc[a.severity] = (acc[a.severity] || 0) + 1;
@@ -475,6 +538,24 @@ export default function CDSSDashboard() {
           />
           <Tab icon={<DrugIcon />} iconPosition="start" label="مكتبة الأدوية" />
           <Tab icon={<LogIcon />} iconPosition="start" label="سجل القرارات" />
+          <Tab
+            icon={
+              <Badge badgeContent={highRiskCount} color="error" max={99}>
+                <RiskIcon />
+              </Badge>
+            }
+            iconPosition="start"
+            label="تقييمات المخاطر"
+          />
+          <Tab
+            icon={
+              <Badge badgeContent={activeDdCount} color="warning" max={99}>
+                <DiagnosisIcon />
+              </Badge>
+            }
+            iconPosition="start"
+            label="التشخيصات التفريقية"
+          />
         </Tabs>
       </Paper>
 
@@ -1162,6 +1243,15 @@ export default function CDSSDashboard() {
             >
               فحص التفاعلات
             </Button>
+            <Button
+              variant="outlined"
+              color="primary"
+              startIcon={rxCheck.loading ? <CircularProgress size={16} /> : <ValidateIcon />}
+              onClick={handleValidateRx}
+              disabled={selectedDrugsForCheck.length < 1 || rxCheck.loading}
+            >
+              التحقق من الوصفة
+            </Button>
           </Stack>
 
           {interactionResult && (
@@ -1176,6 +1266,44 @@ export default function CDSSDashboard() {
                   محتمل — راجع طبيب الفريق
                 </Alert>
               )}
+            </Box>
+          )}
+
+          {rxCheck.result && (
+            <Box mt={2}>
+              <Alert
+                severity={
+                  rxCheck.result.status === 'failed'
+                    ? 'error'
+                    : rxCheck.result.status === 'warnings'
+                      ? 'warning'
+                      : 'success'
+                }
+                icon={
+                  rxCheck.result.status === 'failed' ? (
+                    <CriticalIcon />
+                  ) : rxCheck.result.status === 'warnings' ? (
+                    <WarnIcon />
+                  ) : (
+                    <OkIcon />
+                  )
+                }
+              >
+                <strong>
+                  نتيجة التحقق من الوصفة:{' '}
+                  {rxCheck.result.status === 'failed'
+                    ? 'فشل — أخطاء حرجة'
+                    : rxCheck.result.status === 'warnings'
+                      ? 'تحذيرات'
+                      : 'مطابِقة'}
+                </strong>
+                {(rxCheck.result.errors.length > 0 || rxCheck.result.warnings.length > 0) && (
+                  <Typography variant="caption" sx={{ display: 'block', mt: 0.5 }}>
+                    {rxCheck.result.errors.length} خطأ • {rxCheck.result.warnings.length} تحذير •{' '}
+                    {rxCheck.result.interactions.length} تفاعل
+                  </Typography>
+                )}
+              </Alert>
             </Box>
           )}
         </Paper>
@@ -1324,8 +1452,334 @@ export default function CDSSDashboard() {
       </TabPanel>
 
       {/* ════════════════════════════════════════════════════════════════════
+          TAB 6 — RISK ASSESSMENTS
+      ════════════════════════════════════════════════════════════════════ */}
+      <TabPanel value={tab} index={6}>
+        {/* Auto-generate tool */}
+        <Paper
+          elevation={0}
+          sx={{ p: 2.5, borderRadius: 3, border: '1px solid', borderColor: 'divider', mb: 3 }}
+        >
+          <Typography fontWeight={700} mb={2} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <AutoIcon color="primary" fontSize="small" /> توليد تقييم مخاطر آلي
+          </Typography>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="flex-start">
+            <TextField
+              size="small"
+              label="معرّف المستفيد"
+              value={genRisk.beneficiaryId}
+              onChange={e => setGenRisk(p => ({ ...p, beneficiaryId: e.target.value }))}
+              placeholder="BNF-XXXXX"
+              sx={{ minWidth: 200 }}
+            />
+            <FormControl size="small" sx={{ minWidth: 200 }}>
+              <InputLabel>نوع التقييم</InputLabel>
+              <Select
+                value={genRisk.type}
+                label="نوع التقييم"
+                onChange={e => setGenRisk(p => ({ ...p, type: e.target.value }))}
+              >
+                {Object.entries(RISK_ASSESSMENT_TYPES).map(([k, v]) => (
+                  <MenuItem key={k} value={k}>
+                    {v.label} — {v.tool}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Button
+              variant="contained"
+              startIcon={genRisk.loading ? <CircularProgress size={16} color="inherit" /> : <RunIcon />}
+              onClick={handleGenerateRisk}
+              disabled={!genRisk.beneficiaryId.trim() || genRisk.loading}
+            >
+              توليد بالذكاء الاصطناعي
+            </Button>
+          </Stack>
+        </Paper>
+
+        {/* Type filter */}
+        <Stack direction="row" spacing={1} mb={2} flexWrap="wrap" useFlexGap>
+          <Chip
+            label={`الكل (${riskAssessments.length})`}
+            onClick={() => setRiskTypeFilter('all')}
+            variant={riskTypeFilter === 'all' ? 'filled' : 'outlined'}
+            size="small"
+          />
+          {Object.entries(RISK_ASSESSMENT_TYPES).map(([k, v]) => (
+            <Chip
+              key={k}
+              label={`${v.label} (${riskAssessments.filter(r => r.assessmentType === k).length})`}
+              onClick={() => setRiskTypeFilter(k)}
+              variant={riskTypeFilter === k ? 'filled' : 'outlined'}
+              size="small"
+            />
+          ))}
+        </Stack>
+
+        <Grid container spacing={2}>
+          {filteredRisk.map(ra => {
+            const lvl = RISK_LEVELS[ra.riskLevel] || RISK_LEVELS.low;
+            return (
+              <Grid item xs={12} md={6} key={ra._id}>
+                <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }}>
+                  <Paper
+                    elevation={0}
+                    sx={{
+                      p: 2.5,
+                      borderRadius: 3,
+                      border: '1px solid',
+                      borderColor:
+                        ra.riskLevel === 'very_high' || ra.riskLevel === 'high'
+                          ? 'error.light'
+                          : 'divider',
+                    }}
+                  >
+                    <Stack direction="row" justifyContent="space-between" alignItems="flex-start" mb={1}>
+                      <Box>
+                        <Typography fontWeight={700}>{ra.beneficiaryName}</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {ra.beneficiaryId} •{' '}
+                          {RISK_ASSESSMENT_TYPES[ra.assessmentType]?.label || ra.assessmentType} •{' '}
+                          {ra.toolUsed}
+                        </Typography>
+                      </Box>
+                      <Stack alignItems="flex-end" spacing={0.5}>
+                        <Chip label={lvl.label} size="small" color={lvl.color} sx={{ fontWeight: 700 }} />
+                        <Typography variant="h5" fontWeight={800} sx={{ color: `${lvl.color}.main` }}>
+                          {ra.overallScore}
+                        </Typography>
+                      </Stack>
+                    </Stack>
+
+                    {ra.domains?.length > 0 && (
+                      <Stack spacing={1} mt={1.5}>
+                        {ra.domains.map((dm, i) => (
+                          <Box key={i}>
+                            <Stack direction="row" justifyContent="space-between" mb={0.3}>
+                              <Typography variant="caption" fontWeight={600}>
+                                {dm.domain} {dm.flag && <WarnIcon sx={{ fontSize: 13, color: '#f59e0b' }} />}
+                              </Typography>
+                              <Typography variant="caption" fontWeight={700}>
+                                {dm.score}
+                              </Typography>
+                            </Stack>
+                            <LinearProgress
+                              variant="determinate"
+                              value={Math.min(dm.score, 100)}
+                              color={dm.flag ? 'error' : 'primary'}
+                              sx={{ height: 6, borderRadius: 3 }}
+                            />
+                          </Box>
+                        ))}
+                      </Stack>
+                    )}
+
+                    {ra.recommendedInterventions?.length > 0 && (
+                      <Box mt={1.5}>
+                        <Typography variant="caption" fontWeight={700} color="text.secondary">
+                          التدخلات الموصى بها:
+                        </Typography>
+                        <Stack direction="row" flexWrap="wrap" gap={0.5} mt={0.5}>
+                          {ra.recommendedInterventions.map(iv => (
+                            <Chip key={iv} label={iv} size="small" variant="outlined" sx={{ fontSize: '0.65rem' }} />
+                          ))}
+                        </Stack>
+                      </Box>
+                    )}
+
+                    <Stack direction="row" justifyContent="space-between" alignItems="center" mt={1.5}>
+                      <Typography variant="caption" color="text.secondary">
+                        {ra.mlAssisted && (
+                          <Chip
+                            icon={<AutoIcon sx={{ fontSize: 14 }} />}
+                            label={`AI ${ra.mlConfidenceScore ? `${Math.round(ra.mlConfidenceScore * 100)}%` : ''}`}
+                            size="small"
+                            color="primary"
+                            variant="outlined"
+                            sx={{ fontSize: '0.6rem', mr: 0.5 }}
+                          />
+                        )}
+                        {ra.generatedBy}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {fmtTime(ra.generatedAt)}
+                      </Typography>
+                    </Stack>
+                  </Paper>
+                </motion.div>
+              </Grid>
+            );
+          })}
+          {filteredRisk.length === 0 && (
+            <Grid item xs={12}>
+              <Box sx={{ textAlign: 'center', py: 6, color: 'text.secondary' }}>
+                <RiskIcon sx={{ fontSize: 48, mb: 1, opacity: 0.3 }} />
+                <Typography>لا توجد تقييمات مخاطر</Typography>
+              </Box>
+            </Grid>
+          )}
+        </Grid>
+      </TabPanel>
+
+      {/* ════════════════════════════════════════════════════════════════════
+          TAB 7 — DIFFERENTIAL DIAGNOSES
+      ════════════════════════════════════════════════════════════════════ */}
+      <TabPanel value={tab} index={7}>
+        <Grid container spacing={2}>
+          {diagnoses.map(dd => {
+            const st = DIAGNOSIS_STATUSES[dd.status] || DIAGNOSIS_STATUSES.active;
+            return (
+              <Grid item xs={12} md={6} key={dd._id}>
+                <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }}>
+                  <Paper
+                    elevation={0}
+                    sx={{
+                      p: 2.5,
+                      borderRadius: 3,
+                      border: '1px solid',
+                      borderColor: dd.status === 'confirmed' ? 'success.main' : 'divider',
+                    }}
+                  >
+                    <Stack direction="row" justifyContent="space-between" alignItems="flex-start" mb={1}>
+                      <Box>
+                        <Typography fontWeight={700}>{dd.beneficiaryName}</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {dd.beneficiaryId} • {fmtTime(dd.createdAt)}
+                        </Typography>
+                      </Box>
+                      <Chip label={st.label} size="small" color={st.color} sx={{ fontWeight: 700 }} />
+                    </Stack>
+
+                    <Typography variant="caption" fontWeight={700} color="text.secondary">
+                      الأعراض:
+                    </Typography>
+                    <Stack direction="row" flexWrap="wrap" gap={0.5} mt={0.5} mb={1.5}>
+                      {dd.symptoms.map(s => (
+                        <Chip key={s} label={s} size="small" sx={{ fontSize: '0.65rem' }} />
+                      ))}
+                    </Stack>
+
+                    <Typography variant="caption" fontWeight={700} color="primary">
+                      التشخيصات المحتملة:
+                    </Typography>
+                    <Stack spacing={1} mt={0.5}>
+                      {dd.candidates.map((c, i) => (
+                        <Box key={i}>
+                          <Stack direction="row" justifyContent="space-between" alignItems="center">
+                            <Typography variant="body2" fontWeight={i === 0 ? 700 : 500}>
+                              {c.icdCode && (
+                                <Chip
+                                  label={c.icdCode}
+                                  size="small"
+                                  variant="outlined"
+                                  sx={{ fontSize: '0.6rem', mr: 0.5, fontFamily: 'monospace' }}
+                                />
+                              )}
+                              {c.name}
+                            </Typography>
+                            {c.probability != null && (
+                              <Typography variant="caption" fontWeight={700}>
+                                {c.probability}%
+                              </Typography>
+                            )}
+                          </Stack>
+                          {c.probability != null && (
+                            <LinearProgress
+                              variant="determinate"
+                              value={c.probability}
+                              color={i === 0 ? 'primary' : 'inherit'}
+                              sx={{ height: 5, borderRadius: 3, mt: 0.3 }}
+                            />
+                          )}
+                          {c.reasoning && (
+                            <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                              {c.reasoning}
+                            </Typography>
+                          )}
+                        </Box>
+                      ))}
+                    </Stack>
+
+                    {dd.investigations?.length > 0 && (
+                      <Box mt={1.5}>
+                        <Typography variant="caption" fontWeight={700} color="text.secondary">
+                          الفحوصات الموصى بها:
+                        </Typography>
+                        <Box component="ul" sx={{ m: 0, pl: 2.5, mt: 0.3 }}>
+                          {dd.investigations.map((iv, i) => (
+                            <Typography key={i} component="li" variant="caption">
+                              {iv}
+                            </Typography>
+                          ))}
+                        </Box>
+                      </Box>
+                    )}
+
+                    {dd.status === 'confirmed' && dd.clinicianAssessment && (
+                      <Alert severity="success" sx={{ mt: 1.5, py: 0.2 }}>
+                        <Typography variant="caption">{dd.clinicianAssessment}</Typography>
+                      </Alert>
+                    )}
+
+                    {dd.status === 'active' && (
+                      <Button
+                        size="small"
+                        variant="contained"
+                        color="success"
+                        startIcon={<OkIcon />}
+                        sx={{ mt: 1.5 }}
+                        onClick={() => setConfirmDdDialog({ open: true, id: dd._id, note: '' })}
+                      >
+                        تأكيد التشخيص
+                      </Button>
+                    )}
+                  </Paper>
+                </motion.div>
+              </Grid>
+            );
+          })}
+          {diagnoses.length === 0 && (
+            <Grid item xs={12}>
+              <Box sx={{ textAlign: 'center', py: 6, color: 'text.secondary' }}>
+                <DiagnosisIcon sx={{ fontSize: 48, mb: 1, opacity: 0.3 }} />
+                <Typography>لا توجد تشخيصات تفريقية</Typography>
+              </Box>
+            </Grid>
+          )}
+        </Grid>
+      </TabPanel>
+
+      {/* ════════════════════════════════════════════════════════════════════
           DIALOGS
       ════════════════════════════════════════════════════════════════════ */}
+
+      {/* Confirm Differential Diagnosis Dialog */}
+      <Dialog
+        open={confirmDdDialog.open}
+        onClose={() => setConfirmDdDialog({ open: false, id: null, note: '' })}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>تأكيد التشخيص التفريقي</DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            multiline
+            rows={3}
+            label="التقييم السريري"
+            value={confirmDdDialog.note}
+            onChange={e => setConfirmDdDialog(p => ({ ...p, note: e.target.value }))}
+            placeholder="ملاحظات الطبيب حول التشخيص المؤكَّد..."
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmDdDialog({ open: false, id: null, note: '' })}>إلغاء</Button>
+          <Button variant="contained" color="success" onClick={handleConfirmDd}>
+            تأكيد
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Override Alert Dialog */}
       <Dialog

--- a/frontend/src/services/cdssService.js
+++ b/frontend/src/services/cdssService.js
@@ -50,6 +50,19 @@ export const RISK_LEVELS = {
   low: { label: 'منخفض', color: 'success', score: [0, 39] },
 };
 
+export const RISK_ASSESSMENT_TYPES = {
+  fall_risk: { label: 'خطر السقوط', tool: 'Morse Scale' },
+  pressure_ulcer: { label: 'قرحة الفراش', tool: 'Braden Scale' },
+  malnutrition: { label: 'سوء التغذية', tool: 'MUST' },
+  deterioration: { label: 'التدهور السريري', tool: 'NEWS' },
+};
+
+export const DIAGNOSIS_STATUSES = {
+  active: { label: 'قيد التقييم', color: 'warning' },
+  confirmed: { label: 'مؤكَّد', color: 'success' },
+  dismissed: { label: 'مستبعَد', color: 'default' },
+};
+
 // ─── Mock Data ────────────────────────────────────────────────────────────────
 
 const MOCK_STATS = {
@@ -273,6 +286,40 @@ const MOCK_RISK_ASSESSMENTS = [
     ],
     generatedAt: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
     generatedBy: 'Dr. سلمى العمري',
+  },
+];
+
+const MOCK_DIAGNOSES = [
+  {
+    _id: 'dd1',
+    beneficiaryId: 'BNF-00412',
+    beneficiaryName: 'أحمد محمد العتيبي',
+    symptoms: ['ضعف عضلي تدريجي', 'صعوبة في البلع', 'تشنجات ليلية'],
+    clinicalFindings: ['انخفاض المنعكسات الوترية', 'رنح في المشية'],
+    candidates: [
+      { icdCode: 'G35', name: 'التصلب المتعدد', probability: 62, reasoning: 'نمط الأعراض العصبية + التصوير' },
+      { icdCode: 'G12.2', name: 'التصلب الجانبي الضموري', probability: 24, reasoning: 'ضعف حركي بلا فقد حسي' },
+      { icdCode: 'G70.0', name: 'الوهن العضلي الوبيل', probability: 14, reasoning: 'تعب عضلي متذبذب' },
+    ],
+    investigations: ['رنين مغناطيسي للدماغ والنخاع', 'تخطيط كهربية العضل', 'تحليل السائل الدماغي الشوكي'],
+    status: 'active',
+    createdAt: new Date(Date.now() - 1000 * 60 * 50).toISOString(),
+  },
+  {
+    _id: 'dd2',
+    beneficiaryId: 'BNF-00298',
+    beneficiaryName: 'نورة خالد الغامدي',
+    symptoms: ['تأخر في النطق', 'ضعف تواصل بصري', 'سلوكيات نمطية'],
+    clinicalFindings: ['درجة CARS-2 = 34', 'محدودية اللعب التخيلي'],
+    candidates: [
+      { icdCode: 'F84.0', name: 'اضطراب طيف التوحد', probability: 78, reasoning: 'استيفاء معايير DSM-5 الأساسية' },
+      { icdCode: 'F80.2', name: 'اضطراب اللغة الاستقبالية', probability: 16, reasoning: 'ضعف فهم لغوي معزول' },
+    ],
+    investigations: ['تقييم سمعي شامل', 'تقييم تطوري متعدد التخصصات'],
+    status: 'confirmed',
+    clinicianAssessment: 'تم تأكيد التشخيص بعد التقييم متعدد التخصصات',
+    confirmedAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 30).toISOString(),
   },
 ];
 
@@ -620,6 +667,84 @@ const adaptDecision = l => ({
   timestamp: l?.decisionAt || l?.timestamp || l?.createdAt,
 });
 
+// backend risk level (low/moderate/high/very_high) → UI bucket (low/medium/high/very_high)
+const RISK_LEVEL_MAP = {
+  low: 'low',
+  moderate: 'medium',
+  medium: 'medium',
+  high: 'high',
+  very_high: 'very_high',
+};
+const mapRiskLevel = r => RISK_LEVEL_MAP[r] || 'low';
+
+const adaptRiskAssessment = a => ({
+  _id: a?._id || a?.id,
+  beneficiaryId:
+    (a?.beneficiaryId && typeof a.beneficiaryId === 'object' ? a.beneficiaryId._id : a?.beneficiaryId) || '',
+  beneficiaryName: refName(a?.beneficiaryId) || a?.beneficiaryName || '—',
+  assessmentType: a?.assessmentType || '',
+  toolUsed: a?.toolUsed || '',
+  overallScore:
+    typeof a?.overallScore === 'number'
+      ? a.overallScore
+      : typeof a?.totalScore === 'number'
+        ? a.totalScore
+        : 0,
+  riskLevel: mapRiskLevel(a?.riskLevel),
+  // backend stores domain detail in scoreBreakdown; mock data already uses `domains`
+  domains: Array.isArray(a?.domains)
+    ? a.domains
+    : Array.isArray(a?.scoreBreakdown)
+      ? a.scoreBreakdown.map(d => ({
+          domain: d?.domain || d?.name || d?.label || '',
+          score: typeof d?.score === 'number' ? d.score : (d?.value ?? 0),
+          flag: !!d?.flag,
+        }))
+      : [],
+  recommendedInterventions: toStringArray(a?.recommendedInterventions),
+  generatedAt: a?.generatedAt || a?.assessmentDate || a?.createdAt,
+  generatedBy: a?.generatedBy || (a?.mlAssisted ? 'AI-Auto' : refName(a?.assessedBy)) || '—',
+  mlAssisted: !!a?.mlAssisted,
+  mlConfidenceScore: typeof a?.mlConfidenceScore === 'number' ? a.mlConfidenceScore : null,
+  nextAssessmentDate: a?.nextAssessmentDate,
+});
+
+const adaptDiagnosis = d => ({
+  _id: d?._id || d?.id,
+  beneficiaryId:
+    (d?.beneficiaryId && typeof d.beneficiaryId === 'object' ? d.beneficiaryId._id : d?.beneficiaryId) || '',
+  beneficiaryName: refName(d?.beneficiaryId) || d?.beneficiaryName || '—',
+  symptoms: toStringArray(d?.presentingSymptoms ?? d?.symptoms),
+  clinicalFindings: toStringArray(d?.clinicalFindings),
+  candidates: (Array.isArray(d?.suggestedDiagnoses) ? d.suggestedDiagnoses : d?.candidates || []).map(c => ({
+    icdCode: c?.icd_code || c?.icdCode || '',
+    name: c?.name || c?.diagnosis || '',
+    probability:
+      typeof c?.probability === 'number'
+        ? c.probability <= 1
+          ? Math.round(c.probability * 100)
+          : Math.round(c.probability)
+        : null,
+    reasoning: c?.reasoning || '',
+  })),
+  investigations: toStringArray(d?.recommendedInvestigations ?? d?.investigations),
+  status: d?.status || 'active',
+  clinicianAssessment: d?.clinicianAssessment || '',
+  confirmedAt: d?.confirmedAt,
+  createdAt: d?.createdAt,
+});
+
+const adaptValidation = v => {
+  const errors = Array.isArray(v?.errors) ? v.errors : [];
+  return {
+    status: v?.status || (errors.length ? 'failed' : 'passed'),
+    hasCritical: !!v?.hasCritical || errors.length > 0,
+    warnings: Array.isArray(v?.warnings) ? v.warnings : [],
+    errors,
+    interactions: Array.isArray(v?.drugInteractionResults) ? v.drugInteractionResults : [],
+  };
+};
+
 const adaptList = (body, fn) => {
   try {
     return pickList(body).map(fn);
@@ -699,7 +824,10 @@ export const updateRule = (id, data) =>
 
 export const getRiskAssessments = (params = {}) =>
   withMock(
-    () => apiClient.get(`${BASE}/risk-assessments`, { params }).then(r => pickList(r.data)),
+    () =>
+      apiClient
+        .get(`${BASE}/risk-assessments`, { params })
+        .then(r => adaptList(r.data, adaptRiskAssessment)),
     MOCK_RISK_ASSESSMENTS
   );
 
@@ -708,7 +836,7 @@ export const generateAutoRiskAssessment = (beneficiaryId, assessmentType = 'fall
     () =>
       apiClient
         .post(`${BASE}/risk-assessments/auto`, { beneficiaryId, assessmentType })
-        .then(r => r.data?.data || r.data),
+        .then(r => adaptRiskAssessment(r.data?.data || r.data)),
     MOCK_RISK_ASSESSMENTS[0]
   );
 
@@ -766,4 +894,44 @@ export const evaluateRules = (beneficiaryId, contextType = 'manual', contextData
           alerts: adaptList(r.data, adaptAlert),
         })),
     { triggered: 2, alerts: MOCK_ALERTS.slice(0, 2) }
+  );
+
+// ─── Differential Diagnoses ────────────────────────────────────────────────────
+
+export const getDifferentialDiagnoses = (params = {}) =>
+  withMock(
+    () =>
+      apiClient
+        .get(`${BASE}/differential-diagnoses`, { params })
+        .then(r => adaptList(r.data, adaptDiagnosis)),
+    MOCK_DIAGNOSES
+  );
+
+export const createDifferentialDiagnosis = data =>
+  withMock(
+    () =>
+      apiClient
+        .post(`${BASE}/differential-diagnoses`, data)
+        .then(r => adaptDiagnosis(r.data?.data || r.data)),
+    { ...data, _id: Date.now().toString(), status: 'active' }
+  );
+
+export const confirmDifferentialDiagnosis = (id, payload = {}) =>
+  withMock(
+    () =>
+      apiClient
+        .patch(`${BASE}/differential-diagnoses/${id}/confirm`, payload)
+        .then(r => adaptDiagnosis(r.data?.data || r.data)),
+    { success: true }
+  );
+
+// ─── Prescription Validation ────────────────────────────────────────────────────
+
+export const validatePrescription = ({ beneficiaryId, prescriptionId, drugCodes } = {}) =>
+  withMock(
+    () =>
+      apiClient
+        .post(`${BASE}/prescriptions/validate`, { beneficiaryId, prescriptionId, drugCodes })
+        .then(r => adaptValidation({ ...(r.data?.data || {}), hasCritical: r.data?.hasCritical })),
+    { status: 'passed', hasCritical: false, warnings: [], errors: [], interactions: [] }
   );


### PR DESCRIPTION
## What
Completes the CDSS dashboard (دعم القرار السريري) by exposing three backend surfaces that were mounted at `/api/v1/cdss` but had **no UI**:

- **Risk Assessments tab** — list by tool/type (Morse / Braden / MUST / NEWS) with risk-level chips + per-domain score breakdown, plus an **AI auto-generate** tool (`POST /risk-assessments/auto`).
- **Differential Diagnoses tab** — ICD candidates with probability bars, presenting symptoms, recommended investigations, and a **confirm-diagnosis** action (`PATCH /:id/confirm`).
- **Prescription validation** — added to the Drug Library tab beside the interaction checker (`POST /prescriptions/validate`).

## How
Service layer gains defensive adapters (`adaptRiskAssessment` / `adaptDiagnosis` / `adaptValidation`) over the backend `{data:[...]}` envelopes — risk-level `moderate→medium`, 0–1 probability → %, `scoreBreakdown→domains`, ICD `icd_code→icdCode` — with the established mock-fallback pattern preserved. Builds on the contract-normalization layer from #170.

## Tests
7 new (5 adapter + 2 render-tab) → **21 total green**. Lint (`--max-warnings=0`) + `vite build` clean. All pre-push gates passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)