### PR TITLE
feat(clinical): W722 AudiologyScreening — functional hearing screen + referral

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -847,6 +847,8 @@ on:
       - 'backend/__tests__/scoring-mobility-caregiver-wave708.test.js'
       - 'backend/__tests__/scoring-neuro-disability-wave721.test.js'
       - 'backend/__tests__/tenant-routes-wiring-wave721.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/module-gap-alerts-subscriber-wave717.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1677,6 +1679,8 @@ on:
       - 'backend/__tests__/scoring-mobility-caregiver-wave708.test.js'
       - 'backend/__tests__/scoring-neuro-disability-wave721.test.js'
       - 'backend/__tests__/tenant-routes-wiring-wave721.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/module-gap-alerts-subscriber-wave717.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -849,6 +849,10 @@ on:
       - 'backend/__tests__/tenant-routes-wiring-wave721.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/module-gap-alerts-subscriber-wave717.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/audiology-screening-api-wave722.test.js'
+      - 'backend/__tests__/audiology-screening-behavioral-wave722.test.js'
+      - 'backend/__tests__/audiology-screening-wave722.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1681,6 +1685,10 @@ on:
       - 'backend/__tests__/tenant-routes-wiring-wave721.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/module-gap-alerts-subscriber-wave717.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/audiology-screening-api-wave722.test.js'
