### PR TITLE
fix(ops): W676 — env-gated DB backup cron (closes DR-drill no_backup_found)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -777,6 +777,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/seating-postural-assessment-behavioral-wave675.test.js'
       - 'backend/__tests__/seating-postural-assessment-wave675.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/db-backup-cron-wave676.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1537,6 +1539,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/seating-postural-assessment-behavioral-wave675.test.js'
       - 'backend/__tests__/seating-postural-assessment-wave675.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/db-backup-cron-wave676.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/db-backup-cron-wave676.test.js
+++ b/backend/__tests__/db-backup-cron-wave676.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * W676 drift guard — databaseBackupBootstrap.
+ *
+ * Locks the DB-backup-cron wiring that closes the DR-drill `no_backup_found`
+ * gap (dormant automated-backup service + no in-app backup producer → 3-day
+ * DR-verify failure, diagnosed 2026-05-31):
+ *   • bootstrap is GATED OFF by default — returns { scheduled:false } unless
+ *     ENABLE_DB_BACKUP_CRON==='true' (inert on deploy, zero prod risk)
+ *   • requires logger; throws without it
+ *   • drives the proven scripts/db-backup.js createBackup + cleanupOldBackups
+ *     (writes backup_* to DB_BACKUP_DIR || backups/mongodb — the exact dir +
+ *     naming dr-verify.js SECONDARY scans)
+ *   • Asia/Riyadh, node-cron via loadOptional, lazy-require inside the tick
+ *   • wired into app.js
+ *
+ * Pure static reads + an inert behavioral call (never schedules / never shells
+ * out to mongodump).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const BOOT_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'startup', 'databaseBackupBootstrap.js'),
+  'utf8'
+);
+const APP_SRC = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+
+describe('W676 databaseBackupBootstrap — source shape', () => {
+  it('is env-gated on ENABLE_DB_BACKUP_CRON', () => {
+    expect(BOOT_SRC).toMatch(/process\.env\.ENABLE_DB_BACKUP_CRON\s*!==\s*'true'/);
+  });
+  it('drives the proven db-backup script (createBackup + cleanupOldBackups)', () => {
+    expect(BOOT_SRC).toMatch(/require\(\s*'\.\.\/scripts\/db-backup'\s*\)/);
+    expect(BOOT_SRC).toMatch(/createBackup/);
+    expect(BOOT_SRC).toMatch(/cleanupOldBackups/);
+  });
+  it('schedules via node-cron loaded optionally, Asia/Riyadh', () => {
+    expect(BOOT_SRC).toMatch(/loadOptional\(\s*'node-cron'\s*\)/);
+    expect(BOOT_SRC).toMatch(/timezone:\s*'Asia\/Riyadh'/);
+  });
+  it('exports wireDatabaseBackup', () => {
+    expect(BOOT_SRC).toMatch(/module\.exports\s*=\s*\{\s*wireDatabaseBackup\s*\}/);
+  });
+});
+
+describe('W676 databaseBackupBootstrap — inert default behavior', () => {
+  const { wireDatabaseBackup } = require('../startup/databaseBackupBootstrap');
+  const silentLogger = { info: () => {}, warn: () => {}, error: () => {} };
+
+  it('throws without a logger', () => {
+    expect(() => wireDatabaseBackup({}, {})).toThrow(/logger required/);
+  });
+
+  it('does NOT schedule when ENABLE_DB_BACKUP_CRON is unset (inert default)', () => {
+    const prev = process.env.ENABLE_DB_BACKUP_CRON;
+    delete process.env.ENABLE_DB_BACKUP_CRON;
+    try {
+      const res = wireDatabaseBackup({}, { logger: silentLogger });
+      expect(res).toEqual({ scheduled: false });
+    } finally {
+      if (prev !== undefined) process.env.ENABLE_DB_BACKUP_CRON = prev;
+    }
+  });
+});
+
+describe('W676 — wired into app.js', () => {
+  it('app.js calls wireDatabaseBackup', () => {
+    expect(APP_SRC).toMatch(
+      /databaseBackupBootstrap'\)\.wireDatabaseBackup\(app,\s*\{\s*logger\s*\}\)/
+    );
+  });
+});

