### PR TITLE
feat(clinical): W675 — seating & postural assessment (wired + enumerated)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -774,6 +774,9 @@ on:
       - 'backend/__tests__/session-branch-tenancy-wave647.test.js'
       - 'backend/__tests__/therapy-sessions-analytics-branch-scope-wave657.test.js'
       - 'backend/__tests__/unauthenticated-routes-wave658.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/seating-postural-assessment-behavioral-wave675.test.js'
+      - 'backend/__tests__/seating-postural-assessment-wave675.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1531,6 +1534,9 @@ on:
       - 'backend/__tests__/session-branch-tenancy-wave647.test.js'
       - 'backend/__tests__/therapy-sessions-analytics-branch-scope-wave657.test.js'
       - 'backend/__tests__/unauthenticated-routes-wave658.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/seating-postural-assessment-behavioral-wave675.test.js'
+      - 'backend/__tests__/seating-postural-assessment-wave675.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/seating-postural-assessment-behavioral-wave675.test.js
+++ b/backend/__tests__/seating-postural-assessment-behavioral-wave675.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+/**
+ * Behavioral counterpart for SeatingPosturalAssessment (W675).
+ *
+ * Boots a real in-memory Mongo via mongodb-memory-server, unmocks mongoose, and
+ * asserts the Wave-18 __invariants ACTUALLY FIRE — reject bad saves, accept good
+ * ones — plus that virtuals compute on persisted docs and defaults round-trip.
+ *
+ * Pattern reference: clinical-assessment-trio-behavioral-wave673.
+ */
+
+const mongoose = require('mongoose');
+
+// W675: unmock mongoose so we hit a real in-memory Mongo (jest.setup mocks it).
+jest.unmock('mongoose');
+
+let mongod;
+let Seating;
+
+beforeAll(async () => {
+  const { MongoMemoryServer } = require('mongodb-memory-server');
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  Seating = require('../models/SeatingPosturalAssessment');
+}, 60000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+});
+
+describe('SeatingPosturalAssessment behavioral (W675)', () => {
+  test('rejects moderate/high pressure risk without a mitigation plan', async () => {
+    const doc = new Seating({
+      beneficiaryId: new mongoose.Types.ObjectId(),
+      date: new Date(),
+      pressureInjuryRisk: 'high',
+    });
+    await expect(doc.save()).rejects.toThrow();
+  });
+
+  test('rejects an existing injury without stage + site', async () => {
+    const doc = new Seating({
+      beneficiaryId: new mongoose.Types.ObjectId(),
+      date: new Date(),
+      existingPressureInjury: true,
+    });
+    await expect(doc.save()).rejects.toThrow();
+  });
+
+  test('rejects an invalid postural-support segment', async () => {
+    const doc = new Seating({
+      beneficiaryId: new mongoose.Types.ObjectId(),
+      date: new Date(),
+      posturalSupports: [{ segment: 'tail', support: 'moderate' }],
+    });
+    await expect(doc.save()).rejects.toThrow();
+  });
+
+  test('rejects a discharge without an outcome summary', async () => {
+    const doc = new Seating({
+      beneficiaryId: new mongoose.Types.ObjectId(),
+      date: new Date(),
+      assessmentType: 'discharge',
+    });
+    await expect(doc.save()).rejects.toThrow();
+  });
+
+  test('accepts a valid at-risk assessment + computes virtuals', async () => {
+    const doc = await Seating.create({
+      beneficiaryId: new mongoose.Types.ObjectId(),
+      date: new Date(),
+      assessmentType: 'initial',
+      gmfcsLevel: 'V',
+      pressureInjuryRisk: 'high',
+      mitigationPlan: 'Reposition every 2h; air-cell cushion; daily skin check.',
+      repositioningIntervalMinutes: 120,
+      posturalSupports: [
+        { segment: 'trunk', support: 'moderate', device: 'lateral supports' },
+        { segment: 'head_neck', support: 'total', device: 'headrest' },
+        { segment: 'feet', support: 'none' },
+      ],
+    });
+    expect(doc.isPressureAtRisk).toBe(true);
+    expect(doc.segmentsSupported).toBe(2); // 'none' not counted
+  });
+
+  test('accepts a clean low-risk assessment (no mitigation plan required)', async () => {
+    const doc = await Seating.create({
+      beneficiaryId: new mongoose.Types.ObjectId(),
+      date: new Date(),
+      assessmentType: 'initial',
+      pressureInjuryRisk: 'low',
+    });
+    expect(doc.isPressureAtRisk).toBe(false);
+    expect(doc.status).toBe('draft');
+  });
+
+  test('rejects reassessmentDue earlier than the assessment date', async () => {
+    const doc = new Seating({
+      beneficiaryId: new mongoose.Types.ObjectId(),
+      date: new Date('2026-05-30'),
+      reassessmentDue: new Date('2026-05-01'),
+    });
+    await expect(doc.save()).rejects.toThrow();
+  });
+});