+      - 'backend/__tests__/audiology-screening-behavioral-wave722.test.js'
+      - 'backend/__tests__/audiology-screening-wave722.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/audiology-screening-api-wave722.test.js
+++ b/backend/__tests__/audiology-screening-api-wave722.test.js
@@ -1,0 +1,137 @@
+/**
+ * audiology-screening-api-wave722.test.js — HTTP route-level (supertest) tests
+ * for the W722 functional hearing-screen, on the W699 reusable harness.
+ * Covers the draft→finalize lifecycle + the refer-needs-reason invariant (400).
+ */
+
+'use strict';
+
+process.env.NODE_ENV = 'test';
+process.env.USE_MOCK_DB = 'true';
+process.env.CSRF_DISABLE = 'true';
+process.env.JWT_SECRET =
+  process.env.JWT_SECRET || 'test-secret-for-api-suite-longer-than-sixteen-chars';
+
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+jest.unmock('mongoose');
+jest.resetModules();
+jest.setTimeout(90_000);
+const mongoose = require('mongoose');
+const app = require('../app');
+let ownServer = null;
+
+beforeAll(async () => {
+  const { MongoMemoryServer } = require('mongodb-memory-server');
+  ownServer = await MongoMemoryServer.create();
+  if (mongoose.connection.readyState !== 0) {
+    try {
+      await mongoose.disconnect();
+    } catch {
+      /* ignore */
+    }
+  }
+  await mongoose.connect(ownServer.getUri(), {
+    dbName: 'audiology-api-test',
+    serverSelectionTimeoutMS: 10000,
+  });
+}, 90_000);
+afterAll(async () => {
+  try {
+    await mongoose.disconnect();
+  } catch {
+    /* ignore */
+  }
+  if (ownServer) await ownServer.stop();
+}, 60_000);
+
+function token(role = 'admin') {
+  return jwt.sign(
+    { id: '000000000000000000000001', role, name: 'Tester' },
+    process.env.JWT_SECRET,
+    {
+      expiresIn: '1h',
+    }
+  );
+}
+const auth = (role = 'admin') => ({ Authorization: `Bearer ${token(role)}` });
+const BASE = '/api/v1/audiology-screening';
+const oid = () => new mongoose.Types.ObjectId().toString();
+
+describe('W722 audiology-screening API — mount + validation', () => {
+  it('route mounted (not 404)', async () => {
+    const res = await request(app).get(BASE);
+    expect(res.status).not.toBe(404);
+  });
+  it('200 stats with byMethod/byOutcome/byLossType', async () => {
+    const res = await request(app).get(`${BASE}/stats`).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('byMethod');
+    expect(res.body).toHaveProperty('byOutcome');
+    expect(res.body).toHaveProperty('byLossType');
+  });
+  it('400 unknown screeningMethod', async () => {
+    const res = await request(app)
+      .post(BASE)
+      .set(auth())
+      .send({ beneficiaryId: oid(), screeningMethod: 'telepathy' });
+    expect(res.status).toBe(400);
+  });
+  it('400 malformed ObjectId', async () => {
+    const res = await request(app).get(`${BASE}/not-an-id`).set(auth());
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('W722 audiology-screening API — lifecycle + refer gate', () => {
+  let id;
+  it('201 record a draft screen', async () => {
+    const res = await request(app).post(BASE).set(auth()).send({
+      beneficiaryId: oid(),
+      screeningMethod: 'play_audiometry',
+      levelRight: 'mild_26_40',
+      tympanometryRight: 'B',
+      hearingLossType: 'conductive',
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.data.status).toBe('draft');
+    id = res.body.data._id;
+  });
+  it('200 finalize a monitor-outcome screen', async () => {
+    const res = await request(app).post(`${BASE}/${id}/finalize`).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('finalized');
+  });
+  it('409 re-finalize the same screen', async () => {
+    const res = await request(app).post(`${BASE}/${id}/finalize`).set(auth());
+    expect(res.status).toBe(409);
+  });
+  it('refer-outcome with no referralReason is BLOCKED at create (Wave-18 invariant)', async () => {
+    const res = await request(app)
+      .post(BASE)
+      .set(auth())
+      .send({ beneficiaryId: oid(), screeningMethod: 'otoacoustic_emissions', outcome: 'refer' });
+    // The __invariants validator rejects it; safeError surfaces a 4xx/5xx — the
+    // contract that matters is "not persisted", i.e. not 201.
+    expect(res.status).not.toBe(201);
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  });
+  it('201 refer-outcome WITH a reason, then finalizes to 200', async () => {
+    const created = await request(app).post(BASE).set(auth()).send({
+      beneficiaryId: oid(),
+      screeningMethod: 'otoacoustic_emissions',
+      outcome: 'refer',
+      referralReason: 'absent OAE bilaterally',
+      referralTo: 'ENT',
+    });
+    expect(created.status).toBe(201);
+    const res = await request(app).post(`${BASE}/${created.body.data._id}/finalize`).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.data.needsReferral).toBe(true);
+  });
+  it('200 needs-referral board', async () => {
+    const res = await request(app).get(`${BASE}/needs-referral`).set(auth());
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.items)).toBe(true);
+  });
+});

--- a/backend/__tests__/audiology-screening-behavioral-wave722.test.js
+++ b/backend/__tests__/audiology-screening-behavioral-wave722.test.js
@@ -1,0 +1,152 @@
+'use strict';
+
+/**
+ * audiology-screening-behavioral-wave722.test.js — behavioral counterpart to
+ * the W722 static drift guard. MongoMemoryServer-based: actually persists docs
+ * and asserts the Wave-18 invariants fire, virtuals compute, defaults round-trip.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(30000);
+
+const mongoose = require('mongoose');
+const fs = require('fs');
+const path = require('path');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let AS;
+
+beforeAll(async () => {
+  const URI_FILE = path.join(__dirname, '..', '.test-mongo-uri');
+  let uri;
+  if (fs.existsSync(URI_FILE)) {
+    uri = fs.readFileSync(URI_FILE, 'utf-8').trim();
+  } else {
+    mongod = await MongoMemoryServer.create({ instance: { dbName: 'w722-behavioral-test' } });
+    uri = mongod.getUri();
+  }
+  await mongoose.connect(uri);
+  AS = require('../models/AudiologyScreening');
+  await AS.init();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+beforeEach(async () => {
+  await AS.deleteMany({});
+});
+
+function baseDoc(overrides = {}) {
+  return {
+    beneficiaryId: new mongoose.Types.ObjectId(),
+    branchId: new mongoose.Types.ObjectId(),
+    date: new Date(),
+    screeningMethod: 'play_audiometry',
+    ...overrides,
+  };
+}
+
+describe('W722 behavioral — defaults + method', () => {
+  it('SAVES a draft screen with defaults', async () => {
+    const doc = await AS.create(baseDoc());
+    expect(doc.status).toBe('draft');
+    expect(doc.outcome).toBe('monitor');
+    expect(doc.hearingLossType).toBe('unknown');
+    expect(doc.needsReferral).toBe(false);
+    expect(doc.riskIndicatorCount).toBe(0);
+    expect(doc.worseEarLevel).toBeNull();
+  });
+  it('REJECTS an unknown screeningMethod', async () => {
+    const p = new AS(baseDoc({ screeningMethod: 'telepathy' }));
+    await expect(p.save()).rejects.toThrow();
+  });
+  it('REJECTS an out-of-set per-ear level', async () => {
+    const p = new AS(baseDoc({ levelRight: 'a_bit_deaf' }));
+    await expect(p.save()).rejects.toThrow(/levelRight/);
+  });
+  it('REJECTS an out-of-set tympanometry trace', async () => {
+    const p = new AS(baseDoc({ tympanometryLeft: 'Z' }));
+    await expect(p.save()).rejects.toThrow(/tympanometryLeft/);
+  });
+});
+
+describe('W722 behavioral — referral / amplification / risk gates', () => {
+  it('REJECTS outcome=refer with no referralReason', async () => {
+    const p = new AS(baseDoc({ outcome: 'refer' }));
+    await expect(p.save()).rejects.toThrow(/referralReason/);
+  });
+  it('SAVES outcome=refer WITH a reason (+needsReferral virtual)', async () => {
+    const doc = await AS.create(
+      baseDoc({ outcome: 'refer', referralReason: 'flat tymp + no OAE', referralTo: 'ENT' })
+    );
+    expect(doc.needsReferral).toBe(true);
+  });
+  it('REJECTS amplificationRecommended with no detail', async () => {
+    const p = new AS(baseDoc({ amplificationRecommended: true }));
+    await expect(p.save()).rejects.toThrow(/amplificationDetail/);
+  });
+  it('REJECTS riskIndicatorsPresent with empty indicators', async () => {
+    const p = new AS(baseDoc({ riskIndicatorsPresent: true }));
+    await expect(p.save()).rejects.toThrow(/riskIndicators/);
+  });
+  it('REJECTS an out-of-set risk indicator', async () => {
+    const p = new AS(
+      baseDoc({ riskIndicatorsPresent: true, riskIndicators: ['hates_loud_music'] })
+    );
+    await expect(p.save()).rejects.toThrow(/riskIndicators/);
+  });
+  it('SAVES risk cluster + computes riskIndicatorCount', async () => {
+    const doc = await AS.create(
+      baseDoc({
+        riskIndicatorsPresent: true,
+        riskIndicators: ['family_history_of_hearing_loss', 'frequent_ear_infections'],
+      })
+    );
+    expect(doc.riskIndicatorCount).toBe(2);
+  });
+});
+
+describe('W722 behavioral — finalize gate', () => {
+  it('REJECTS finalized without a screener', async () => {
+    const p = new AS(baseDoc({ status: 'finalized', screenedAt: new Date() }));
+    await expect(p.save()).rejects.toThrow(/screener|screenedBy/);
+  });
+  it('REJECTS finalized without screenedAt', async () => {
+    const p = new AS(baseDoc({ status: 'finalized', screenedByName: 'Dr Hana' }));
+    await expect(p.save()).rejects.toThrow(/screenedAt/);
+  });
+  it('SAVES finalized with screener + screenedAt', async () => {
+    const doc = await AS.create(
+      baseDoc({ status: 'finalized', screenedByName: 'Dr Hana', screenedAt: new Date() })
+    );
+    expect(doc.status).toBe('finalized');
+  });
+});
+
+describe('W722 behavioral — worseEarLevel virtual', () => {
+  it('picks the worse of the two measured ears', async () => {
+    const doc = await AS.create(baseDoc({ levelRight: 'mild_26_40', levelLeft: 'severe_71_90' }));
+    expect(doc.worseEarLevel).toBe('severe_71_90');
+  });
+  it('reassessmentDue before date is REJECTED', async () => {
+    const p = new AS(
+      baseDoc({ date: new Date('2026-06-01'), reassessmentDue: new Date('2026-05-01') })
+    );
+    await expect(p.save()).rejects.toThrow(/reassessmentDue/);
+  });
+});
+
+describe('W722 behavioral — indexes', () => {
+  it('compound indexes exist', async () => {
+    const indexes = await AS.collection.indexes();
+    const keys = indexes.map(i => Object.keys(i.key).join('+'));
+    expect(keys).toContain('beneficiaryId+date');
+    expect(keys).toContain('branchId+date');
+    expect(keys).toContain('outcome+date');
+    expect(keys).toContain('status+date');
+  });
+});

--- a/backend/__tests__/audiology-screening-wave722.test.js
+++ b/backend/__tests__/audiology-screening-wave722.test.js
@@ -1,0 +1,180 @@
+'use strict';
+
+/**
+ * W722 drift guard — AudiologyScreening + audiology-screening routes.
+ *
+ * Functional hearing-screening surface (sibling of VisionScreening W720 on the
+ * sensory axis). Static (source-as-text + export introspection); jest.setup
+ * mocks mongoose. Behavioral counterpart in
+ * `audiology-screening-behavioral-wave722.test.js`.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MODEL_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'models', 'AudiologyScreening.js'),
+  'utf8'
+);
+const ROUTES_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'routes', 'audiology-screening.routes.js'),
+  'utf8'
+);
+const REGISTRY_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'routes', 'registries', 'features.registry.js'),
+  'utf8'
+);
+const CANONICAL_INDEX_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'intelligence', 'canonical', 'index.js'),
+  'utf8'
+);
+
+const model = require('../models/AudiologyScreening');
+
+describe('W722 AudiologyScreening — exports & enums', () => {
+  it('exports METHODS (8 ability-graded screening methods)', () => {
+    expect(model.METHODS).toEqual([
+      'pure_tone_audiometry',
+      'play_audiometry',
+      'visual_reinforcement_audiometry',
+      'otoacoustic_emissions',
+      'auditory_brainstem_response',
+      'tympanometry_only',
+      'behavioral_observation',
+      'otoscopy_only',
+    ]);
+  });
+  it('exports HEARING_LEVELS with empty + 6 dB-HL bands + unable', () => {
+    expect(model.HEARING_LEVELS[0]).toBe('');
+    expect(model.HEARING_LEVELS).toEqual(
+      expect.arrayContaining([
+        'normal_le_25',
+        'mild_26_40',
+        'moderate_41_55',
+        'moderately_severe_56_70',
+        'severe_71_90',
+        'profound_gt_90',
+        'unable_to_assess',
+      ])
+    );
+  });
+  it('exports TYMPANOMETRY_TYPES (Jerger A/As/Ad/B/C + empty)', () => {
+    expect(model.TYMPANOMETRY_TYPES).toEqual(['', 'A', 'As', 'Ad', 'B', 'C']);
+  });
+  it('exports LOSS_TYPES + OUTCOMES + STATUSES', () => {
+    expect(model.LOSS_TYPES).toEqual(['none', 'conductive', 'sensorineural', 'mixed', 'unknown']);
+    expect(model.OUTCOMES).toEqual(['pass', 'monitor', 'refer']);
+    expect(model.STATUSES).toEqual(['draft', 'finalized']);
+  });
+  it('exports JCIH RISK_INDICATORS (multi-select cluster)', () => {
+    expect(model.RISK_INDICATORS).toEqual(
+      expect.arrayContaining([
+        'no_startle_to_loud_sound',
+        'family_history_of_hearing_loss',
+        'frequent_ear_infections',
+        'parent_caregiver_concern',
+      ])
+    );
+  });
+});
+
+describe('W722 AudiologyScreening — canonical refs', () => {
+  it('beneficiaryId refs Beneficiary', () => {
+    expect(MODEL_SRC).toMatch(/beneficiaryId\s*:\s*\{[\s\S]{0,200}ref\s*:\s*['"]Beneficiary['"]/);
+  });
+  it('branchId refs Branch', () => {
+    expect(MODEL_SRC).toMatch(/branchId\s*:\s*\{[\s\S]{0,200}ref\s*:\s*['"]Branch['"]/);
+  });
+  it('carePlanVersionId refs CarePlanVersion; screenedBy refs User', () => {
+    expect(MODEL_SRC).toMatch(
+      /carePlanVersionId\s*:\s*\{[\s\S]{0,200}ref\s*:\s*['"]CarePlanVersion['"]/
+    );
+    expect(MODEL_SRC).toMatch(/screenedBy\s*:\s*\{[\s\S]{0,160}ref\s*:\s*['"]User['"]/);
+  });
+});
+
+describe('W722 AudiologyScreening — Wave-18 invariants', () => {
+  it('declares __invariants validate', () => {
+    expect(MODEL_SRC).toMatch(/path\(['"]__invariants['"]\)\.validate/);
+  });
+  it('refer outcome requires referralReason', () => {
+    expect(MODEL_SRC).toMatch(
+      /outcome\s*===\s*['"]refer['"][\s\S]{0,200}invalidate\(['"]referralReason['"]/
+    );
+  });
+  it('amplificationRecommended requires amplificationDetail', () => {
+    expect(MODEL_SRC).toMatch(
+      /amplificationRecommended[\s\S]{0,200}invalidate\(\s*['"]amplificationDetail['"]/
+    );
+  });
+  it('riskIndicatorsPresent requires at least one riskIndicator', () => {
+    expect(MODEL_SRC).toMatch(
+      /riskIndicatorsPresent[\s\S]{0,260}invalidate\(\s*['"]riskIndicators['"]/
+    );
+  });
+  it('finalize requires screener + screenedAt', () => {
+    expect(MODEL_SRC).toMatch(/status\s*===\s*['"]finalized['"]/);
+    expect(MODEL_SRC).toMatch(/invalidate\(['"]screenedAt['"]/);
+  });
+});
+
+describe('W722 AudiologyScreening — virtuals', () => {
+  it('declares needsReferral + riskIndicatorCount + worseEarLevel', () => {
+    expect(MODEL_SRC).toMatch(/virtual\(['"]needsReferral['"]\)/);
+    expect(MODEL_SRC).toMatch(/virtual\(['"]riskIndicatorCount['"]\)/);
+    expect(MODEL_SRC).toMatch(/virtual\(['"]worseEarLevel['"]\)/);
+  });
+});
+
+describe('W722 routes — endpoint surface', () => {
+  const eps = [
+    /router\.get\(\s*['"]\/today['"]/,
+    /router\.get\(\s*['"]\/['"]/,
+    /router\.get\(\s*['"]\/needs-referral['"]/,
+    /router\.get\(\s*['"]\/due['"]/,
+    /router\.get\(\s*['"]\/by-beneficiary\/:id['"]/,
+    /router\.get\(\s*['"]\/stats['"]/,
+    /router\.get\(\s*['"]\/:id['"]/,
+    /router\.post\(\s*['"]\/['"]/,
+    /router\.post\(\s*['"]\/:id\/finalize['"]/,
+    /router\.patch\(\s*['"]\/:id['"]/,
+    /router\.delete\(\s*['"]\/:id['"]/,
+  ];
+  it('declares all 11 endpoints', () => {
+    for (const re of eps) expect(ROUTES_SRC).toMatch(re);
+  });
+  it('finalize is immutable-after (409 on re-finalize)', () => {
+    expect(ROUTES_SRC).toMatch(/سبق وأن تم اعتماده[\s\S]{0,80}|\.status\(409\)/);
+  });
+  it('branch-scoped; no req.branchId leak; ObjectId-validated', () => {
+    expect(ROUTES_SRC).toMatch(/router\.use\(requireBranchAccess\)/);
+    expect(ROUTES_SRC).toMatch(/branchFilter\(req\)/);
+    expect(ROUTES_SRC).not.toMatch(/req\.branchId/);
+    expect(ROUTES_SRC).toMatch(/mongoose\.isValidObjectId/);
+  });
+  it('finalize restricted to FINALIZE_ROLES incl. audiologist', () => {
+    expect(ROUTES_SRC).toMatch(/FINALIZE_ROLES\s*=\s*\[[\s\S]{0,200}audiologist/);
+  });
+});
+
+describe('W722 wiring — registry + canonical', () => {
+  it("loads via safeRequire('../routes/audiology-screening.routes')", () => {
+    expect(REGISTRY_SRC).toMatch(
+      /audiologyScreeningRoutes\s*=\s*safeRequire\(['"]\.\.\/routes\/audiology-screening\.routes['"]\)/
+    );
+  });
+  it('mounts at /audiology-screening via dualMountAuth', () => {
+    expect(REGISTRY_SRC).toMatch(
+      /dualMountAuth\(\s*app\s*,\s*['"]audiology-screening['"]\s*,\s*audiologyScreeningRoutes\s*,\s*authenticate\s*\)/
+    );
+  });
+  it('wave comment cites W722 + Arabic label', () => {
+    expect(REGISTRY_SRC).toMatch(/Wave 722/);
+    expect(REGISTRY_SRC).toMatch(/فحص السمع/);
+  });
+  it('canonical index registers audiology-screening schema', () => {
+    expect(CANONICAL_INDEX_SRC).toMatch(
+      /require\(['"]\.\/schemas\/audiology-screening\.canonical['"]\)/
+    );
+  });
+});

--- a/backend/__tests__/module-gap-alerts-subscriber-wave717.test.js
+++ b/backend/__tests__/module-gap-alerts-subscriber-wave717.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+/**
+ * W717 — module-gap-alerts-subscriber + sweeper→bus emit wiring.
+ *
+ * Upgrades the W695 sweepers from log-only to the real alert pipeline:
+ * sweeper emits `module_gap.<x>.overdue` → this subscriber logs + emits
+ * downstream `notification.module_gap.overdue.alert`. Mirrors the W349
+ * capa-alerts pattern.
+ *
+ *   1. static: subscriber exports + downstream-event name + bootstrap wires it
+ *   2. behavioral: drive a REAL QualityEventBus — emit a source event, flush,
+ *      assert the downstream alert fires with a normalized + severity payload
+ *
+ * No DB (the bus is pure in-memory).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SUB_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'services', 'module-gap-alerts-subscriber.service.js'),
+  'utf8'
+);
+const BOOT_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'startup', 'moduleGapSweepersBootstrap.js'),
+  'utf8'
+);
+
+const sub = require('../services/module-gap-alerts-subscriber.service');
+
+describe('W717 subscriber — shape', () => {
+  it('exports wireModuleGapAlerts + DOWNSTREAM_EVENT', () => {
+    expect(typeof sub.wireModuleGapAlerts).toBe('function');
+    expect(sub.DOWNSTREAM_EVENT).toBe('notification.module_gap.overdue.alert');
+    expect(sub.SOURCE_PATTERN).toBe('module_gap.*');
+  });
+  it('throws without a bus that has .on()', () => {
+    expect(() => sub.wireModuleGapAlerts({})).toThrow(/bus/);
+  });
+});
+
+describe('W717 bootstrap — emits + wires (read-only preserved)', () => {
+  it('resolves the QualityEventBus + wires the subscriber', () => {
+    expect(BOOT_SRC).toMatch(/qualityEventBus\.service/);
+    expect(BOOT_SRC).toMatch(/wireModuleGapAlerts/);
+  });
+  it('emits the 4 module_gap source events', () => {
+    for (const ev of [
+      'module_gap.pando_followup.overdue',
+      'module_gap.sensory_review.due',
+      'module_gap.sponsorship.expired',
+      'module_gap.vfss_pending.aging',
+    ]) {
+      expect(BOOT_SRC).toMatch(new RegExp(ev.replace(/\./g, '\\.')));
+    }
+  });
+  it('still READ-ONLY — no persistence writes added', () => {
+    expect(BOOT_SRC).not.toMatch(/\.save\(/);
+    expect(BOOT_SRC).not.toMatch(
+      /\.updateOne\(|\.updateMany\(|\.findOneAndUpdate\(|\.deleteOne\(|\.deleteMany\(|\.create\(/
+    );
+  });
+});
+
+describe('W717 subscriber — behavioral over a REAL QualityEventBus', () => {
+  let Bus;
+  beforeAll(() => {
+    // The bus module exports a class + getDefault(); use a FRESH instance so
+    // we don't pollute the singleton across tests.
+    const mod = require('../services/quality/qualityEventBus.service');
+    Bus = mod.QualityEventBus || mod.default || null;
+  });
+
+  it('source event → downstream notification.module_gap.overdue.alert (via bus.emit)', async () => {
+    const mod = require('../services/quality/qualityEventBus.service');
+    const bus =
+      typeof mod.QualityEventBus === 'function' ? new mod.QualityEventBus() : mod.getDefault();
+    const received = [];
+    bus.on('notification.module_gap.overdue.alert', payload => received.push(payload));
+
+    sub.wireModuleGapAlerts({ bus, logger: { warn() {}, error() {}, info() {} } });
+    await bus.emit('module_gap.pando_followup.overdue', {
+      kind: 'pando_followup',
+      beneficiaryId: 'b1',
+      branchId: 'br1',
+      recordId: 'o1',
+      daysOverdue: 10,
+      dueDate: '2026-05-01',
+    });
+    await bus.flush();
+
+    expect(received.length).toBe(1);
+    expect(received[0].source).toBe('module_gap.pando_followup.overdue');
+    expect(received[0].beneficiaryId).toBe('b1');
+    expect(received[0].daysOverdue).toBe(10);
+    expect(received[0].severity).toBe('warning'); // 7 <= 10 < 30
+    expect(received[0].detectedAt).toBeTruthy();
+  });
+
+  it('downstreamEmit override is used when provided + severity tiers map', async () => {
+    const mod = require('../services/quality/qualityEventBus.service');
+    const bus =
+      typeof mod.QualityEventBus === 'function' ? new mod.QualityEventBus() : mod.getDefault();
+    const out = [];
+    sub.wireModuleGapAlerts({
+      bus,
+      logger: { warn() {}, error() {}, info() {} },
+      downstreamEmit: (name, payload) => out.push({ name, payload }),
+    });
+    await bus.emit('module_gap.sponsorship.expired', { recordId: 's1', daysOverdue: 45 });
+    await bus.flush();
+    expect(out.length).toBe(1);
+    expect(out[0].name).toBe('notification.module_gap.overdue.alert');
+    expect(out[0].payload.severity).toBe('critical'); // >= 30
+  });
+
+  it('_normalizePayload defaults severity to warning when days unknown', () => {
+    const n = sub._normalizePayload('module_gap.vfss_pending.aging', { recordId: 'v1' });
+    expect(n.severity).toBe('warning');
+    expect(n.daysOverdue).toBeNull();
+  });
+});

--- a/backend/intelligence/canonical/index.js
+++ b/backend/intelligence/canonical/index.js
@@ -60,6 +60,8 @@ const ENTRIES = [
   require('./schemas/adjunct-therapy-session.canonical'),
   // W715 spasticity / botulinum-toxin injection procedure (2026-06-01):
   require('./schemas/spasticity-injection.canonical'),
+  // W722 functional hearing screening (2026-06-01):
+  require('./schemas/audiology-screening.canonical'),
 ];
 
 for (const entry of ENTRIES) registry.register(entry);

--- a/backend/intelligence/canonical/schemas/audiology-screening.canonical.js
+++ b/backend/intelligence/canonical/schemas/audiology-screening.canonical.js
@@ -1,0 +1,89 @@
+'use strict';
+/**
+ * Canonical AudiologyScreening — module: Sensory Screening.
+ *
+ * One functional hearing-screen: per-ear level estimate + tympanometry +
+ * JCIH risk cluster + outcome (pass/monitor/refer). See
+ * `backend/models/AudiologyScreening.js` (W722). Sibling of VisionScreening.
+ */
+
+const { z, ObjectIdLike, IsoDateLoose, AuditEnvelope } = require('../_primitives');
+
+const Method = z.enum([
+  'pure_tone_audiometry',
+  'play_audiometry',
+  'visual_reinforcement_audiometry',
+  'otoacoustic_emissions',
+  'auditory_brainstem_response',
+  'tympanometry_only',
+  'behavioral_observation',
+  'otoscopy_only',
+]);
+const Level = z.enum([
+  '',
+  'normal_le_25',
+  'mild_26_40',
+  'moderate_41_55',
+  'moderately_severe_56_70',
+  'severe_71_90',
+  'profound_gt_90',
+  'unable_to_assess',
+]);
+const Tymp = z.enum(['', 'A', 'As', 'Ad', 'B', 'C']);
+const LossType = z.enum(['none', 'conductive', 'sensorineural', 'mixed', 'unknown']);
+const Outcome = z.enum(['pass', 'monitor', 'refer']);
+const Status = z.enum(['draft', 'finalized']);
+
+const AudiologyScreening = z.object({
+  _id: ObjectIdLike.optional(),
+
+  beneficiaryId: ObjectIdLike,
+  branchId: ObjectIdLike.optional(),
+  sectionId: ObjectIdLike.optional(),
+  carePlanVersionId: ObjectIdLike.optional(),
+
+  date: IsoDateLoose,
+  reason: z.string().max(300).optional(),
+
+  screeningMethod: Method,
+  wearsAmplificationDuringScreen: z.boolean().optional(),
+
+  levelRight: Level.optional(),
+  levelLeft: Level.optional(),
+  tympanometryRight: Tymp.optional(),
+  tympanometryLeft: Tymp.optional(),
+  hearingLossType: LossType,
+
+  functionalDomainsIntact: z.array(z.string()).optional(),
+  riskIndicatorsPresent: z.boolean().optional(),
+  riskIndicators: z.array(z.string()).optional(),
+
+  otoscopyAbnormal: z.boolean().optional(),
+  otoscopyDetail: z.string().max(300).optional(),
+
+  outcome: Outcome,
+  referralReason: z.string().max(500).optional(),
+  referralTo: z.string().max(120).optional(),
+
+  amplificationRecommended: z.boolean().optional(),
+  amplificationDetail: z.string().max(300).optional(),
+
+  recommendations: z.string().max(1000).optional(),
+  reassessmentDue: IsoDateLoose.optional(),
+  notes: z.string().max(1000).optional(),
+
+  screenedBy: ObjectIdLike.optional(),
+  screenedByName: z.string().max(100).optional(),
+  screenedAt: IsoDateLoose.optional(),
+
+  status: Status,
+
+  ...AuditEnvelope.shape,
+});
+
+module.exports = {
+  name: 'AudiologyScreening',
+  modulePath: 'Sensory Screening',
+  mongooseModelName: 'AudiologyScreening',
+  schema: AudiologyScreening,
+};

--- a/backend/models/AudiologyScreening.js
+++ b/backend/models/AudiologyScreening.js
@@ -1,0 +1,310 @@
+'use strict';
+
+/**
+ * AudiologyScreening — W722.
+ *
+ * "فحص السمع الوظيفي / مسح السمع" — a functional-hearing screening for
+ * day-rehab beneficiaries. Hearing loss is highly prevalent and routinely
+ * under-detected in this population: ~independent or co-occurring in many
+ * children with cerebral palsy, Down syndrome (chronic otitis media → fluctuating
+ * conductive loss), autism, and NICU/TORCH histories. Undetected hearing loss
+ * silently caps EVERY language, AAC, education and behaviour goal — so a
+ * structured, longitudinal functional-hearing record is a first-class need, not
+ * a free-text note. The sibling of VisionScreening (W720) on the sensory axis.
+ *
+ * Why a dedicated model (NOT a generic assessment, NOT AssistiveDevice):
+ *   • This is a SCREEN (refer / monitor / pass), not a full diagnostic
+ *     audiology work-up — it captures functional hearing + a per-ear level
+ *     estimate + tympanometry + the behavioural risk cluster, and drives an
+ *     ENT / audiology REFERRAL.
+ *   • Level is method-dependent (pure-tone vs play/VRA for young kids vs OAE/ABR
+ *     for non-responsive vs behavioural-observation) — a generic score field
+ *     can't encode WHICH method produced the estimate.
+ *   • Tympanometry (A/As/Ad/B/C) is a distinct middle-ear measure per ear, the
+ *     key signal for the effusion that dominates this population's fluctuating loss.
+ *   • Longitudinal: post-grommets / post-amplification re-screen is the progress
+ *     marker; serial comparison needs structured persistence.
+ *
+ * Wave-18 invariants:
+ *   • screeningMethod ∈ METHODS ; outcome ∈ OUTCOMES ; hearingLossType ∈ LOSS_TYPES
+ *   • each ear's hearing level (when set) ∈ HEARING_LEVELS
+ *   • each ear's tympanometry (when set) ∈ TYMPANOMETRY_TYPES
+ *   • outcome='refer' → referralReason required (cannot refer with no reason)
+ *   • amplificationRecommended=true → amplificationDetail required
+ *   • riskIndicatorsPresent=true → at least one riskIndicator required
+ *   • status=finalized → screenedBy/Name + screenedAt required
+ *   • reassessmentDue (when set) must be ≥ date
+ */
+
+const mongoose = require('mongoose');
+
+// Screening methods — vary by the beneficiary's ability to respond.
+const METHODS = [
+  'pure_tone_audiometry', // literate / verbal, headphones + hand-raise
+  'play_audiometry', // conditioned play (toddlers)
+  'visual_reinforcement_audiometry', // VRA (infants 6–24mo)
+  'otoacoustic_emissions', // OAE (objective, cochlear)
+  'auditory_brainstem_response', // ABR / BAER (objective, non-responsive)
+  'tympanometry_only', // middle-ear screen only
+  'behavioral_observation', // functional observation, no formal audiometry
+  'otoscopy_only', // visual canal/drum inspection only
+];
+
+// Functional hearing bands per ear (dB HL estimate). '' = not measured.
+const HEARING_LEVELS = [
+  '',
+  'normal_le_25', // ≤25 dB HL
+  'mild_26_40',
+  'moderate_41_55',
+  'moderately_severe_56_70',
+  'severe_71_90',
+  'profound_gt_90', // >90 dB HL
+  'unable_to_assess',
+];
+
+// Tympanometry trace type per ear (Jerger classification). '' = not done.
+const TYMPANOMETRY_TYPES = [
+  '',
+  'A', // normal middle-ear pressure + compliance
+  'As', // shallow (stiff — otosclerosis / scarring)
+  'Ad', // deep (hypermobile — ossicular discontinuity)
+  'B', // flat (effusion / perforation / impacted cerumen)
+  'C', // negative pressure (eustachian-tube dysfunction)
+];
+
+const LOSS_TYPES = ['none', 'conductive', 'sensorineural', 'mixed', 'unknown'];
+
+const OUTCOMES = ['pass', 'monitor', 'refer'];
+
+// Behavioural / history risk indicators (JCIH-aligned) — multi-select.
+const RISK_INDICATORS = [
+  'no_startle_to_loud_sound',
+  'does_not_turn_to_voice',
+  'delayed_or_absent_speech',
+  'frequent_ear_infections', // recurrent otitis media
+  'family_history_of_hearing_loss',
+  'nicu_stay_over_5_days',
+  'torch_infection_history', // CMV/rubella/toxo etc
+  'craniofacial_anomaly',
+  'ototoxic_medication_exposure',
+  'parent_caregiver_concern',
+  'meningitis_history',
+  'speech_regression',
+];
+
+// Functional-hearing behaviours observed OK during the screen (multi-select).
+const FUNCTIONAL_DOMAINS = [
+  'responds_to_name',
+  'localizes_sound',
+  'follows_verbal_instruction',
+  'responds_to_environmental_sound',
+  'discriminates_speech_in_quiet',
+  'uses_amplification_consistently',
+];
+
+const STATUSES = ['draft', 'finalized'];
+
+const AudiologyScreeningSchema = new mongoose.Schema(
+  {
+    beneficiaryId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Beneficiary',
+      required: true,
+      index: true,
+    },
+    branchId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Branch',
+      default: null,
+      index: true,
+    },
+    sectionId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'BeneficiarySection',
+      default: null,
+    },
+    carePlanVersionId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'CarePlanVersion',
+      default: null,
+    },
+
+    date: { type: Date, required: true, index: true },
+    reason: { type: String, default: '', maxlength: 300 }, // intake / annual / concern-triggered
+
+    screeningMethod: { type: String, enum: METHODS, required: true, index: true },
+    wearsAmplificationDuringScreen: { type: Boolean, default: false }, // tested with current aids/CI?
+
+    // Per-ear functional hearing-level estimate (validated in __invariants).
+    levelRight: { type: String, default: '' },
+    levelLeft: { type: String, default: '' },
+
+    // Per-ear tympanometry trace (middle-ear status).
+    tympanometryRight: { type: String, default: '' },
+    tympanometryLeft: { type: String, default: '' },
+
+    hearingLossType: { type: String, enum: LOSS_TYPES, default: 'unknown', index: true },
+
+    // Functional hearing in daily activities (multi-select of behaviours observed OK).
+    functionalDomainsIntact: { type: [String], default: () => [] },
+
+    // Risk cluster.
+    riskIndicatorsPresent: { type: Boolean, default: false },
+    riskIndicators: { type: [String], default: () => [] },
+
+    // Quick observations.
+    otoscopyAbnormal: { type: Boolean, default: false }, // wax / inflammation / perforation seen
+    otoscopyDetail: { type: String, default: '', maxlength: 300 },
+
+    // Outcome + action.
+    outcome: { type: String, enum: OUTCOMES, default: 'monitor', index: true },
+    referralReason: { type: String, default: '', maxlength: 500 }, // required when outcome='refer'
+    referralTo: { type: String, default: '', maxlength: 120 }, // ENT / audiology / cochlear-implant program
+
+    amplificationRecommended: { type: Boolean, default: false },
+    amplificationDetail: { type: String, default: '', maxlength: 300 }, // hearing aid / CI candidacy / FM system
+
+    recommendations: { type: String, default: '', maxlength: 1000 }, // classroom/therapy adaptations
+    reassessmentDue: { type: Date, default: null },
+
+    notes: { type: String, default: '', maxlength: 1000 },
+
+    screenedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+    screenedByName: { type: String, default: '', maxlength: 100 },
+    screenedAt: { type: Date, default: null },
+
+    status: { type: String, enum: STATUSES, default: 'draft', index: true },
+  },
+  { timestamps: true, collection: 'audiology_screenings' }
+);
+
+AudiologyScreeningSchema.index({ beneficiaryId: 1, date: -1 });
+AudiologyScreeningSchema.index({ branchId: 1, date: -1 });
+AudiologyScreeningSchema.index({ outcome: 1, date: -1 });
+AudiologyScreeningSchema.index({ status: 1, date: -1 });
+
+AudiologyScreeningSchema.add({
+  __invariants: { type: mongoose.Schema.Types.Mixed, select: false, default: null },
+});
+
+AudiologyScreeningSchema.path('__invariants').validate(function () {
+  let ok = true;
+  if (!METHODS.includes(this.screeningMethod)) {
+    this.invalidate('screeningMethod', `must be one of ${METHODS.join(',')}`);
+    ok = false;
+  }
+  if (!OUTCOMES.includes(this.outcome)) {
+    this.invalidate('outcome', `must be one of ${OUTCOMES.join(',')}`);
+    ok = false;
+  }
+  if (!LOSS_TYPES.includes(this.hearingLossType)) {
+    this.invalidate('hearingLossType', `must be one of ${LOSS_TYPES.join(',')}`);
+    ok = false;
+  }
+  // Per-ear hearing-level value-set (empty = not measured = allowed).
+  for (const [field, val] of [
+    ['levelRight', this.levelRight],
+    ['levelLeft', this.levelLeft],
+  ]) {
+    if (val && !HEARING_LEVELS.includes(val)) {
+      this.invalidate(field, `${field} must be one of ${HEARING_LEVELS.filter(Boolean).join(',')}`);
+      ok = false;
+    }
+  }
+  // Per-ear tympanometry value-set.
+  for (const [field, val] of [
+    ['tympanometryRight', this.tympanometryRight],
+    ['tympanometryLeft', this.tympanometryLeft],
+  ]) {
+    if (val && !TYMPANOMETRY_TYPES.includes(val)) {
+      this.invalidate(
+        field,
+        `${field} must be one of ${TYMPANOMETRY_TYPES.filter(Boolean).join(',')}`
+      );
+      ok = false;
+    }
+  }
+  // Risk-indicator value-set.
+  for (const s of this.riskIndicators || []) {
+    if (!RISK_INDICATORS.includes(s)) {
+      this.invalidate('riskIndicators', `invalid risk indicator: ${s}`);
+      ok = false;
+      break;
+    }
+  }
+  // A referral must carry a reason — no silent "refer".
+  if (this.outcome === 'refer' && !String(this.referralReason || '').trim()) {
+    this.invalidate('referralReason', 'referralReason required when outcome=refer');
+    ok = false;
+  }
+  // Amplification recommendation must say what.
+  if (this.amplificationRecommended && !String(this.amplificationDetail || '').trim()) {
+    this.invalidate(
+      'amplificationDetail',
+      'amplificationDetail required when amplificationRecommended=true'
+    );
+    ok = false;
+  }
+  // A risk flag must be evidenced by at least one indicator.
+  if (
+    this.riskIndicatorsPresent &&
+    (!Array.isArray(this.riskIndicators) || this.riskIndicators.length === 0)
+  ) {
+    this.invalidate(
+      'riskIndicators',
+      'at least one riskIndicator required when riskIndicatorsPresent=true'
+    );
+    ok = false;
+  }
+  if (this.reassessmentDue && this.date && this.reassessmentDue < this.date) {
+    this.invalidate('reassessmentDue', 'reassessmentDue must be >= screening date');
+    ok = false;
+  }
+  if (this.status === 'finalized') {
+    if (!this.screenedBy && !String(this.screenedByName || '').trim()) {
+      this.invalidate('screenedBy', 'screener required to finalize');
+      ok = false;
+    }
+    if (!this.screenedAt) {
+      this.invalidate('screenedAt', 'screenedAt required to finalize');
+      ok = false;
+    }
+  }
+  return ok;
+});
+
+/** True when the screen should drive an external referral (hearing at risk). */
+AudiologyScreeningSchema.virtual('needsReferral').get(function () {
+  return this.outcome === 'refer';
+});
+
+/** Count of risk indicators present — quick severity signal. */
+AudiologyScreeningSchema.virtual('riskIndicatorCount').get(function () {
+  return Array.isArray(this.riskIndicators) ? this.riskIndicators.length : 0;
+});
+
+/** Worse of the two ears' measured levels — null when neither measured. */
+AudiologyScreeningSchema.virtual('worseEarLevel').get(function () {
+  const order = HEARING_LEVELS.filter(Boolean);
+  const r = order.indexOf(this.levelRight);
+  const l = order.indexOf(this.levelLeft);
+  const measured = [r, l].filter(i => i >= 0);
+  if (!measured.length) return null;
+  return order[Math.max(...measured)];
+});
+
+AudiologyScreeningSchema.set('toJSON', { virtuals: true });
+AudiologyScreeningSchema.set('toObject', { virtuals: true });
+
+module.exports =
+  mongoose.models.AudiologyScreening ||
+  mongoose.model('AudiologyScreening', AudiologyScreeningSchema);
+
+module.exports.METHODS = METHODS;
+module.exports.HEARING_LEVELS = HEARING_LEVELS;
+module.exports.TYMPANOMETRY_TYPES = TYMPANOMETRY_TYPES;
+module.exports.LOSS_TYPES = LOSS_TYPES;
+module.exports.OUTCOMES = OUTCOMES;
+module.exports.RISK_INDICATORS = RISK_INDICATORS;
+module.exports.FUNCTIONAL_DOMAINS = FUNCTIONAL_DOMAINS;
+module.exports.STATUSES = STATUSES;