--- a/backend/app.js
+++ b/backend/app.js
@@ -2086,6 +2086,11 @@ require('./startup/riskSweeperBootstrap').wireRiskSweeper(app, { logger });
 // → no_show after 24h with no check-in). All others query + log.
 require('./startup/clinicalSweepersBootstrap').wireClinicalSweepers(app, { logger });
 
+// W676 — DB backup producer cron (env-gated, default OFF). Closes the DR-drill
+// `no_backup_found` gap: feeds backups/mongodb (the dir dr-verify.js scans).
+// Inert until ENABLE_DB_BACKUP_CRON=true + mongodump present on host.
+require('./startup/databaseBackupBootstrap').wireDatabaseBackup(app, { logger });
+
 // W455 — GAS T-score weekly snapshot cron (env-gated, default OFF).
 // ENABLE_GAS_SNAPSHOT_CRON=true + GAS_SNAPSHOT_BRANCH_IDS=b1,b2
 require('./startup/gasSnapshotBootstrap').wireGasSnapshots(app, { logger });

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -154,6 +154,7 @@ __tests__/cultural-profile-wave475.test.js
 __tests__/da-periodic-cron-wave286.test.js
 __tests__/data-quality-wave22.test.js
 __tests__/day-rehab-section-bus-trip-behavioral-wave175-183-202b.test.js
+__tests__/db-backup-cron-wave676.test.js
 __tests__/decision-rights-behavioral-wave461.test.js
 __tests__/decision-rights-routes-wave515.test.js
 __tests__/decision-rights-wave461.test.js

--- a/backend/startup/databaseBackupBootstrap.js
+++ b/backend/startup/databaseBackupBootstrap.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * databaseBackupBootstrap.js — Wave 676.
+ *
+ * Wires a scheduled MongoDB backup producer so the daily DR drill
+ * (`scripts/dr-verify.js`, workflow `🛡️ DR Drill (daily)`) finds a recent
+ * backup instead of failing with `no_backup_found`.
+ *
+ * ROOT CAUSE (diagnosed 2026-05-31): the production VPS had NO backup
+ * producer — `services/automated-backup.service.js` was dormant (never wired
+ * into app.js / startup / any scheduler) and no in-app backup cron existed —
+ * so `dr-verify.js` scanned both `BACKUP_DIR` (backend/backups) and
+ * `DB_BACKUP_DIR` (backups/mongodb) and found nothing. The DR drill failed for
+ * 3+ consecutive days (and OPS_ALERT_* recipients were unset, so the failures
+ * were silent).
+ *
+ * This runs the proven `scripts/db-backup.js` `createBackup()` — which writes a
+ * `backup_<label>_<ts>` directory to `DB_BACKUP_DIR || backups/mongodb`, the
+ * EXACT directory + `backup_*` naming that dr-verify's SECONDARY check scans —
+ * on a daily cron, then prunes old backups via `cleanupOldBackups()`.
+ *
+ * GATED OFF BY DEFAULT. The capability ships inert; nothing runs until an
+ * operator opts in AND confirms the host prerequisites:
+ *   • `mongodump` installed on the host (db-backup.js checks this and fails
+ *     loudly if absent),
+ *   • `DB_BACKUP_DIR` (or default backups/mongodb) writable by the app user.
+ *
+ * Env:
+ *   ENABLE_DB_BACKUP_CRON    — 'true' to schedule (default: OFF)
+ *   DB_BACKUP_CRON_SCHEDULE  — cron expr (default '0 2 * * *' = daily 02:00)
+ *   DB_BACKUP_KEEP_DAYS      — retention days (db-backup.js default: 30)
+ *   DB_BACKUP_DIR            — backup output dir (default: backups/mongodb)
+ */
+
+function loadOptional(modulePath) {
+  try {
+    return require(modulePath);
+  } catch {
+    return null;
+  }
+}
+
+function wireDatabaseBackup(app, deps = {}) {
+  const { logger } = deps;
+  if (!logger) {
+    throw new Error('databaseBackupBootstrap.wireDatabaseBackup: logger required');
+  }
+
+  if (process.env.ENABLE_DB_BACKUP_CRON !== 'true') {
+    logger.info('[startup] DB backup cron disabled (set ENABLE_DB_BACKUP_CRON=true to schedule)');
+    return { scheduled: false };
+  }
+
+  const cron = loadOptional('node-cron');
+  if (!cron) {
+    logger.warn('[startup] node-cron not available; DB backup cron not scheduled');
+    return { scheduled: false };
+  }
+
+  const schedule = process.env.DB_BACKUP_CRON_SCHEDULE || '0 2 * * *';
+  const TZ = { timezone: 'Asia/Riyadh' };
+
+  cron.schedule(
+    schedule,
+    async () => {
+      try {
+        // Lazy-require so a backup-script load error can't break app boot.
+        const { createBackup, cleanupOldBackups } = require('../scripts/db-backup');
+        logger.info('[db-backup] scheduled backup starting');
+        const res = await createBackup({ label: 'cron' });
+        if (res && res.success) {
+          logger.info(
+            `[db-backup] backup complete: ${(res.meta && res.meta.backupName) || res.backupPath}`
+          );
+        } else {
+          logger.error(`[db-backup] backup failed: ${(res && res.error) || 'unknown error'}`);
+        }
+        try {
+          const pruned = cleanupOldBackups();
+          logger.info(`[db-backup] retention prune: ${pruned ? pruned.deleted : 0} removed`);
+        } catch (pruneErr) {
+          logger.error('[db-backup] retention prune failed', pruneErr);
+        }
+      } catch (err) {
+        logger.error('[db-backup] scheduled backup failed', err);
+      }
+    },
+    TZ
+  );
+
+  logger.info(`[startup] W676 DB backup cron scheduled (${schedule} Asia/Riyadh)`);
+  return { scheduled: true };
+}
+
+module.exports = { wireDatabaseBackup };


