### PR TITLE
fix(security): visitor JWT via httpOnly cookie (audit #23, W584)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -779,6 +779,8 @@ on:
       - 'backend/__tests__/seating-postural-assessment-wave675.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/db-backup-cron-wave676.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/visitor-auth-httponly-cookie-wave584.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1541,6 +1543,8 @@ on:
       - 'backend/__tests__/seating-postural-assessment-wave675.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/db-backup-cron-wave676.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/visitor-auth-httponly-cookie-wave584.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/visitor-auth-httponly-cookie-wave584.test.js
+++ b/backend/__tests__/visitor-auth-httponly-cookie-wave584.test.js
@@ -1,0 +1,84 @@
+/**
+ * Audit #23 — visitor JWT moved from localStorage to an httpOnly cookie.
+ *
+ * Verifies the backend contract of routes/visitor-auth.routes.js:
+ *   - GET  /my-submissions authenticates from the `visitor_jwt` cookie,
+ *   - falls back to the `Authorization: Bearer` header (transitional clients),
+ *   - 401s when neither is present,
+ *   - POST /logout clears the cookie.
+ *
+ * No Mongo / no OTP randomness: FormSubmission is mocked and the JWT is signed
+ * directly with the test secret. supertest drives the mounted router.
+ */
+'use strict';
+
+jest.mock('../models/FormSubmission', () => ({
+  exists: jest.fn().mockResolvedValue(true),
+  find: jest.fn(() => ({
+    select: () => ({ sort: () => ({ limit: () => ({ lean: () => Promise.resolve([]) }) }) }),
+  })),
+}));
+
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+const SECRET = 'test-visitor-secret';
+
+function makeApp() {
+  process.env.JWT_SECRET = SECRET;
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/public/visitor', require('../routes/visitor-auth.routes'));
+  return app;
+}
+
+function visitorToken(contact = 'a@b.com') {
+  return jwt.sign({ contact, role: 'visitor' }, SECRET, { expiresIn: '24h' });
+}
+
+describe('visitor-auth httpOnly cookie (audit #23)', () => {
+  const app = makeApp();
+
+  test('my-submissions authenticates from the visitor_jwt cookie', async () => {
+    const res = await request(app)
+      .get('/api/v1/public/visitor/my-submissions')
+      .set('Cookie', [`visitor_jwt=${visitorToken('cookie@x.com')}`]);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.contact).toBe('cookie@x.com');
+  });
+
+  test('my-submissions still accepts a Bearer header (transitional fallback)', async () => {
+    const res = await request(app)
+      .get('/api/v1/public/visitor/my-submissions')
+      .set('Authorization', `Bearer ${visitorToken('bearer@x.com')}`);
+    expect(res.status).toBe(200);
+    expect(res.body.contact).toBe('bearer@x.com');
+  });
+
+  test('my-submissions 401s with neither cookie nor header', async () => {
+    const res = await request(app).get('/api/v1/public/visitor/my-submissions');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('NO_TOKEN');
+  });
+
+  test('a non-visitor token is rejected even via the cookie', async () => {
+    const adminToken = jwt.sign({ contact: 'x@x.com', role: 'admin' }, SECRET, { expiresIn: '1h' });
+    const res = await request(app)
+      .get('/api/v1/public/visitor/my-submissions')
+      .set('Cookie', [`visitor_jwt=${adminToken}`]);
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('NOT_VISITOR_TOKEN');
+  });
+
+  test('logout clears the visitor_jwt cookie', async () => {
+    const res = await request(app).post('/api/v1/public/visitor/logout');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    const setCookie = (res.headers['set-cookie'] || []).join(';');
+    expect(setCookie).toMatch(/visitor_jwt=/);
+    // cleared cookie carries an expiry in the past (Expires=… 1970 or Max-Age=0/negative)
+    expect(setCookie).toMatch(/Expires=Thu, 01 Jan 1970|Max-Age=0|Max-Age=-/i);
+  });
+});

--- a/backend/routes/visitor-auth.routes.js
+++ b/backend/routes/visitor-auth.routes.js
@@ -75,6 +75,36 @@ function isPhone(c) {
   return /^\+?\d[\d\s-]{6,}$/.test(c);
 }
 