--- a/backend/routes/audiology-screening.routes.js
+++ b/backend/routes/audiology-screening.routes.js
@@ -1,0 +1,470 @@
+'use strict';
+
+/**
+ * audiology-screening.routes.js — W722.
+ *
+ * Functional hearing-screening admin surface. Mounted via dualMountAuth at
+ * /api/(v1/)?audiology-screening. Sibling of vision-screening (W720) on the
+ * sensory-screening axis.
+ *
+ * Endpoints:
+ *   GET    /today                  — today's screenings (branch filter)
+ *   GET    /                       — list w/ filters (paginated)
+ *   GET    /needs-referral         — outcome=refer board (branch)
+ *   GET    /due                    — reassessments due (branch)
+ *   GET    /by-beneficiary/:id     — per-kid history (last 100) + first/latest pair
+ *   GET    /stats                  — method + outcome + loss-type distribution
+ *   GET    /:id
+ *   POST   /                       — record screening (draft)
+ *   POST   /:id/finalize           — finalize (immutable after)
+ *   PATCH  /:id                    — correct (only while status=draft)
+ *   DELETE /:id                    — admin-only
+ */
+
+const express = require('express');
+const router = express.Router();
+const mongoose = require('mongoose');
+const { authenticateToken, requireRole } = require('../middleware/auth');
+
+const AudiologyScreening = require('../models/AudiologyScreening');
+const Beneficiary = require('../models/Beneficiary');
+const safeError = require('../utils/safeError');
+const { requireBranchAccess, branchFilter } = require('../middleware/branchScope.middleware');
+const { bodyScopedBeneficiaryGuard } = require('../middleware/assertBranchMatch');
+
+router.use(authenticateToken);
+router.use(requireBranchAccess); // W445
+router.use(bodyScopedBeneficiaryGuard); // W441
+
+const READ_ROLES = [
+  'admin',
+  'superadmin',
+  'super_admin',
+  'manager',
+  'clinical_supervisor',
+  'therapist',
+  'speech_language_pathologist',
+  'audiologist',
+  'teacher',
+  'nurse',
+  'quality',
+];
+const WRITE_ROLES = [
+  'admin',
+  'superadmin',
+  'super_admin',
+  'manager',
+  'clinical_supervisor',
+  'therapist',
+  'speech_language_pathologist',
+  'audiologist',
+  'nurse',
+];
+const FINALIZE_ROLES = [
+  'admin',
+  'superadmin',
+  'super_admin',
+  'manager',
+  'clinical_supervisor',
+  'audiologist',
+];
+const DELETE_ROLES = ['admin', 'superadmin', 'super_admin'];
+
+const {
+  METHODS,
+  HEARING_LEVELS,
+  TYMPANOMETRY_TYPES,
+  LOSS_TYPES,
+  OUTCOMES,
+  RISK_INDICATORS,
+  FUNCTIONAL_DOMAINS,
+} = AudiologyScreening;
+
+function startOfDay(d) {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+function endOfDay(d) {
+  const x = new Date(d);
+  x.setHours(23, 59, 59, 999);
+  return x;
+}
+
+async function hydrate(items) {
+  const ids = [...new Set(items.map(r => String(r.beneficiaryId)).filter(Boolean))].filter(id =>
+    mongoose.isValidObjectId(id)
+  );
+  const benefs = ids.length
+    ? await Beneficiary.find({ _id: { $in: ids } })
+        .select('firstName_ar lastName_ar beneficiaryNumber')
+        .lean()
+    : [];
+  const map = new Map(benefs.map(b => [String(b._id), b]));
+  return items.map(r => ({ ...r, beneficiary: map.get(String(r.beneficiaryId)) || null }));
+}
+
+function sanitizeEnumList(raw, allowed, max) {
+  if (!Array.isArray(raw)) return [];
+  return [...new Set(raw.map(String))].filter(v => allowed.includes(v)).slice(0, max);
+}
+
+// ── GET /today ──────────────────────────────────────────────────────────
+router.get('/today', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const d = req.query.date ? new Date(req.query.date) : new Date();
+    const filter = {
+      ...branchFilter(req), // W445
+      date: { $gte: startOfDay(d), $lte: endOfDay(d) },
+    };
+    if (req.query.branchId && mongoose.isValidObjectId(req.query.branchId)) {
+      filter.branchId = req.query.branchId;
+    }
+    const raw = await AudiologyScreening.find(filter).sort({ date: -1 }).lean();
+    const items = await hydrate(raw);
+    res.json({ success: true, items, count: items.length, date: startOfDay(d) });
+  } catch (err) {
+    return safeError(res, err, 'audiology.today');
+  }
+});
+
+// ── GET / ────────────────────────────────────────────────────────────────
+router.get('/', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const filter = { ...branchFilter(req) }; /* W445 */
+    if (req.query.beneficiaryId && mongoose.isValidObjectId(req.query.beneficiaryId)) {
+      filter.beneficiaryId = req.query.beneficiaryId;
+    }
+    if (req.query.branchId && mongoose.isValidObjectId(req.query.branchId)) {
+      filter.branchId = req.query.branchId;
+    }
+    if (req.query.screeningMethod && METHODS.includes(String(req.query.screeningMethod))) {
+      filter.screeningMethod = String(req.query.screeningMethod);
+    }
+    if (req.query.outcome && OUTCOMES.includes(String(req.query.outcome))) {
+      filter.outcome = String(req.query.outcome);
+    }
+    if (req.query.hearingLossType && LOSS_TYPES.includes(String(req.query.hearingLossType))) {
+      filter.hearingLossType = String(req.query.hearingLossType);
+    }
+    if (req.query.status && ['draft', 'finalized'].includes(String(req.query.status))) {
+      filter.status = String(req.query.status);
+    }
+    if (req.query.from || req.query.to) {
+      filter.date = {};
+      if (req.query.from) filter.date.$gte = startOfDay(new Date(req.query.from));
+      if (req.query.to) filter.date.$lte = endOfDay(new Date(req.query.to));
+    }
+    const p = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const l = Math.min(200, Math.max(1, parseInt(req.query.limit, 10) || 50));
+    const [raw, total] = await Promise.all([
+      AudiologyScreening.find(filter)
+        .sort({ date: -1 })
+        .skip((p - 1) * l)
+        .limit(l)
+        .lean(),
+      AudiologyScreening.countDocuments(filter),
+    ]);
+    const items = await hydrate(raw);
+    res.json({
+      success: true,
+      items,
+      pagination: { page: p, limit: l, total, pages: Math.ceil(total / l) },
+    });
+  } catch (err) {
+    return safeError(res, err, 'audiology.list');
+  }
+});
+
+// ── GET /needs-referral — outcome=refer board ─────────────────────────────
+router.get('/needs-referral', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const filter = {
+      ...branchFilter(req), // W445
+      outcome: 'refer',
+    };
+    if (req.query.branchId && mongoose.isValidObjectId(req.query.branchId)) {
+      filter.branchId = req.query.branchId;
+    }
+    const raw = await AudiologyScreening.find(filter).sort({ date: -1 }).limit(300).lean();
+    const items = await hydrate(raw);
+    res.json({ success: true, items, count: items.length });
+  } catch (err) {
+    return safeError(res, err, 'audiology.needsReferral');
+  }
+});
+
+// ── GET /due — reassessments due across the branch ───────────────────────
+router.get('/due', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const by = req.query.by ? endOfDay(new Date(req.query.by)) : endOfDay(new Date());
+    const filter = {
+      ...branchFilter(req), // W445
+      reassessmentDue: { $ne: null, $lte: by },
+    };
+    if (req.query.branchId && mongoose.isValidObjectId(req.query.branchId)) {
+      filter.branchId = req.query.branchId;
+    }
+    const raw = await AudiologyScreening.find(filter)
+      .sort({ reassessmentDue: 1 })
+      .limit(300)
+      .lean();
+    const items = await hydrate(raw);
+    res.json({ success: true, items, count: items.length });
+  } catch (err) {
+    return safeError(res, err, 'audiology.due');
+  }
+});
+
+// ── GET /by-beneficiary/:id ──────────────────────────────────────────────
+router.get('/by-beneficiary/:id', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
+    }
+    const items = await AudiologyScreening.find({
+      ...branchFilter(req),
+      /* W445 */ beneficiaryId: req.params.id,
+    })
+      .sort({ date: -1 })
+      .limit(100)
+      .lean();
+    const first = [...items].reverse()[0] || null;
+    const latest = items.find(r => r.status === 'finalized') || items[0] || null;
+    res.json({
+      success: true,
+      items,
+      count: items.length,
+      first: first ? { id: first._id, date: first.date, outcome: first.outcome } : null,
+      latest: latest ? { id: latest._id, date: latest.date, outcome: latest.outcome } : null,
+    });
+  } catch (err) {
+    return safeError(res, err, 'audiology.byBeneficiary');
+  }
+});
+
+// ── GET /stats ───────────────────────────────────────────────────────────
+router.get('/stats', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const from = req.query.from
+      ? startOfDay(new Date(req.query.from))
+      : startOfDay(new Date(Date.now() - 365 * 24 * 60 * 60 * 1000));
+    const to = req.query.to ? endOfDay(new Date(req.query.to)) : endOfDay(new Date());
+    const filter = {
+      ...branchFilter(req), // W445
+      date: { $gte: from, $lte: to },
+    };
+    if (req.query.branchId && mongoose.isValidObjectId(req.query.branchId)) {
+      filter.branchId = req.query.branchId;
+    }
+    if (req.query.beneficiaryId && mongoose.isValidObjectId(req.query.beneficiaryId)) {
+      filter.beneficiaryId = req.query.beneficiaryId;
+    }
+    const raw = await AudiologyScreening.find(filter)
+      .select(
+        'screeningMethod outcome hearingLossType amplificationRecommended riskIndicatorsPresent'
+      )
+      .lean();
+    const byMethod = METHODS.reduce((acc, m) => ((acc[m] = 0), acc), {});
+    const byOutcome = OUTCOMES.reduce((acc, o) => ((acc[o] = 0), acc), {});
+    const byLossType = LOSS_TYPES.reduce((acc, t) => ((acc[t] = 0), acc), {});
+    let amplification = 0;
+    let atRisk = 0;
+    for (const r of raw) {
+      if (r.screeningMethod) byMethod[r.screeningMethod] = (byMethod[r.screeningMethod] || 0) + 1;
+      if (r.outcome) byOutcome[r.outcome] = (byOutcome[r.outcome] || 0) + 1;
+      if (r.hearingLossType)
+        byLossType[r.hearingLossType] = (byLossType[r.hearingLossType] || 0) + 1;
+      if (r.amplificationRecommended) amplification++;
+      if (r.riskIndicatorsPresent) atRisk++;
+    }
+    res.json({
+      success: true,
+      from,
+      to,
+      total: raw.length,
+      byMethod,
+      byOutcome,
+      byLossType,
+      amplificationRecommended: amplification,
+      riskIndicatorsPresent: atRisk,
+    });
+  } catch (err) {
+    return safeError(res, err, 'audiology.stats');
+  }
+});
+
+// ── GET /:id ─────────────────────────────────────────────────────────────
+router.get('/:id', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
+    }
+    const row = await AudiologyScreening.findOne({
+      _id: req.params.id,
+      ...branchFilter(req),
+    }).lean(); /* W445 */
+    if (!row) return res.status(404).json({ success: false, message: 'السجل غير موجود' });
+    const [hydrated] = await hydrate([row]);
+    res.json({ success: true, data: hydrated });
+  } catch (err) {
+    return safeError(res, err, 'audiology.get');
+  }
+});
+
+// ── POST / — record screening (draft) ─────────────────────────────────────
+router.post('/', requireRole(WRITE_ROLES), async (req, res) => {
+  try {
+    const body = req.body || {};
+    if (!body.beneficiaryId || !mongoose.isValidObjectId(body.beneficiaryId)) {
+      return res.status(400).json({ success: false, message: 'beneficiaryId مطلوب' });
+    }
+    if (!METHODS.includes(String(body.screeningMethod))) {
+      return res
+        .status(400)
+        .json({ success: false, message: `أداة الفحص يجب أن تكون: ${METHODS.join(' | ')}` });
+    }
+    const date = body.date ? new Date(body.date) : new Date();
+    const level = v => (HEARING_LEVELS.includes(String(v)) ? String(v) : '');
+    const tymp = v => (TYMPANOMETRY_TYPES.includes(String(v)) ? String(v) : '');
+
+    const doc = await AudiologyScreening.create({
+      beneficiaryId: body.beneficiaryId,
+      branchId: body.branchId && mongoose.isValidObjectId(body.branchId) ? body.branchId : null,
+      sectionId: body.sectionId && mongoose.isValidObjectId(body.sectionId) ? body.sectionId : null,
+      carePlanVersionId:
+        body.carePlanVersionId && mongoose.isValidObjectId(body.carePlanVersionId)
+          ? body.carePlanVersionId
+          : null,
+      date: startOfDay(date),
+      reason: String(body.reason || '').slice(0, 300),
+      screeningMethod: String(body.screeningMethod),
+      wearsAmplificationDuringScreen: !!body.wearsAmplificationDuringScreen,
+      levelRight: level(body.levelRight),
+      levelLeft: level(body.levelLeft),
+      tympanometryRight: tymp(body.tympanometryRight),
+      tympanometryLeft: tymp(body.tympanometryLeft),
+      hearingLossType: LOSS_TYPES.includes(String(body.hearingLossType))
+        ? String(body.hearingLossType)
+        : 'unknown',
+      functionalDomainsIntact: sanitizeEnumList(
+        body.functionalDomainsIntact,
+        FUNCTIONAL_DOMAINS,
+        8
+      ),
+      riskIndicatorsPresent: !!body.riskIndicatorsPresent,
+      riskIndicators: sanitizeEnumList(body.riskIndicators, RISK_INDICATORS, 14),
+      otoscopyAbnormal: !!body.otoscopyAbnormal,
+      otoscopyDetail: String(body.otoscopyDetail || '').slice(0, 300),
+      outcome: OUTCOMES.includes(String(body.outcome)) ? String(body.outcome) : 'monitor',
+      referralReason: String(body.referralReason || '').slice(0, 500),
+      referralTo: String(body.referralTo || '').slice(0, 120),
+      amplificationRecommended: !!body.amplificationRecommended,
+      amplificationDetail: String(body.amplificationDetail || '').slice(0, 300),
+      recommendations: String(body.recommendations || '').slice(0, 1000),
+      reassessmentDue: body.reassessmentDue ? new Date(body.reassessmentDue) : null,
+      notes: String(body.notes || '').slice(0, 1000),
+      status: 'draft',
+    });
+    res.status(201).json({ success: true, data: doc });
+  } catch (err) {
+    return safeError(res, err, 'audiology.create');
+  }
+});
+
+// ── POST /:id/finalize ────────────────────────────────────────────────────
+router.post('/:id/finalize', requireRole(FINALIZE_ROLES), async (req, res) => {
+  try {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
+    }
+    const row = await AudiologyScreening.findOne({
+      _id: req.params.id,
+      ...branchFilter(req),
+    }); /* W445 */
+    if (!row) return res.status(404).json({ success: false, message: 'السجل غير موجود' });
+    if (row.status === 'finalized') {
+      return res.status(409).json({ success: false, message: 'الفحص سبق وأن تم اعتماده' });
+    }
+    row.screenedBy = req.user?.id || null;
+    row.screenedByName = req.user?.name || String(req.body?.screenerName || '').slice(0, 100);
+    row.screenedAt = new Date();
+    row.status = 'finalized';
+    await row.save(); // __invariants enforce refer⇒reason, amplification⇒detail, risk⇒indicators
+    res.json({ success: true, data: row });
+  } catch (err) {
+    return safeError(res, err, 'audiology.finalize');
+  }
+});
+
+// ── PATCH /:id — correct while still 'draft' ─────────────────────────────
+router.patch('/:id', requireRole(WRITE_ROLES), async (req, res) => {
+  try {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
+    }
+    const row = await AudiologyScreening.findOne({
+      _id: req.params.id,
+      ...branchFilter(req),
+    }); /* W445 */
+    if (!row) return res.status(404).json({ success: false, message: 'السجل غير موجود' });
+    if (row.status === 'finalized') {
+      return res.status(409).json({ success: false, message: 'لا يمكن تعديل فحص تم اعتماده' });
+    }
+    if ('functionalDomainsIntact' in req.body)
+      row.functionalDomainsIntact = sanitizeEnumList(
+        req.body.functionalDomainsIntact,
+        FUNCTIONAL_DOMAINS,
+        8
+      );
+    if ('riskIndicators' in req.body)
+      row.riskIndicators = sanitizeEnumList(req.body.riskIndicators, RISK_INDICATORS, 14);
+    const editable = [
+      'reason',
+      'screeningMethod',
+      'wearsAmplificationDuringScreen',
+      'levelRight',
+      'levelLeft',
+      'tympanometryRight',
+      'tympanometryLeft',
+      'hearingLossType',
+      'riskIndicatorsPresent',
+      'otoscopyAbnormal',
+      'otoscopyDetail',
+      'outcome',
+      'referralReason',
+      'referralTo',
+      'amplificationRecommended',
+      'amplificationDetail',
+      'recommendations',
+      'reassessmentDue',
+      'notes',
+    ];
+    for (const k of editable) {
+      if (k in req.body) row[k] = req.body[k];
+    }
+    await row.save();
+    res.json({ success: true, data: row });
+  } catch (err) {
+    return safeError(res, err, 'audiology.patch');
+  }
+});
+
+// ── DELETE /:id — admin-only ─────────────────────────────────────────────
+router.delete('/:id', requireRole(DELETE_ROLES), async (req, res) => {
+  try {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
+    }
+    const row = await AudiologyScreening.findOneAndDelete({
+      _id: req.params.id,
+      ...branchFilter(req),
+    }); /* W445 */
+    if (!row) return res.status(404).json({ success: false, message: 'السجل غير موجود' });
+    res.json({ success: true, deleted: true, id: req.params.id });
+  } catch (err) {
+    return safeError(res, err, 'audiology.delete');
+  }
+});
+
+module.exports = router;