--- a/backend/__tests__/seating-postural-assessment-wave675.test.js
+++ b/backend/__tests__/seating-postural-assessment-wave675.test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+/**
+ * Static drift guard — SeatingPosturalAssessment (W675).
+ *
+ * Mirrors the W670-W672 guards: asserts the model file declares the canonical
+ * enums, the Wave-18 __invariants block with each required invalidate() call,
+ * the right refs, virtuals, and that the route file wires the standard
+ * branch-scoped middleware stack + the dualMountAuth contract.
+ *
+ * Static (source-text) only — jest.setup mocks mongoose so we don't boot Mongo.
+ * The behavioral counterpart is seating-postural-assessment-behavioral-wave675.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MODEL_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'models', 'SeatingPosturalAssessment.js'),
+  'utf8'
+);
+const ROUTE_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'routes', 'seating-postural-assessment.routes.js'),
+  'utf8'
+);
+const REGISTRY_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'routes', 'registries', 'features.registry.js'),
+  'utf8'
+);
+
+describe('SeatingPosturalAssessment model — W675 static drift guard', () => {
+  test('declares canonical enums', () => {
+    expect(MODEL_SRC).toMatch(/const ASSESSMENT_TYPES = \[/);
+    expect(MODEL_SRC).toMatch(/const CONTEXTS = \[/);
+    expect(MODEL_SRC).toMatch(/const BODY_SEGMENTS = \[/);
+    expect(MODEL_SRC).toMatch(/const SUPPORT_LEVELS = \[/);
+    expect(MODEL_SRC).toMatch(/const RISK_LEVELS = \[/);
+    expect(MODEL_SRC).toMatch(/const INJURY_STAGES = \[/);
+    expect(MODEL_SRC).toMatch(/const EQUIPMENT_TYPES = \[/);
+  });
+
+  test('GMFCS levels include IV and V (the seating-critical band)', () => {
+    expect(MODEL_SRC).toMatch(/const GMFCS_LEVELS = \[/);
+    expect(MODEL_SRC).toMatch(/'IV'/);
+    expect(MODEL_SRC).toMatch(/'V'/);
+  });
+
+  test('beneficiaryId + branchId refs are canonical', () => {
+    expect(MODEL_SRC).toMatch(/ref: 'Beneficiary'/);
+    expect(MODEL_SRC).toMatch(/ref: 'Branch'/);
+  });
+
+  test('cross-links the AssistiveDevice inventory record', () => {
+    expect(MODEL_SRC).toMatch(/ref: 'AssistiveDevice'/);
+  });
+
+  test('declares __invariants validate block', () => {
+    expect(MODEL_SRC).toMatch(/__invariants/);
+    expect(MODEL_SRC).toMatch(/\.path\('__invariants'\)\.validate\(/);
+  });
+
+  test('enforces moderate/high pressure risk -> mitigationPlan', () => {
+    expect(MODEL_SRC).toMatch(/mitigationPlan required when pressureInjuryRisk/);
+  });
+
+  test('enforces existingPressureInjury -> stage + site', () => {
+    expect(MODEL_SRC).toMatch(/injuryStage required when existingPressureInjury/);
+    expect(MODEL_SRC).toMatch(/injurySite required when existingPressureInjury/);
+  });
+
+  test('enforces discharge -> outcomeSummary', () => {
+    expect(MODEL_SRC).toMatch(/outcomeSummary required for a discharge/);
+  });
+
+  test('enforces finalized -> assessor + assessedAt', () => {
+    expect(MODEL_SRC).toMatch(/assessor required to finalize/);
+    expect(MODEL_SRC).toMatch(/assessedAt required to finalize/);
+  });
+
+  test('declares isPressureAtRisk + segmentsSupported virtuals', () => {
+    expect(MODEL_SRC).toMatch(/virtual\('isPressureAtRisk'\)/);
+    expect(MODEL_SRC).toMatch(/virtual\('segmentsSupported'\)/);
+  });
+
+  test('exports enums for route reuse', () => {
+    expect(MODEL_SRC).toMatch(/module\.exports\.ASSESSMENT_TYPES = ASSESSMENT_TYPES/);
+    expect(MODEL_SRC).toMatch(/module\.exports\.RISK_LEVELS = RISK_LEVELS/);
+    expect(MODEL_SRC).toMatch(/module\.exports\.BODY_SEGMENTS = BODY_SEGMENTS/);
+  });
+});
+
+describe('seating-postural-assessment routes — W675 static drift guard', () => {
+  test('mounts the branch-scoped middleware stack', () => {
+    expect(ROUTE_SRC).toMatch(/router\.use\(authenticateToken\)/);
+    expect(ROUTE_SRC).toMatch(/router\.use\(requireBranchAccess\)/);
+    expect(ROUTE_SRC).toMatch(/router\.use\(bodyScopedBeneficiaryGuard\)/);
+  });
+
+  test('every query is branch-filtered (W445)', () => {
+    expect(ROUTE_SRC).toMatch(/branchFilter\(req\)/);
+    const finds = (ROUTE_SRC.match(/\.find\(/g) || []).length;
+    const filters = (ROUTE_SRC.match(/branchFilter\(req\)/g) || []).length;
+    expect(filters).toBeGreaterThanOrEqual(Math.min(5, finds));
+  });
+
+  test('validates ObjectId on :id routes', () => {
+    expect(ROUTE_SRC).toMatch(/isValidObjectId/);
+  });
+
+  test('exposes the pressure-injury at-risk board', () => {
+    expect(ROUTE_SRC).toMatch(/\/at-risk/);
+  });
+
+  test('finalize transition exists', () => {
+    expect(ROUTE_SRC).toMatch(/\/:id\/finalize/);
+  });
+});
+
+describe('seating-postural-assessment registry wiring — W675', () => {
+  test('route is required + mounted via dualMountAuth (not a null placeholder)', () => {
+    expect(REGISTRY_SRC).toMatch(
+      /seatingPosturalAssessmentRoutes = safeRequire\(\s*'\.\.\/routes\/seating-postural-assessment\.routes'/
+    );
+    expect(REGISTRY_SRC).toMatch(
+      /dualMountAuth\(\s*app,\s*'seating-postural-assessment',\s*seatingPosturalAssessmentRoutes,\s*authenticate/
+    );
+    // guard against the interrupted-edit bug: no null placeholder mount
+    expect(REGISTRY_SRC).not.toMatch(/seatingRoutesMaybe/);
+  });
+});

--- a/backend/models/SeatingPosturalAssessment.js
+++ b/backend/models/SeatingPosturalAssessment.js
@@ -1,0 +1,298 @@
+'use strict';
+
+/**
+ * SeatingPosturalAssessment — W675.
+ *
+ * "تقييم الجلوس والوضعية / إدارة الوضعية على مدار 24 ساعة" — a clinical
+ * seating + postural-management evaluation for day-rehab beneficiaries who are
+ * dependent for positioning (cerebral palsy GMFCS IV–V, severe hypotonia,
+ * progressive neuromuscular disease, post-TBI). For these children the
+ * wheelchair / seating system is a 24-hour medical device: a wrong setup
+ * causes pressure injury, accelerates scoliosis / hip migration, compromises
+ * respiration and feeding, and blocks participation in therapy and education.
+ *
+ * Why a dedicated model (NOT AssistiveDevice, NOT PhysiotherapyAssessment):
+ *   • AssistiveDevice tracks the wheelchair as INVENTORY (loan, maintenance,
+ *     cost, condition). It does NOT capture the clinical seating PRESCRIPTION
+ *     — postural support per body segment, pressure-injury risk, the 24-hour
+ *     positioning plan, cushion/support recommendation with justification.
+ *   • PhysiotherapyAssessment (W672) captures ROM / tone / strength / gait —
+ *     the impairment level. Seating is the participation/equipment level: how
+ *     the impairment is accommodated in sitting/lying/standing across the day.
+ *   • Pressure-injury risk + bony-prominence sites drive a mitigation plan and
+ *     a re-assessment cadence — a life-safety decision a generic note can't hold.
+ *   • Longitudinal: growth, tone change, and skin breakdown all trigger a
+ *     re-fit; serial comparison (initial → review) is the whole point.
+ *
+ * Wave-18 invariants:
+ *   • assessmentType ∈ ASSESSMENT_TYPES ; positioningContext ∈ CONTEXTS
+ *   • every posturalSupports[].segment ∈ BODY_SEGMENTS and .support ∈ SUPPORT_LEVELS
+ *   • pressureInjuryRisk ∈ RISK_LEVELS
+ *   • pressureInjuryRisk ∈ {moderate,high} → mitigationPlan required (cannot
+ *     leave an at-risk child without a documented skin-protection plan)
+ *   • existingPressureInjury=true → injuryStage + injurySite required
+ *   • assessmentType='discharge' → outcomeSummary required
+ *   • status=finalized → assessedBy + assessedAt required
+ *   • reassessmentDue (when set) must be ≥ date
+ */
+
+const mongoose = require('mongoose');
+
+const ASSESSMENT_TYPES = ['initial', 'review', 'refit', 'discharge'];
+
+// Where the positioning plan applies — a 24-hour view, not just the chair.
+const CONTEXTS = ['sitting', 'lying', 'standing', 'transfers', 'transport', 'multiple'];
+
+// GMFCS — Gross Motor Function Classification System (seating relevance climbs
+// steeply at IV–V). '' = not classified / not applicable.
+const GMFCS_LEVELS = ['I', 'II', 'III', 'IV', 'V', ''];
+
+// Body segments a seating system supports.
+const BODY_SEGMENTS = [
+  'head_neck',
+  'trunk',
+  'pelvis',
+  'hips',
+  'lower_extremities',
+  'upper_extremities',
+  'feet',
+];
+
+// How much external support a segment needs.
+const SUPPORT_LEVELS = ['none', 'monitor', 'minimal', 'moderate', 'total'];
+
+// Pressure-injury risk band (simplified Braden-style clinical judgement).
+const RISK_LEVELS = ['none', 'low', 'moderate', 'high'];
+
+// NPUAP/EPUAP pressure-injury staging.
+const INJURY_STAGES = [
+  '',
+  'stage_1',
+  'stage_2',
+  'stage_3',
+  'stage_4',
+  'unstageable',
+  'deep_tissue',
+];
+
+// Seating equipment categories recommended / in use.
+const EQUIPMENT_TYPES = [
+  'standard_wheelchair',
+  'tilt_in_space_wheelchair',
+  'powered_wheelchair',
+  'buggy_stroller',
+  'activity_chair',
+  'standing_frame',
+  'sleep_system',
+  'custom_moulded_seat',
+  'other',
+];
+
+// Pressure-relief / cushion class.
+const CUSHION_TYPES = ['none', 'foam', 'gel', 'air_cell', 'honeycomb', 'custom_contoured', 'other'];
+
+const STATUSES = ['draft', 'finalized'];
+
+// One postural-support requirement for a single body segment.
+const PosturalSupportSchema = new mongoose.Schema(
+  {
+    segment: { type: String, default: '' }, // validated against BODY_SEGMENTS in __invariants
+    support: { type: String, default: '' }, // validated against SUPPORT_LEVELS in __invariants
+    device: { type: String, default: '', maxlength: 80 }, // lateral trunk supports, headrest, pommel…
+    note: { type: String, default: '', maxlength: 120 },
+  },
+  { _id: false }
+);
+
+const SeatingPosturalAssessmentSchema = new mongoose.Schema(
+  {
+    beneficiaryId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Beneficiary',
+      required: true,
+      index: true,
+    },
+    branchId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Branch',
+      default: null,
+      index: true,
+    },
+    sectionId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'BeneficiarySection',
+      default: null,
+    },
+    carePlanVersionId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'CarePlanVersion',
+      default: null,
+    },
+    // The wheelchair / seating device in inventory this prescription configures.
+    assistiveDeviceId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'AssistiveDevice',
+      default: null,
+    },
+
+    date: { type: Date, required: true, index: true },
+    assessmentType: { type: String, enum: ASSESSMENT_TYPES, default: 'initial', index: true },
+    positioningContext: { type: String, enum: CONTEXTS, default: 'sitting' },
+    gmfcsLevel: { type: String, enum: GMFCS_LEVELS, default: '' },
+    reason: { type: String, default: '', maxlength: 300 },
+
+    // Clinical observation.
+    posturalObservation: { type: String, default: '', maxlength: 600 },
+    fixedDeformities: { type: [String], default: () => [] }, // scoliosis, windswept hips, kyphosis…
+    toleratesUpright: { type: Boolean, default: true },
+    sittingToleranceMinutes: { type: Number, default: null, min: 0, max: 1440 },
+
+    // Per-segment postural support needs (the prescription core).
+    posturalSupports: { type: [PosturalSupportSchema], default: () => [] },
+
+    // Pressure-injury management — the life-safety axis.
+    pressureInjuryRisk: { type: String, enum: RISK_LEVELS, default: 'none', index: true },
+    bonyProminenceSites: { type: [String], default: () => [] }, // sacrum, ischial_tuberosities, heels…
+    existingPressureInjury: { type: Boolean, default: false },
+    injuryStage: { type: String, enum: INJURY_STAGES, default: '' },
+    injurySite: { type: String, default: '', maxlength: 80 },
+    mitigationPlan: { type: String, default: '', maxlength: 1000 }, // repositioning schedule, offloading…
+    repositioningIntervalMinutes: { type: Number, default: null, min: 0, max: 1440 },
+
+    // Equipment recommendation.
+    equipmentType: { type: String, enum: EQUIPMENT_TYPES.concat(['']), default: '' },
+    cushionType: { type: String, enum: CUSHION_TYPES, default: 'none' },
+    equipmentRecommendation: { type: String, default: '', maxlength: 1000 },
+
+    // 24-hour positioning plan — free narrative per posture across the day.
+    positioningPlan: { type: String, default: '', maxlength: 1500 },
+
+    goalsSummary: { type: String, default: '', maxlength: 1000 },
+    outcomeSummary: { type: String, default: '', maxlength: 1000 }, // required at discharge
+    caregiverEducationGiven: { type: Boolean, default: false },
+    reassessmentDue: { type: Date, default: null },
+
+    notes: { type: String, default: '', maxlength: 1000 },
+
+    assessedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+    assessedByName: { type: String, default: '', maxlength: 100 },
+    assessedAt: { type: Date, default: null },
+
+    status: { type: String, enum: STATUSES, default: 'draft', index: true },
+  },
+  { timestamps: true, collection: 'seating_postural_assessments' }
+);
+
+SeatingPosturalAssessmentSchema.index({ beneficiaryId: 1, date: -1 });
+SeatingPosturalAssessmentSchema.index({ branchId: 1, date: -1 });
+SeatingPosturalAssessmentSchema.index({ pressureInjuryRisk: 1, date: -1 });
+SeatingPosturalAssessmentSchema.index({ status: 1, date: -1 });
+
+SeatingPosturalAssessmentSchema.add({
+  __invariants: { type: mongoose.Schema.Types.Mixed, select: false, default: null },
+});
+
+SeatingPosturalAssessmentSchema.path('__invariants').validate(function () {
+  let ok = true;
+  if (!ASSESSMENT_TYPES.includes(this.assessmentType)) {
+    this.invalidate('assessmentType', `must be one of ${ASSESSMENT_TYPES.join(',')}`);
+    ok = false;
+  }
+  if (!CONTEXTS.includes(this.positioningContext)) {
+    this.invalidate('positioningContext', `must be one of ${CONTEXTS.join(',')}`);
+    ok = false;
+  }
+  if (!RISK_LEVELS.includes(this.pressureInjuryRisk)) {
+    this.invalidate('pressureInjuryRisk', `must be one of ${RISK_LEVELS.join(',')}`);
+    ok = false;
+  }
+  // Validate embedded per-segment support value-sets.
+  for (const s of this.posturalSupports || []) {
+    if (s.segment && !BODY_SEGMENTS.includes(s.segment)) {
+      this.invalidate('posturalSupports', `segment must be one of ${BODY_SEGMENTS.join(',')}`);
+      ok = false;
+      break;
+    }
+    if (s.support && !SUPPORT_LEVELS.includes(s.support)) {
+      this.invalidate('posturalSupports', `support must be one of ${SUPPORT_LEVELS.join(',')}`);
+      ok = false;
+      break;
+    }
+  }
+  // An at-risk child must have a documented skin-protection plan — no silent risk.
+  if (
+    ['moderate', 'high'].includes(this.pressureInjuryRisk) &&
+    !String(this.mitigationPlan || '').trim()
+  ) {
+    this.invalidate(
+      'mitigationPlan',
+      'mitigationPlan required when pressureInjuryRisk is moderate or high'
+    );
+    ok = false;
+  }
+  // An existing injury must be staged + sited (drives wound care + offloading).
+  if (this.existingPressureInjury) {
+    if (!this.injuryStage || !INJURY_STAGES.includes(this.injuryStage) || this.injuryStage === '') {
+      this.invalidate('injuryStage', 'injuryStage required when existingPressureInjury=true');
+      ok = false;
+    }
+    if (!String(this.injurySite || '').trim()) {
+      this.invalidate('injurySite', 'injurySite required when existingPressureInjury=true');
+      ok = false;
+    }
+  }
+  // A discharge assessment must state the outcome.
+  if (this.assessmentType === 'discharge' && !String(this.outcomeSummary || '').trim()) {
+    this.invalidate('outcomeSummary', 'outcomeSummary required for a discharge assessment');
+    ok = false;
+  }
+  if (this.reassessmentDue && this.date && this.reassessmentDue < this.date) {
+    this.invalidate('reassessmentDue', 'reassessmentDue must be >= assessment date');
+    ok = false;
+  }
+  if (this.status === 'finalized') {
+    if (!this.assessedBy && !String(this.assessedByName || '').trim()) {
+      this.invalidate('assessedBy', 'assessor required to finalize');
+      ok = false;
+    }
+    if (!this.assessedAt) {
+      this.invalidate('assessedAt', 'assessedAt required to finalize');
+      ok = false;
+    }
+  }
+  return ok;
+});
+
+/** True when the child carries a clinically significant skin-breakdown risk. */
+SeatingPosturalAssessmentSchema.virtual('isPressureAtRisk').get(function () {
+  return (
+    this.existingPressureInjury ||
+    this.pressureInjuryRisk === 'high' ||
+    this.pressureInjuryRisk === 'moderate'
+  );
+});
+
+/** Count of body segments with a defined support need — completeness signal. */
+SeatingPosturalAssessmentSchema.virtual('segmentsSupported').get(function () {
+  return Array.isArray(this.posturalSupports)
+    ? this.posturalSupports.filter(s => s.support && s.support !== 'none').length
+    : 0;
+});
+
+SeatingPosturalAssessmentSchema.set('toJSON', { virtuals: true });
+SeatingPosturalAssessmentSchema.set('toObject', { virtuals: true });
+
+module.exports =
+  mongoose.models.SeatingPosturalAssessment ||
+  mongoose.model('SeatingPosturalAssessment', SeatingPosturalAssessmentSchema);
+
+module.exports.ASSESSMENT_TYPES = ASSESSMENT_TYPES;
+module.exports.CONTEXTS = CONTEXTS;
+module.exports.GMFCS_LEVELS = GMFCS_LEVELS;
+module.exports.BODY_SEGMENTS = BODY_SEGMENTS;
+module.exports.SUPPORT_LEVELS = SUPPORT_LEVELS;
+module.exports.RISK_LEVELS = RISK_LEVELS;
+module.exports.INJURY_STAGES = INJURY_STAGES;
+module.exports.EQUIPMENT_TYPES = EQUIPMENT_TYPES;
+module.exports.CUSHION_TYPES = CUSHION_TYPES;
+module.exports.STATUSES = STATUSES;