### PR DESCRIPTION
@
## Problem

The daily **🛡️ DR Drill** workflow (`dr-verify.js`) has failed **3 consecutive days** (2026-05-29/30/31) with `"error": "no_backup_found"`. Root cause: the production host has **no backup producer** —
- `services/automated-backup.service.js` is **dormant** (never wired into `app.js` / `startup/` / any scheduler), and
- no in-app backup cron exists,

so `dr-verify.js` scans both `BACKUP_DIR` (`backend/backups`) and `DB_BACKUP_DIR` (`backups/mongodb`) and finds nothing. Separately, `OPS_ALERT_EMAIL`/`OPS_ALERT_PHONE` are unset, so the failures have been **silent**.

## Fix (inert by default)

Adds `startup/databaseBackupBootstrap.js`, wired in `app.js`, which runs the proven `scripts/db-backup.js` `createBackup()` on a daily cron — writing `backup_<label>_<ts>` to `DB_BACKUP_DIR || backups/mongodb`, the **exact dir + naming** `dr-verify.js`s SECONDARY check scans — then prunes via `cleanupOldBackups()`.

**Gated OFF by default** (`ENABLE_DB_BACKUP_CRON!=true`): ships inert, zero production behavior change, fully reversible. The capability is wired and ready; nothing runs until an operator opts in.

## Operator activation runbook (requires host access — out of CI scope)
1. Confirm `mongodump` is installed on the host + `DB_BACKUP_DIR` is writable by the app user.
2. Set `ENABLE_DB_BACKUP_CRON=true` (optional `DB_BACKUP_CRON_SCHEDULE`, `DB_BACKUP_KEEP_DAYS`) and restart.
3. Re-run the DR Drill via `workflow_dispatch` to confirm it now finds the backup.
4. Set `OPS_ALERT_EMAIL` / `OPS_ALERT_PHONE` so future DR failures actually alert.

## Verification (local)
- W676 drift guard: **7/7** (env-gated default OFF + db-backup wiring + Asia/Riyadh + app.js mount + inert behavioral check — never schedules / never shells out to mongodump).
- `check:routes-load`: 557 route files load cleanly (app.js boots with the new bootstrap).
- `check:sprint-paths`: in sync. Pre-push gates + lint (4 sub-projects): passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@