--- a/backend/routes/registries/features.registry.js
+++ b/backend/routes/registries/features.registry.js
@@ -67,6 +67,7 @@ module.exports = function registerFeatureRoutes(
   const adjunctTherapyRoutes = safeRequire('../routes/adjunct-therapy.routes');
   const therapyActivityRoutes = safeRequire('../routes/therapy-activity.routes');
   const spasticityInjectionRoutes = safeRequire('../routes/spasticity-injection.routes');
+  const audiologyScreeningRoutes = safeRequire('../routes/audiology-screening.routes');
   const digitalAssessmentRoutes = safeRequire('../routes/digital-assessment.routes');
   const measureRecommendationRoutes = safeRequire('../routes/measure-recommendations.routes');
   const measuresAnalyzeRoutes = safeRequire('../routes/measures-analyze.routes');
@@ -210,6 +211,10 @@ module.exports = function registerFeatureRoutes(
   // per-muscle injection map + MAS + consent gate + reassessment clock. Procedure record,
   // distinct from the PhysiotherapyAssessment (W670) spasticity FIELD.
   dualMountAuth(app, 'spasticity-injection', spasticityInjectionRoutes, authenticate);
+  // Wave 722: Functional hearing-screening (فحص السمع الوظيفي) — per-ear level estimate +
+  // tympanometry + JCIH risk cluster → ENT/audiology referral. Sibling of vision-screening
+  // (W720) on the sensory-screening axis; SCREEN, not a diagnostic audiology work-up.
+  dualMountAuth(app, 'audiology-screening', audiologyScreeningRoutes, authenticate);
   // Wave 557: Digital standardized-assessment administration (التطبيق الرقمي للمقاييس).
   // Item-bank-driven administration (M-CHAT-R/CARS-2/PedsQL — W553–W556) → auto-score via
   // the W212 registry → persist a MeasureApplication so it flows into outcome rollups, goal

--- a/backend/services/module-gap-alerts-subscriber.service.js
+++ b/backend/services/module-gap-alerts-subscriber.service.js
@@ -1,0 +1,87 @@
+'use strict';
+
+/**
+ * module-gap-alerts-subscriber.service.js — Wave 717.
+ *
+ * Bus subscriber that turns the W695 module-gap sweeper events into the
+ * notification-fan-out seam. Mirrors the W349 capa-alerts-subscriber pattern
+ * exactly: subscribe on the QualityEventBus, log a structured WARN, and emit
+ * a downstream `notification.module_gap.overdue.alert` event that the
+ * notification channels (in-app/email/SMS) consume — without coupling the
+ * sweepers to notification internals.
+ *
+ * Upgrades the W695 sweepers from log-ONLY to a real alert pipeline:
+ *   sweeper → emit `module_gap.<x>.overdue` → THIS subscriber →
+ *   emit `notification.module_gap.overdue.alert` → channel subscribers.
+ *
+ * Public surface:
+ *   wireModuleGapAlerts({ bus, logger, downstreamEmit })
+ *     - bus: QualityEventBus instance (from getDefault())
+ *     - logger: structured logger
+ *     - downstreamEmit?: optional alternate emitter (defaults to the bus)
+ *   Returns { unsubscribe, downstreamEvent }.
+ *
+ * Subscribes ONCE on the `module_gap.*` wildcard. Per-event try/catch so a
+ * thrown downstream listener can never break the bus. Persists nothing (the
+ * bus ring-buffer + the log line are the audit trail) — read-only, same as
+ * the sweepers it serves (W364 invariant).
+ */
+
+const DOWNSTREAM_EVENT = 'notification.module_gap.overdue.alert';
+const SOURCE_PATTERN = 'module_gap.*';
+
+function _severityForDays(days) {
+  if (!Number.isFinite(days)) return 'warning';
+  if (days >= 30) return 'critical';
+  if (days >= 7) return 'warning';
+  return 'info';
+}
+
+function _normalizePayload(sourceEvent, payload = {}) {
+  return {
+    source: sourceEvent,
+    kind: payload.kind ?? sourceEvent,
+    beneficiaryId: payload.beneficiaryId ?? null,
+    branchId: payload.branchId ?? null,
+    recordId: payload.recordId ?? null,
+    daysOverdue: Number.isFinite(payload.daysOverdue) ? payload.daysOverdue : null,
+    dueDate: payload.dueDate ?? null,
+    detail: payload.detail ?? null,
+    severity: _severityForDays(payload.daysOverdue),
+    detectedAt: new Date().toISOString(),
+  };
+}
+
+function wireModuleGapAlerts({ bus, logger = console, downstreamEmit = null } = {}) {
+  if (!bus || typeof bus.on !== 'function') {
+    throw new Error('wireModuleGapAlerts: bus with .on(pattern, fn) required');
+  }
+  const emit =
+    typeof downstreamEmit === 'function'
+      ? downstreamEmit
+      : typeof bus.emit === 'function'
+        ? (name, payload) => bus.emit(name, payload)
+        : null;
+
+  const unsubscribe = bus.on(SOURCE_PATTERN, async (payload, eventName) => {
+    // The QualityEventBus invokes listeners as (name, payload); guard both.
+    const src = typeof payload === 'string' ? payload : eventName;
+    const data = typeof payload === 'string' ? {} : payload || {};
+    const normalized = _normalizePayload(src || SOURCE_PATTERN, data);
+    logger.warn?.(
+      `[module-gap-alerts] ${normalized.source} beneficiary=${normalized.beneficiaryId ?? '?'} ` +
+        `record=${normalized.recordId ?? '?'} daysOverdue=${normalized.daysOverdue ?? '?'} ` +
+        `severity=${normalized.severity} branch=${normalized.branchId ?? '?'}`
+    );
+    if (!emit) return;
+    try {
+      await emit(DOWNSTREAM_EVENT, normalized);
+    } catch (err) {
+      logger.error?.(`[module-gap-alerts] downstream emit failed: ${err.message}`);
+    }
+  });
+
+  return { unsubscribe, downstreamEvent: DOWNSTREAM_EVENT, sourcePattern: SOURCE_PATTERN };
+}
+
+module.exports = { wireModuleGapAlerts, DOWNSTREAM_EVENT, SOURCE_PATTERN, _normalizePayload };

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -503,3 +503,6 @@ __tests__/scoring-mental-health-pain-wave706.test.js
 __tests__/scoring-mobility-caregiver-wave708.test.js
 __tests__/scoring-neuro-disability-wave721.test.js
 __tests__/tenant-routes-wiring-wave721.test.js
+__tests__/audiology-screening-api-wave722.test.js
+__tests__/audiology-screening-behavioral-wave722.test.js
+__tests__/audiology-screening-wave722.test.js

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -314,6 +314,7 @@ __tests__/medication-administration-record-behavioral-wave191b.test.js
 __tests__/meeting-branch-tenancy-wave635.test.js
 __tests__/messaging-threads-real-impl-wave276c.test.js
 __tests__/models-use-defensive-guard-wave411.test.js
+__tests__/module-gap-alerts-subscriber-wave717.test.js
 __tests__/module-gap-sweepers-wave695.test.js
 __tests__/money-lib-wave579.test.js
 __tests__/mudad-wps-bootstrap-wave282b.test.js

--- a/backend/startup/moduleGapSweepersBootstrap.js
+++ b/backend/startup/moduleGapSweepersBootstrap.js
@@ -11,8 +11,12 @@
  *
  * W364 INVARIANT preserved: these sweepers are READ-ONLY (log/observe only) —
  * zero state mutation (no persistence writes). A drift guard (W695 test)
- * asserts no mutation creeps in. Wiring an alert/notification channel is later;
- * for now they emit structured `logger.warn` lines a log-drain can alert on.
+ * asserts no mutation creeps in. W717: in addition to the structured
+ * `logger.warn` lines, each sweep now EMITS a `module_gap.<x>.overdue` event on
+ * the QualityEventBus → module-gap-alerts-subscriber → downstream
+ * `notification.module_gap.overdue.alert` (consumed by the notification
+ * channels). Emitting an event is not a persistence write — the read-only
+ * invariant still holds. Bus is optional; absent → log-only (original W695).
  *
  * Sweepers (all default OFF):
  *   ENABLE_PANDO_FOLLOWUP_SWEEPER       — P&O orders past followUpDueDate
@@ -52,6 +56,35 @@ function wireModuleGapSweepers(app, deps = {}) {
 
   let scheduled = 0;
 
+  // W717: resolve the QualityEventBus once + wire the alerts subscriber so each
+  // sweep raises a real `notification.module_gap.overdue.alert` (consumed by the
+  // notification channels), not just a log line. Bus is optional — if absent the
+  // sweepers degrade to log-only (their original W695 behaviour). Emitting a bus
+  // event is NOT a persistence write, so the W695 read-only invariant holds.
+  const busModule = loadOptional('../services/quality/qualityEventBus.service');
+  const bus =
+    busModule && typeof busModule.getDefault === 'function' ? busModule.getDefault() : null;
+  if (bus) {
+    try {
+      const { wireModuleGapAlerts } = require('../services/module-gap-alerts-subscriber.service');
+      const wired = wireModuleGapAlerts({ bus, logger });
+      logger.info?.(`[startup] W717 module-gap alerts subscriber wired → ${wired.downstreamEvent}`);
+    } catch (err) {
+      logger.warn?.(`[startup] W717 module-gap alerts subscriber failed: ${err.message}`);
+    }
+  }
+  const daysSince = d => Math.floor((Date.now() - new Date(d).getTime()) / DAY_MS);
+  async function emitOverdue(eventName, items, mapFn) {
+    if (!bus || typeof bus.emit !== 'function') return;
+    for (const it of items.slice(0, 100)) {
+      try {
+        await bus.emit(eventName, mapFn(it));
+      } catch {
+        /* bus self-guards each listener; never let alerting break the sweep */
+      }
+    }
+  }
+
   // ── P&O overdue follow-ups (W680) ──────────────────────────────────────
   if (process.env.ENABLE_PANDO_FOLLOWUP_SWEEPER === 'true') {
     cron.schedule(
@@ -73,6 +106,15 @@ function wireModuleGapSweepers(app, deps = {}) {
               `[W695 pando-followup] order=${o._id} beneficiary=${o.beneficiaryId} category=${o.deviceCategory} due=${o.followUpDueDate}`
             );
           }
+          await emitOverdue('module_gap.pando_followup.overdue', overdue, o => ({
+            kind: 'pando_followup',
+            beneficiaryId: o.beneficiaryId ? String(o.beneficiaryId) : null,
+            branchId: o.branchId ? String(o.branchId) : null,
+            recordId: String(o._id),
+            dueDate: o.followUpDueDate,
+            daysOverdue: daysSince(o.followUpDueDate),
+            detail: o.deviceCategory,
+          }));
         } catch (err) {
           logger.error?.('[W695 pando-followup] sweep failed', err);
         }
@@ -104,6 +146,15 @@ function wireModuleGapSweepers(app, deps = {}) {
               `[W695 sensory-review] program=${d._id} beneficiary=${d.beneficiaryId} reviewDate=${d.reviewDate}`
             );
           }
+          await emitOverdue('module_gap.sensory_review.due', due, d => ({
+            kind: 'sensory_review',
+            beneficiaryId: d.beneficiaryId ? String(d.beneficiaryId) : null,
+            branchId: d.branchId ? String(d.branchId) : null,
+            recordId: String(d._id),
+            dueDate: d.reviewDate,
+            daysOverdue: daysSince(d.reviewDate),
+            detail: 'sensory_diet_review',
+          }));
         } catch (err) {
           logger.error?.('[W695 sensory-review] sweep failed', err);
         }
@@ -137,6 +188,15 @@ function wireModuleGapSweepers(app, deps = {}) {
               `[W695 sponsorship-expiry] sponsorship=${s._id} donor=${s.donorId} beneficiary=${s.beneficiaryId} endDate=${s.endDate}`
             );
           }
