### PR TITLE
feat(authz): W730 ADR-037 D2 — reconcile the 26 rbac-only roles into one union

### DIFF
--- a/backend/__tests__/check-role-registry-divergence-script.test.js
+++ b/backend/__tests__/check-role-registry-divergence-script.test.js
@@ -48,18 +48,21 @@ describe('role-registry divergence — diff() ratchet logic', () => {
 describe('role-registry divergence — real-tree computeDivergence()', () => {
   const div = computeDivergence();
 
-  it('rbac.config has more roles than roles.constants (superset-ish)', () => {
-    expect(div.rcCount).toBeGreaterThan(div.conCount);
+  // ADR-037 D2 (W730, 2026-06-01): the 26 rbac-only roles were reconciled INTO
+  // roles.constants (additive union). The rbac-only side is now EMPTY; only the
+  // 9 const-only roles remain (their permission-map reconciliation is D3, gated
+  // on Q1–Q2). These assertions track the post-D2 / pre-D3 state.
+  it('rbac-only side is fully reconciled (ADR-037 D2 — gap now 0)', () => {
+    expect(div.onlyInRbac).toHaveLength(0);
+    // the formerly rbac-only roles now live in BOTH registries
+    expect(div.onlyInRbac).not.toContain('branch_manager');
+    expect(div.onlyInRbac).not.toContain('clinical_director');
   });
 
-  it('the known bidirectional divergence is present (rbac-only incl. branch_manager)', () => {
-    expect(div.onlyInRbac).toContain('branch_manager');
-    expect(div.onlyInRbac).toContain('clinical_director');
-  });
-
-  it('const-only side present (incl. the W464 CRPD + DPO roles)', () => {
+  it('const-only side still present (the 9, pending ADR-037 D3 grants)', () => {
     expect(div.onlyInConst).toContain('independent_advocate');
     expect(div.onlyInConst).toContain('dpo');
+    expect(div.onlyInConst.length).toBe(9);
   });
 
   it('current divergence exactly equals the committed baseline (no pre-existing drift)', () => {

--- a/backend/config/constants/roles.constants.js
+++ b/backend/config/constants/roles.constants.js
@@ -57,6 +57,45 @@ const ROLES = {
   // Family Counsellor per Phase C. Sister of Cultural Officer — reserved
   // here for forward-compat.
   FAMILY_COUNSELLOR: 'family_counsellor',
+  // ── ADR-037 D2 union (W730, 2026-06-01): the 26 roles that existed ONLY
+  //    in config/rbac.config.js (carrying real ROLE_HIERARCHY + permission
+  //    maps) but were absent here, so a role defined there yet checked via
+  //    this registry's resolver did not resolve. ADDITIVE — values are
+  //    byte-identical to rbac.config, so existing callers are unaffected; this
+  //    only makes both registries agree (drives check:role-divergence rbac-only
+  //    26 → 0). D3 (permission maps for the 9 const-only roles) stays gated on
+  //    ADR-037 Q1–Q2; this commit does NOT touch grants.
+  // Org / branch (Phase-7)
+  BRANCH_MANAGER: 'branch_manager',
+  REGIONAL_DIRECTOR: 'regional_director',
+  REGIONAL_QUALITY: 'regional_quality',
+  QUALITY_COORDINATOR: 'quality_coordinator',
+  CLINICAL_DIRECTOR: 'clinical_director',
+  // HQ exec / governance
+  GROUP_GM: 'group_gm',
+  GROUP_CFO: 'group_cfo',
+  GROUP_CHRO: 'group_chro',
+  GROUP_QUALITY_OFFICER: 'group_quality_officer',
+  COMPLIANCE_OFFICER: 'compliance_officer',
+  INTERNAL_AUDITOR: 'internal_auditor',
+  IT_ADMIN: 'it_admin',
+  // Dept supervisors
+  HR_OFFICER: 'hr_officer',
+  HR_SUPERVISOR: 'hr_supervisor',
+  FINANCE_SUPERVISOR: 'finance_supervisor',
+  THERAPY_SUPERVISOR: 'therapy_supervisor',
+  SPECIAL_ED_SUPERVISOR: 'special_ed_supervisor',
+  // Clinical specialties
+  THERAPIST_SLP: 'therapist_slp',
+  THERAPIST_OT: 'therapist_ot',
+  THERAPIST_PT: 'therapist_pt',
+  THERAPIST_PSYCH: 'therapist_psych',
+  SPECIAL_ED_TEACHER: 'special_ed_teacher',
+  THERAPY_ASSISTANT: 'therapy_assistant',
+  // Support / external (NON_MATRIX archetype — ADR-036 D5)
+  DRIVER: 'driver',
+  BUS_ASSISTANT: 'bus_assistant',
+  GUARDIAN: 'guardian',
   // ─────────────────────────────────────────────────────────────────
   PARENT: 'parent',
   STUDENT: 'student',

--- a/backend/scripts/check-role-registry-divergence.js
+++ b/backend/scripts/check-role-registry-divergence.js
@@ -50,34 +50,13 @@ const BARE = ARGS.includes('--bare');
 
 // ── BASELINE (2026-05-30). Roles present in exactly one registry. Ratchet DOWN
 //    as the registries are reconciled (a role added to BOTH leaves the gap). ──
-const ONLY_IN_RBAC_BASELINE = new Set([
-  'branch_manager',
-  'bus_assistant',
-  'clinical_director',
-  'compliance_officer',
-  'driver',
-  'finance_supervisor',
-  'group_cfo',
-  'group_chro',
-  'group_gm',
-  'group_quality_officer',
-  'guardian',
-  'hr_officer',
-  'hr_supervisor',
-  'internal_auditor',
-  'it_admin',
-  'quality_coordinator',
-  'regional_director',
-  'regional_quality',
-  'special_ed_supervisor',
-  'special_ed_teacher',
-  'therapist_ot',
-  'therapist_psych',
-  'therapist_pt',
-  'therapist_slp',
-  'therapy_assistant',
-  'therapy_supervisor',
-]);
+// ADR-037 D2/D5 (W730, 2026-06-01): all 26 rbac-only roles were reconciled INTO
+// roles.constants.js (additive union — identical values) and pruned from this
+// baseline in the same commit per the ratchet-DOWN contract. rbac-only gap now 0.
+// The 9 const-only roles remain below — their reconciliation is D3, gated on
+// ADR-037 Q1–Q2 (assigning real permission maps is a security decision, not a
+// mechanical merge), so they stay baselined until those grants are signed off.
+const ONLY_IN_RBAC_BASELINE = new Set([]);
 const ONLY_IN_CONST_BASELINE = new Set([
   'crm_supervisor',
   'cultural_officer',


### PR DESCRIPTION
Implements **ADR-037 D2/D5** — the agent-executable, low-risk, additive half of the role-registry reconciliation. Closes the rbac-only side of the 26+9 bidirectional divergence.

## Problem (ADR-037 context)
`config/rbac.config.js` (46 roles) and `config/constants/roles.constants.js` (28) had diverged in BOTH directions. The **26 roles only in rbac.config** carried real `ROLE_HIERARCHY` + permission maps, but a role checked through the *constants* resolver simply **did not resolve** — a latent auth bug, frozen by `check:role-registry-divergence`.

## What this does (D2)
- Adds the 26 to `roles.constants.js` ROLES (**28 → 54**), grouped per ADR-037 clusters (org/branch, HQ exec, dept supervisors, clinical specialties, support/external).
- **ADDITIVE + behavior-preserving**: values byte-identical to rbac.config; `rbac.config.js` **untouched**; no grant change, no caller change.
- Ratchets `check:role-registry-divergence` rbac-only **26 → 0** (baseline emptied same commit per D5); guard self-test updated to assert post-D2 state (rbac-only=0, const-only=9).

## Explicitly OUT of scope (still gated)
- **D3** — permission maps for the 9 const-only roles (`dpo`, nursing ladder, CRM) — needs **ADR-037 Q1–Q2** sign-off (a security decision; mis-mapping over/under-grants). Those 9 stay baselined.
- **D4** — the `rbac.config.ROLES = require(constants).ROLES` re-export shim — follows D3.

## Verification
- `check:role-registry-divergence` ✓ (0 rbac-only + 9 const-only)
- `check:authz-consolidation` ✓ (16 baseline)
- authz-registry + archetype-map + divergence + consolidation suites ✓ **46 tests**
- `check:routes-load` ✓ 571 files
- `resolveRole` + `rbac.resolvePermissions` intact for both new + existing roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)