+// ── httpOnly cookie for the visitor JWT (audit #23) ─────────────────────────
+// web-admin and this API share the same site (alaweal.org), so SameSite=Lax is
+// sufficient and needs no CORS change. Secure in prod; relaxed in dev for
+// http://localhost. The cookie is httpOnly so page JS can't read/exfiltrate it
+// (the prior localStorage token was XSS-exfiltratable). No cookie-parser
+// dependency — we read the one cookie we care about directly off the header.
+const VISITOR_COOKIE = 'visitor_jwt';
+const COOKIE_PATH = '/api/v1/public/visitor';
+function cookieOpts() {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: COOKIE_PATH,
+    maxAge: 24 * 60 * 60 * 1000, // 24h — matches the JWT expiry
+  };
+}
+function readVisitorCookie(req) {
+  const raw = req.headers.cookie;
+  if (!raw) return null;
+  for (const part of raw.split(';')) {
+    const i = part.indexOf('=');
+    if (i === -1) continue;
+    if (part.slice(0, i).trim() === VISITOR_COOKIE) {
+      return decodeURIComponent(part.slice(i + 1).trim());
+    }
+  }
+  return null;
+}
+
 router.post('/request-otp', rateLimit, async (req, res) => {
   try {
     const contact = normalize(req.body?.contact);
@@ -158,6 +188,10 @@ router.post('/verify-otp', rateLimit, async (req, res) => {
     const effectiveSecret = secret || 'dev-fallback-do-not-use-in-production';
     const token = jwt.sign({ contact, role: 'visitor' }, effectiveSecret, { expiresIn: '24h' });
 
+    // audit #23: deliver the JWT as an httpOnly cookie (XSS-safe). The body
+    // `token` is retained for ONE transition release so a not-yet-updated
+    // frontend keeps working; drop it once all clients read the cookie.
+    res.cookie(VISITOR_COOKIE, token, cookieOpts());
     res.json({ ok: true, token, contact });
   } catch (err) {
     return safeError(res, err, 'visitorAuth', { shape: 'ok' });
@@ -168,7 +202,10 @@ router.get('/my-submissions', async (req, res) => {
   try {
     const auth = req.headers.authorization || '';
     const m = /^Bearer (.+)$/.exec(auth);
-    if (!m) return res.status(401).json({ ok: false, error: 'NO_TOKEN' });
+    // audit #23: prefer the httpOnly cookie; fall back to the Bearer header for
+    // transitional clients and non-browser API callers.
+    const rawToken = readVisitorCookie(req) || (m ? m[1] : null);
+    if (!rawToken) return res.status(401).json({ ok: false, error: 'NO_TOKEN' });
     // W457: refuse to fall back to 'dev-fallback' in production —
     // attacker knowing the literal could forge any visitor token.
     const secret = process.env.JWT_SECRET || process.env.AUTH_SECRET;
@@ -183,7 +220,7 @@ router.get('/my-submissions', async (req, res) => {
     const effectiveSecret = secret || 'dev-fallback-do-not-use-in-production';
     let payload;
     try {
-      payload = jwt.verify(m[1], effectiveSecret, { algorithms: ['HS256'] });
+      payload = jwt.verify(rawToken, effectiveSecret, { algorithms: ['HS256'] });
     } catch {
       return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
     }
@@ -204,6 +241,12 @@ router.get('/my-submissions', async (req, res) => {
   } catch (err) {
     return safeError(res, err, 'visitorAuth', { shape: 'ok' });
   }
+});
+
+// audit #23: clear the httpOnly cookie (the page JS can't, since it's httpOnly).
+router.post('/logout', (req, res) => {
+  res.clearCookie(VISITOR_COOKIE, { path: COOKIE_PATH });
+  res.json({ ok: true });
 });
 
 module.exports = router;

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -453,6 +453,7 @@ __tests__/transition-plan-wave361.test.js
 __tests__/unauthenticated-routes-wave658.test.js
 __tests__/user-branch-role-window.test.js
 __tests__/utilization-digest-script.test.js
+__tests__/visitor-auth-httponly-cookie-wave584.test.js
 __tests__/voice-log-routes-wave513.test.js
 __tests__/waiting-list-service.test.js
 __tests__/waitlist-digest-script.test.js


### PR DESCRIPTION
@
## What

Publishes the **audit #23** backend security fix that was sitting unmerged on `security/audit-23-visitor-httponly` (found via `git cherry` — genuinely not on `main`). Cherry-picked clean onto current `main` (only the sprint-enumeration files needed a union resolve).

Moves the visitor portal JWT off `localStorage` (XSS-exfiltratable) onto an **httpOnly cookie**:
- `verify-otp` now sets an httpOnly `visitor_jwt` cookie (`SameSite=Lax`; `Secure` in prod) **in addition** to returning the token in the body — kept for ONE transition release so a not-yet-updated frontend still works.
- `my-submissions` reads the cookie first, falling back to the `Authorization: Bearer` header for transitional / non-browser callers.
- Adds `POST /logout` to clear the cookie (page JS cant, since its httpOnly).
- No `cookie-parser` dependency — the single cookie is read off the header directly.

## Verification
- New drift/behavioral test `visitor-auth-httponly-cookie-wave584.test.js`: **5/5** (cookie auth, Bearer fallback, no-token 401, non-visitor-token rejection, logout-clears-cookie — supertest + mocked model, no Mongo/OTP dependency). Enumerated in sprint-tests.txt + CI paths.
- `check:routes-load`: 557 route files load cleanly. `check:sprint-paths`: in sync (460 × 2).

## Pairs with
The web-admin frontend half (`security/audit-23-visitor-cookie-frontend`) — published separately to the rehab-platform repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@