+          await emitOverdue('module_gap.sponsorship.expired', expired, s => ({
+            kind: 'sponsorship_expired',
+            beneficiaryId: s.beneficiaryId ? String(s.beneficiaryId) : null,
+            branchId: s.branchId ? String(s.branchId) : null,
+            recordId: String(s._id),
+            dueDate: s.endDate,
+            daysOverdue: daysSince(s.endDate),
+            detail: s.donorId ? `donor:${s.donorId}` : null,
+          }));
         } catch (err) {
           logger.error?.('[W695 sponsorship-expiry] sweep failed', err);
         }
@@ -172,6 +232,15 @@ function wireModuleGapSweepers(app, deps = {}) {
               `[W695 vfss-pending] study=${a._id} beneficiary=${a.beneficiaryId} type=${a.studyType} ordered=${a.orderedDate}`
             );
           }
+          await emitOverdue('module_gap.vfss_pending.aging', aging, a => ({
+            kind: 'vfss_pending',
+            beneficiaryId: a.beneficiaryId ? String(a.beneficiaryId) : null,
+            branchId: a.branchId ? String(a.branchId) : null,
+            recordId: String(a._id),
+            dueDate: a.orderedDate,
+            daysOverdue: daysSince(a.orderedDate),
+            detail: a.studyType,
+          }));
         } catch (err) {
           logger.error?.('[W695 vfss-pending] sweep failed', err);
         }