--- a/backend/routes/registries/features.registry.js
+++ b/backend/routes/registries/features.registry.js
@@ -52,6 +52,9 @@ module.exports = function registerFeatureRoutes(
   const dysphagiaAssessmentRoutes = safeRequire('../routes/dysphagia-assessment.routes');
   const painAssessmentRoutes = safeRequire('../routes/pain-assessment.routes');
   const physiotherapyAssessmentRoutes = safeRequire('../routes/physiotherapy-assessment.routes');
+  const seatingPosturalAssessmentRoutes = safeRequire(
+    '../routes/seating-postural-assessment.routes'
+  );
   const facilityAssetRoutes = safeRequire('../routes/facility-asset.routes');
   const caregiverSupportProgramRoutes = safeRequire('../routes/caregiver-support-program.routes');
   const digitalAssessmentRoutes = safeRequire('../routes/digital-assessment.routes');
@@ -151,6 +154,8 @@ module.exports = function registerFeatureRoutes(
   dualMountAuth(app, 'pain-assessment', painAssessmentRoutes, authenticate);
   // Wave 672: Physiotherapy assessment (تقييم العلاج الطبيعي) — ROM/Ashworth/strength/gait + initial-progress-discharge
   dualMountAuth(app, 'physiotherapy-assessment', physiotherapyAssessmentRoutes, authenticate);
+  // Wave 675: Seating & postural assessment (تقييم الجلوس والوضعية) — wheelchair/seating + postural risk + pressure-care
+  dualMountAuth(app, 'seating-postural-assessment', seatingPosturalAssessmentRoutes, authenticate);
   // Wave 369: Facility asset PPM (أصول المنشأة) — elevators/ramps/HVAC/fire/water/oxygen/sensory rooms
   dualMountAuth(app, 'facility-asset', facilityAssetRoutes, authenticate);
   // Wave 384: Caregiver support program (برنامج دعم مقدمي الرعاية) — counseling/training/support-group persistence

--- a/backend/routes/seating-postural-assessment.routes.js
+++ b/backend/routes/seating-postural-assessment.routes.js
@@ -1,0 +1,497 @@
+'use strict';
+
+/**
+ * seating-postural-assessment.routes.js — W675.
+ *
+ * Seating & postural-management assessment admin surface. Mounted via
+ * dualMountAuth at /api/(v1/)?seating-postural-assessment.
+ *
+ * Endpoints:
+ *   GET    /today                  — today's assessments (branch filter)
+ *   GET    /                       — list w/ filters (paginated)
+ *   GET    /at-risk                — pressure-injury at-risk board (branch)
+ *   GET    /due                    — reassessments due (branch)
+ *   GET    /by-beneficiary/:id     — per-kid history (last 100) + initial/latest pair
+ *   GET    /stats                  — type + risk distribution
+ *   GET    /:id
+ *   POST   /                       — record assessment (draft)
+ *   POST   /:id/finalize           — finalize (immutable after)
+ *   PATCH  /:id                    — correct (only while status=draft)
+ *   DELETE /:id                    — admin-only
+ */
+
+const express = require('express');
+const router = express.Router();
+const mongoose = require('mongoose');
+const { authenticateToken, requireRole } = require('../middleware/auth');
+
+const SeatingPosturalAssessment = require('../models/SeatingPosturalAssessment');
+const Beneficiary = require('../models/Beneficiary');
+const safeError = require('../utils/safeError');
+const { requireBranchAccess, branchFilter } = require('../middleware/branchScope.middleware');
+const { bodyScopedBeneficiaryGuard } = require('../middleware/assertBranchMatch');
+
+router.use(authenticateToken);
+router.use(requireBranchAccess); // W445
+router.use(bodyScopedBeneficiaryGuard); // W441
+
+const READ_ROLES = [
+  'admin',
+  'superadmin',
+  'super_admin',
+  'manager',
+  'clinical_supervisor',
+  'therapist',
+  'physiotherapist',
+  'occupational_therapist',
+  'teacher',
+  'nurse',
+  'quality',
+];
+const WRITE_ROLES = [
+  'admin',
+  'superadmin',
+  'super_admin',
+  'manager',
+  'clinical_supervisor',
+  'therapist',
+  'physiotherapist',
+  'occupational_therapist',
+];
+const FINALIZE_ROLES = [
+  'admin',
+  'superadmin',
+  'super_admin',
+  'manager',
+  'clinical_supervisor',
+  'physiotherapist',
+  'occupational_therapist',
+];
+const DELETE_ROLES = ['admin', 'superadmin', 'super_admin'];
+
+const {
+  ASSESSMENT_TYPES,
+  CONTEXTS,
+  GMFCS_LEVELS,
+  BODY_SEGMENTS,
+  SUPPORT_LEVELS,
+  RISK_LEVELS,
+  INJURY_STAGES,
+  EQUIPMENT_TYPES,
+  CUSHION_TYPES,
+} = SeatingPosturalAssessment;
+
+function startOfDay(d) {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+function endOfDay(d) {
+  const x = new Date(d);
+  x.setHours(23, 59, 59, 999);
+  return x;
+}
+
+async function hydrate(items) {
+  const ids = [...new Set(items.map(r => String(r.beneficiaryId)).filter(Boolean))].filter(id =>
+    mongoose.isValidObjectId(id)
+  );
+  const benefs = ids.length
+    ? await Beneficiary.find({ _id: { $in: ids } })
+        .select('firstName_ar lastName_ar beneficiaryNumber')
+        .lean()
+    : [];
+  const map = new Map(benefs.map(b => [String(b._id), b]));
+  return items.map(r => ({ ...r, beneficiary: map.get(String(r.beneficiaryId)) || null }));
+}
+
+function sanitizeSupports(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw.slice(0, 20).map(s => ({
+    segment: BODY_SEGMENTS.includes(String(s?.segment)) ? String(s.segment) : '',
+    support: SUPPORT_LEVELS.includes(String(s?.support)) ? String(s.support) : '',
+    device: String(s?.device || '').slice(0, 80),
+    note: String(s?.note || '').slice(0, 120),
+  }));
+}
+
+function sanitizeStrList(raw, max, len) {
+  if (!Array.isArray(raw)) return [];
+  return raw.slice(0, max).map(s => String(s).slice(0, len));
+}
+
+function num(v, min, max) {
+  if (typeof v !== 'number' || Number.isNaN(v)) return null;
+  return Math.max(min, Math.min(max, v));
+}
+
+// ── GET /today ──────────────────────────────────────────────────────────
+router.get('/today', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const d = req.query.date ? new Date(req.query.date) : new Date();
+    const filter = {
+      ...branchFilter(req), // W445
+      date: { $gte: startOfDay(d), $lte: endOfDay(d) },
+    };
+    if (req.query.branchId && mongoose.isValidObjectId(req.query.branchId)) {
+      filter.branchId = req.query.branchId;
+    }
+    const raw = await SeatingPosturalAssessment.find(filter).sort({ date: -1 }).lean();
+    const items = await hydrate(raw);
+    res.json({ success: true, items, count: items.length, date: startOfDay(d) });
+  } catch (err) {
+    return safeError(res, err, 'seating.today');
+  }
+});
+
+// ── GET / ────────────────────────────────────────────────────────────────
+router.get('/', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const filter = { ...branchFilter(req) }; /* W445 */
+    if (req.query.beneficiaryId && mongoose.isValidObjectId(req.query.beneficiaryId)) {
+      filter.beneficiaryId = req.query.beneficiaryId;
+    }
+    if (req.query.branchId && mongoose.isValidObjectId(req.query.branchId)) {
+      filter.branchId = req.query.branchId;
+    }
+    if (req.query.assessmentType && ASSESSMENT_TYPES.includes(String(req.query.assessmentType))) {
+      filter.assessmentType = String(req.query.assessmentType);
+    }
+    if (
+      req.query.pressureInjuryRisk &&
+      RISK_LEVELS.includes(String(req.query.pressureInjuryRisk))
+    ) {
+      filter.pressureInjuryRisk = String(req.query.pressureInjuryRisk);
+    }
+    if (req.query.status && ['draft', 'finalized'].includes(String(req.query.status))) {
+      filter.status = String(req.query.status);
+    }
+    if (req.query.from || req.query.to) {
+      filter.date = {};
+      if (req.query.from) filter.date.$gte = startOfDay(new Date(req.query.from));
+      if (req.query.to) filter.date.$lte = endOfDay(new Date(req.query.to));
+    }
+    const p = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const l = Math.min(200, Math.max(1, parseInt(req.query.limit, 10) || 50));
+    const [raw, total] = await Promise.all([
+      SeatingPosturalAssessment.find(filter)
+        .sort({ date: -1 })
+        .skip((p - 1) * l)
+        .limit(l)
+        .lean(),
+      SeatingPosturalAssessment.countDocuments(filter),
+    ]);
+    const items = await hydrate(raw);
+    res.json({
+      success: true,
+      items,
+      pagination: { page: p, limit: l, total, pages: Math.ceil(total / l) },
+    });
+  } catch (err) {
+    return safeError(res, err, 'seating.list');
+  }
+});
+
+// ── GET /at-risk — pressure-injury board (moderate/high or existing injury) ─
+router.get('/at-risk', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const filter = {
+      ...branchFilter(req), // W445
+      $or: [
+        { pressureInjuryRisk: { $in: ['moderate', 'high'] } },
+        { existingPressureInjury: true },
+      ],
+    };
+    if (req.query.branchId && mongoose.isValidObjectId(req.query.branchId)) {
+      filter.branchId = req.query.branchId;
+    }
+    const raw = await SeatingPosturalAssessment.find(filter)
+      .sort({ pressureInjuryRisk: -1, date: -1 })
+      .limit(300)
+      .lean();
+    const items = await hydrate(raw);
+    res.json({ success: true, items, count: items.length });
+  } catch (err) {
+    return safeError(res, err, 'seating.atRisk');
+  }
+});
+
+// ── GET /due — reassessments due across the branch ───────────────────────
+router.get('/due', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const by = req.query.by ? endOfDay(new Date(req.query.by)) : endOfDay(new Date());
+    const filter = {
+      ...branchFilter(req), // W445
+      reassessmentDue: { $ne: null, $lte: by },
+    };
+    if (req.query.branchId && mongoose.isValidObjectId(req.query.branchId)) {
+      filter.branchId = req.query.branchId;
+    }
+    const raw = await SeatingPosturalAssessment.find(filter)
+      .sort({ reassessmentDue: 1 })
+      .limit(300)
+      .lean();
+    const items = await hydrate(raw);
+    res.json({ success: true, items, count: items.length });
+  } catch (err) {
+    return safeError(res, err, 'seating.due');
+  }
+});
+
+// ── GET /by-beneficiary/:id ──────────────────────────────────────────────
+router.get('/by-beneficiary/:id', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
+    }
+    const items = await SeatingPosturalAssessment.find({
+      ...branchFilter(req),
+      /* W445 */ beneficiaryId: req.params.id,
+    })
+      .sort({ date: -1 })
+      .limit(100)
+      .lean();
+    const initial = [...items].reverse().find(r => r.assessmentType === 'initial') || null;
+    const latest = items.find(r => r.status === 'finalized') || items[0] || null;
+    res.json({
+      success: true,
+      items,
+      count: items.length,
+      initial: initial
+        ? { id: initial._id, date: initial.date, pressureInjuryRisk: initial.pressureInjuryRisk }
+        : null,
+      latest: latest
+        ? { id: latest._id, date: latest.date, pressureInjuryRisk: latest.pressureInjuryRisk }
+        : null,
+    });
+  } catch (err) {
+    return safeError(res, err, 'seating.byBeneficiary');
+  }
+});
+
+// ── GET /stats ───────────────────────────────────────────────────────────
+router.get('/stats', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const from = req.query.from
+      ? startOfDay(new Date(req.query.from))
+      : startOfDay(new Date(Date.now() - 90 * 24 * 60 * 60 * 1000));
+    const to = req.query.to ? endOfDay(new Date(req.query.to)) : endOfDay(new Date());
+    const filter = {
+      ...branchFilter(req), // W445
+      date: { $gte: from, $lte: to },
+    };
+    if (req.query.branchId && mongoose.isValidObjectId(req.query.branchId)) {
+      filter.branchId = req.query.branchId;
+    }
+    if (req.query.beneficiaryId && mongoose.isValidObjectId(req.query.beneficiaryId)) {
+      filter.beneficiaryId = req.query.beneficiaryId;
+    }
+    const raw = await SeatingPosturalAssessment.find(filter)
+      .select('assessmentType pressureInjuryRisk existingPressureInjury caregiverEducationGiven')
+      .lean();
+    const byType = ASSESSMENT_TYPES.reduce((acc, t) => ((acc[t] = 0), acc), {});
+    const byRisk = RISK_LEVELS.reduce((acc, r) => ((acc[r] = 0), acc), {});
+    let withInjury = 0;
+    let caregiverEducated = 0;
+    for (const r of raw) {
+      if (r.assessmentType) byType[r.assessmentType] = (byType[r.assessmentType] || 0) + 1;
+      if (r.pressureInjuryRisk)
+        byRisk[r.pressureInjuryRisk] = (byRisk[r.pressureInjuryRisk] || 0) + 1;
+      if (r.existingPressureInjury) withInjury++;
+      if (r.caregiverEducationGiven) caregiverEducated++;
+    }
+    res.json({
+      success: true,
+      from,
+      to,
+      total: raw.length,
+      byType,
+      byRisk,
+      existingInjuries: withInjury,
+      caregiverEducated,
+    });
+  } catch (err) {
+    return safeError(res, err, 'seating.stats');
+  }
+});
+
+// ── GET /:id ─────────────────────────────────────────────────────────────
+router.get('/:id', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
+    }
+    const row = await SeatingPosturalAssessment.findOne({
+      _id: req.params.id,
+      ...branchFilter(req),
+    }).lean(); /* W445 */
+    if (!row) return res.status(404).json({ success: false, message: 'السجل غير موجود' });
+    const [hydrated] = await hydrate([row]);
+    res.json({ success: true, data: hydrated });
+  } catch (err) {
+    return safeError(res, err, 'seating.get');
+  }
+});
+
+// ── POST / — record assessment (draft) ───────────────────────────────────
+router.post('/', requireRole(WRITE_ROLES), async (req, res) => {
+  try {
+    const body = req.body || {};
+    if (!body.beneficiaryId || !mongoose.isValidObjectId(body.beneficiaryId)) {
+      return res.status(400).json({ success: false, message: 'beneficiaryId مطلوب' });
+    }
+    const date = body.date ? new Date(body.date) : new Date();
+
+    const doc = await SeatingPosturalAssessment.create({
+      beneficiaryId: body.beneficiaryId,
+      branchId: body.branchId && mongoose.isValidObjectId(body.branchId) ? body.branchId : null,
+      sectionId: body.sectionId && mongoose.isValidObjectId(body.sectionId) ? body.sectionId : null,
+      carePlanVersionId:
+        body.carePlanVersionId && mongoose.isValidObjectId(body.carePlanVersionId)
+          ? body.carePlanVersionId
+          : null,
+      assistiveDeviceId:
+        body.assistiveDeviceId && mongoose.isValidObjectId(body.assistiveDeviceId)
+          ? body.assistiveDeviceId
+          : null,
+      date: startOfDay(date),
+      assessmentType: ASSESSMENT_TYPES.includes(String(body.assessmentType))
+        ? String(body.assessmentType)
+        : 'initial',
+      positioningContext: CONTEXTS.includes(String(body.positioningContext))
+        ? String(body.positioningContext)
+        : 'sitting',
+      gmfcsLevel: GMFCS_LEVELS.includes(String(body.gmfcsLevel)) ? String(body.gmfcsLevel) : '',
+      reason: String(body.reason || '').slice(0, 300),
+      posturalObservation: String(body.posturalObservation || '').slice(0, 600),
+      fixedDeformities: sanitizeStrList(body.fixedDeformities, 20, 60),
+      toleratesUpright: body.toleratesUpright !== undefined ? !!body.toleratesUpright : true,
+      sittingToleranceMinutes: num(body.sittingToleranceMinutes, 0, 1440),
+      posturalSupports: sanitizeSupports(body.posturalSupports),
+      pressureInjuryRisk: RISK_LEVELS.includes(String(body.pressureInjuryRisk))
+        ? String(body.pressureInjuryRisk)
+        : 'none',
+      bonyProminenceSites: sanitizeStrList(body.bonyProminenceSites, 20, 40),
+      existingPressureInjury: !!body.existingPressureInjury,
+      injuryStage: INJURY_STAGES.includes(String(body.injuryStage)) ? String(body.injuryStage) : '',
+      injurySite: String(body.injurySite || '').slice(0, 80),
+      mitigationPlan: String(body.mitigationPlan || '').slice(0, 1000),
+      repositioningIntervalMinutes: num(body.repositioningIntervalMinutes, 0, 1440),
+      equipmentType: EQUIPMENT_TYPES.includes(String(body.equipmentType))
+        ? String(body.equipmentType)
+        : '',
+      cushionType: CUSHION_TYPES.includes(String(body.cushionType))
+        ? String(body.cushionType)
+        : 'none',
+      equipmentRecommendation: String(body.equipmentRecommendation || '').slice(0, 1000),
+      positioningPlan: String(body.positioningPlan || '').slice(0, 1500),
+      goalsSummary: String(body.goalsSummary || '').slice(0, 1000),
+      outcomeSummary: String(body.outcomeSummary || '').slice(0, 1000),
+      caregiverEducationGiven: !!body.caregiverEducationGiven,
+      reassessmentDue: body.reassessmentDue ? new Date(body.reassessmentDue) : null,
+      notes: String(body.notes || '').slice(0, 1000),
+      status: 'draft',
+    });
+    res.status(201).json({ success: true, data: doc });
+  } catch (err) {
+    return safeError(res, err, 'seating.create');
+  }
+});
+
+// ── POST /:id/finalize ────────────────────────────────────────────────────
+router.post('/:id/finalize', requireRole(FINALIZE_ROLES), async (req, res) => {
+  try {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
+    }
+    const row = await SeatingPosturalAssessment.findOne({
+      _id: req.params.id,
+      ...branchFilter(req),
+    }); /* W445 */
+    if (!row) return res.status(404).json({ success: false, message: 'السجل غير موجود' });
+    if (row.status === 'finalized') {
+      return res.status(409).json({ success: false, message: 'التقييم سبق وأن تم اعتماده' });
+    }
+    row.assessedBy = req.user?.id || null;
+    row.assessedByName = req.user?.name || String(req.body?.assessorName || '').slice(0, 100);
+    row.assessedAt = new Date();
+    row.status = 'finalized';
+    await row.save(); // __invariants enforce risk⇒mitigationPlan, injury staging, discharge⇒outcome
+    res.json({ success: true, data: row });
+  } catch (err) {
+    return safeError(res, err, 'seating.finalize');
+  }
+});
+
+// ── PATCH /:id — correct while still 'draft' ─────────────────────────────
+router.patch('/:id', requireRole(WRITE_ROLES), async (req, res) => {
+  try {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
+    }
+    const row = await SeatingPosturalAssessment.findOne({
+      _id: req.params.id,
+      ...branchFilter(req),
+    }); /* W445 */
+    if (!row) return res.status(404).json({ success: false, message: 'السجل غير موجود' });
+    if (row.status === 'finalized') {
+      return res.status(409).json({ success: false, message: 'لا يمكن تعديل تقييم تم اعتماده' });
+    }
+    if ('posturalSupports' in req.body)
+      row.posturalSupports = sanitizeSupports(req.body.posturalSupports);
+    if ('fixedDeformities' in req.body)
+      row.fixedDeformities = sanitizeStrList(req.body.fixedDeformities, 20, 60);
+    if ('bonyProminenceSites' in req.body)
+      row.bonyProminenceSites = sanitizeStrList(req.body.bonyProminenceSites, 20, 40);
+    const editable = [
+      'assessmentType',
+      'positioningContext',
+      'gmfcsLevel',
+      'reason',
+      'posturalObservation',
+      'toleratesUpright',
+      'sittingToleranceMinutes',
+      'pressureInjuryRisk',
+      'existingPressureInjury',
+      'injuryStage',
+      'injurySite',
+      'mitigationPlan',
+      'repositioningIntervalMinutes',
+      'equipmentType',
+      'cushionType',
+      'equipmentRecommendation',
+      'positioningPlan',
+      'goalsSummary',
+      'outcomeSummary',
+      'caregiverEducationGiven',
+      'reassessmentDue',
+      'notes',
+    ];
+    for (const k of editable) {
+      if (k in req.body) row[k] = req.body[k];
+    }
+    await row.save();
+    res.json({ success: true, data: row });
+  } catch (err) {
+    return safeError(res, err, 'seating.patch');
+  }
+});
+
+// ── DELETE /:id — admin-only ─────────────────────────────────────────────
+router.delete('/:id', requireRole(DELETE_ROLES), async (req, res) => {
+  try {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
+    }
+    const row = await SeatingPosturalAssessment.findOneAndDelete({
+      _id: req.params.id,
+      ...branchFilter(req),
+    }); /* W445 */
+    if (!row) return res.status(404).json({ success: false, message: 'السجل غير موجود' });
+    res.json({ success: true, deleted: true, id: req.params.id });
+  } catch (err) {
+    return safeError(res, err, 'seating.delete');
+  }
+});
+
+module.exports = router;

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -408,6 +408,8 @@ __tests__/scoring-cp-motor-classifications-wave566.test.js
 __tests__/scoring-item-bank-contract-wave553.test.js
 __tests__/scoring-mchat-r-wave554.test.js
 __tests__/scoring-sdq-wave565.test.js