### PR DESCRIPTION
## What

The **hearing sibling of VisionScreening (W720)** on the sensory-screening axis — closes the remaining Tier-1 sensory gap. Hearing loss is highly prevalent and under-detected in day-rehab beneficiaries (chronic otitis media in Down syndrome, NICU/TORCH histories, cerebral palsy) and silently caps every language / AAC / education / behaviour goal, so a structured longitudinal functional-hearing record is a first-class need — not a free-text note.

## Changes
- **`models/AudiologyScreening.js`** — per-ear functional level estimate (dB-HL bands) + tympanometry (Jerger A/As/Ad/B/C) + hearing-loss type + JCIH behavioural risk cluster + 8 ability-graded screening methods (pure-tone / play / VRA / OAE / ABR / tympanometry / observation / otoscopy). Wave-18 invariants: refer⇒reason, amplification⇒detail, risk-flag⇒≥1 indicator, finalize⇒screener; reassessmentDue ≥ date. Virtuals: `needsReferral`, `riskIndicatorCount`, `worseEarLevel`.
- **`routes/audiology-screening.routes.js`** — 11 endpoints, dualMountAuth at `/api/(v1/)?audiology-screening`; branch-scoped (`branchFilter`, zero `req.branchId`); draft→finalize (immutable after finalize); `mongoose.isValidObjectId` on every param; `audiologist` role added.
- Canonical Zod schema + registration; `features.registry` mount.

## Tests — 48 assertions
- 24 static drift (`audiology-screening-wave722`)
- 14 behavioral over MongoMemoryServer (`audiology-screening-behavioral-wave722`)
- 10 supertest route-level on the W699 harness (`audiology-screening-api-wave722`)
- All enumerated in `sprint-tests.txt` + synced into the CI path triggers.

## Note
Stacks on **W717 (PR #210)** — both commits appear here until #210 merges, then this reduces to the single W722 commit. Independent feature; zero env vars; deployable on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)