+__tests__/seating-postural-assessment-behavioral-wave675.test.js
+__tests__/seating-postural-assessment-wave675.test.js
 __tests__/seed-rag-policies-wave283d.test.js
 __tests__/sehhaty-adapter-wave280.test.js
 __tests__/sehhaty-bootstrap-wave280b.test.js


### PR DESCRIPTION
@
## What

Completes and publishes the **W675 SeatingPosturalAssessment** build. The model, routes, and two test suites existed as untracked working-tree files from an earlier session but were never wired in or committed — the route was unmounted and 1 of 24 tests was red on the missing registry entry.

This PR finishes it:
- **Wires** `seating-postural-assessment.routes` into `features.registry.js` via `dualMountAuth` (auth-required, mirroring the W671 pain-assessment sibling).
- **Enumerates** both `wave675` test suites in `sprint-tests.txt` + syncs the sprint trigger yml (458 entries).
- Commits the model + routes + 2 test suites that were previously untracked.

## Verification (local)
- W675 tests: **24/24 green** (static drift guard + behavioral, incl. the registry-wiring assertion that was the only red).
- `dual-mount-auth-locked`: 19/19 (registry integrity).
- `check:routes-load`: 557 route files load cleanly (route mounts).
- `check:sprint-paths`: in sync (458 × 2).
- Pre-push gates + lint across all 4 sub-projects: passed.

## Scope note
Branched off the latest `origin/main`; touches only the W675 files + the registry/sprint-enumeration wiring. No other in-flight work included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@