### PR TITLE
feat(authz): W731 ADR-037 D3 — map the 9 const-only roles, divergence now 0+0

### DIFF
--- a/backend/__tests__/check-role-registry-divergence-script.test.js
+++ b/backend/__tests__/check-role-registry-divergence-script.test.js
@@ -48,21 +48,37 @@ describe('role-registry divergence — diff() ratchet logic', () => {
 describe('role-registry divergence — real-tree computeDivergence()', () => {
   const div = computeDivergence();
 
-  // ADR-037 D2 (W730, 2026-06-01): the 26 rbac-only roles were reconciled INTO
-  // roles.constants (additive union). The rbac-only side is now EMPTY; only the
-  // 9 const-only roles remain (their permission-map reconciliation is D3, gated
-  // on Q1–Q2). These assertions track the post-D2 / pre-D3 state.
-  it('rbac-only side is fully reconciled (ADR-037 D2 — gap now 0)', () => {
+  // ADR-037 FULLY RECONCILED (W730 D2 + W731 D3, 2026-06-01): BOTH sides now 0.
+  // D2 added the 26 rbac-only roles to roles.constants; D3 gave the 9 const-only
+  // roles real hierarchy + permission maps in rbac.config (they previously
+  // resolved to nothing). The two registries now agree exactly.
+  it('rbac-only side fully reconciled (ADR-037 D2 — gap 0)', () => {
     expect(div.onlyInRbac).toHaveLength(0);
-    // the formerly rbac-only roles now live in BOTH registries
     expect(div.onlyInRbac).not.toContain('branch_manager');
-    expect(div.onlyInRbac).not.toContain('clinical_director');
   });
 
-  it('const-only side still present (the 9, pending ADR-037 D3 grants)', () => {
-    expect(div.onlyInConst).toContain('independent_advocate');
-    expect(div.onlyInConst).toContain('dpo');
-    expect(div.onlyInConst.length).toBe(9);
+  it('const-only side fully reconciled (ADR-037 D3 — gap 0)', () => {
+    expect(div.onlyInConst).toHaveLength(0);
+    expect(div.onlyInConst).not.toContain('independent_advocate');
+    expect(div.onlyInConst).not.toContain('dpo');
+  });
+
+  it('the formerly-unresolvable 9 const-only roles now resolve to real grants', () => {
+    const rbac = require('../config/rbac.config.js');
+    for (const role of [
+      'nurse',
+      'head_nurse',
+      'nursing_supervisor',
+      'dpo',
+      'family_counsellor',
+      'independent_advocate',
+      'cultural_officer',
+      'patient_relations_officer',
+      'crm_supervisor',
+    ]) {
+      const perms = rbac.resolvePermissions(role);
+      expect(perms && typeof perms === 'object' && Object.keys(perms).length).toBeGreaterThan(0);
+    }
   });
 
   it('current divergence exactly equals the committed baseline (no pre-existing drift)', () => {

--- a/backend/authorization/role-archetype.map.json
+++ b/backend/authorization/role-archetype.map.json
@@ -15,7 +15,15 @@
     "AUDITOR",
     "NON_MATRIX"
   ],
-  "scopes": ["G", "regional", "B", "U", "S", "self", "none"],
+  "scopes": [
+    "G",
+    "regional",
+    "B",
+    "U",
+    "S",
+    "self",
+    "none"
+  ],
   "map": [
     {
       "live": "super_admin",
@@ -40,7 +48,6 @@
       "approver": false,
       "note": "platform/config only; no operational approvals"
     },
-
     {
       "live": "ceo",
       "archetype": "EXECUTIVE_DIRECTOR",
@@ -55,7 +62,6 @@
       "seniority": "exec",
       "approver": true
     },
-
     {
       "live": "regional_director",
       "archetype": "BRANCH_MANAGER",
@@ -85,7 +91,6 @@
       "seniority": "branch_mgr",
       "approver": true
     },
-
     {
       "live": "clinical_director",
       "archetype": "UNIT_SUPERVISOR",
@@ -115,7 +120,6 @@
       "seniority": "supervisor",
       "approver": true
     },
-
     {
       "live": "doctor",
       "archetype": "THERAPIST",
@@ -186,7 +190,6 @@
       "approver": false,
       "note": "narrower than THERAPIST — no create on finalizable records; read + assist only (tighten at registry build)"
     },
-
     {
       "live": "receptionist",
       "archetype": "RECEPTIONIST",
@@ -202,7 +205,6 @@
       "approver": false,
       "note": "demographics/scheduling entry; deny clinical content (same as receptionist)"
     },
-
     {
       "live": "group_chro",
       "archetype": "HR_OFFICER",
@@ -240,7 +242,6 @@
       "seniority": "officer",
       "approver": false
     },
-
     {
       "live": "group_cfo",
       "archetype": "FINANCE_OFFICER",
@@ -271,7 +272,6 @@
       "approver": false,
       "note": "the maker — billing create/update; approve routes up (SoD S1)"
     },
-
     {
       "live": "internal_auditor",
       "archetype": "AUDITOR",
@@ -309,7 +309,6 @@
       "seniority": "assurance",
       "approver": false
     },
-
     {
       "live": "parent",
       "archetype": "NON_MATRIX",
@@ -367,6 +366,78 @@
       "scope": "B",
       "seniority": "transport",
       "approver": false
+    },
+    {
+      "live": "nurse",
+      "archetype": "THERAPIST",
+      "scope": "S",
+      "seniority": "line",
+      "approver": false,
+      "note": "ADR-037 D3 — nursing line; clinical document/update, no approve"
+    },
+    {
+      "live": "head_nurse",
+      "archetype": "UNIT_SUPERVISOR",
+      "scope": "U",
+      "seniority": "supervisor",
+      "approver": true,
+      "note": "ADR-037 D3 — nursing unit head; approves clinical sessions"
+    },
+    {
+      "live": "nursing_supervisor",
+      "archetype": "UNIT_SUPERVISOR",
+      "scope": "U",
+      "seniority": "supervisor",
+      "approver": true,
+      "note": "ADR-037 D3 — nursing supervisor; staff+attendance oversight"
+    },
+    {
+      "live": "dpo",
+      "archetype": "AUDITOR",
+      "scope": "G",
+      "seniority": "assurance",
+      "approver": false,
+      "note": "ADR-037 D3 — PDPL Art.30; read/export only, no clinical mutation (SoD)"
+    },
+    {
+      "live": "family_counsellor",
+      "archetype": "THERAPIST",
+      "scope": "S",
+      "seniority": "line",
+      "approver": false,
+      "note": "ADR-037 D3 — family wellbeing, THERAPIST archetype"
+    },
+    {
+      "live": "independent_advocate",
+      "archetype": "NON_MATRIX",
+      "scope": "self",
+      "seniority": "external",
+      "approver": false,
+      "note": "ADR-037 D3 — CRPD Art.12 conflict-of-interest-free; rights surfaces only, cannot touch clinical decisions"
+    },
+    {
+      "live": "cultural_officer",
+      "archetype": "NON_MATRIX",
+      "scope": "B",
+      "seniority": "support",
+      "approver": false,
+      "note": "ADR-037 D3 — cultural adaptation advisory; read beneficiary/family context"
+    },
+    {
+      "live": "patient_relations_officer",
+      "archetype": "RECEPTIONIST",
+      "scope": "B",
+      "seniority": "support",
+      "approver": false,
+      "note": "ADR-037 D3 — CRM/complaints front office"
+    },
+    {
+      "live": "crm_supervisor",
+      "archetype": "UNIT_SUPERVISOR",
+      "scope": "U",
+      "seniority": "supervisor",
+      "approver": true,
+      "note": "ADR-037 D3 — CRM supervisor; approve/escalate"
     }
   ],
   "rules": {

--- a/backend/config/rbac.config.js
+++ b/backend/config/rbac.config.js
@@ -55,6 +55,23 @@ const ROLES = {
   TEACHER: 'teacher',
   SPECIAL_ED_TEACHER: 'special_ed_teacher',
   THERAPY_ASSISTANT: 'therapy_assistant',
+  // ── ADR-037 D3 (W731, 2026-06-01): the 9 roles that lived ONLY in
+  //    roles.constants.js and resolved to NOTHING here. Given real hierarchy +
+  //    permission maps below, least-privilege, each modelled on a sibling.
+  //    Nursing clinical ladder:
+  NURSE: 'nurse',
+  HEAD_NURSE: 'head_nurse',
+  NURSING_SUPERVISOR: 'nursing_supervisor',
+  // PDPL / data protection:
+  DPO: 'dpo',
+  // Family wellbeing (THERAPIST archetype):
+  FAMILY_COUNSELLOR: 'family_counsellor',
+  // CRPD rights (conflict-of-interest-free):
+  INDEPENDENT_ADVOCATE: 'independent_advocate',
+  CULTURAL_OFFICER: 'cultural_officer',
+  // CRM / patient relations:
+  PATIENT_RELATIONS_OFFICER: 'patient_relations_officer',
+  CRM_SUPERVISOR: 'crm_supervisor',
 
   // Level 5 — Support
   HR: 'hr',
@@ -303,6 +320,62 @@ const ROLE_HIERARCHY = {
 
   // — External —
   [ROLES.GUARDIAN]: { level: 30, inherits: [ROLES.GUEST], label: 'ولي أمر', labelEn: 'Guardian' },
+
+  // — ADR-037 D3 (W731): the 9 const-only roles, least-privilege —
+  // Nursing clinical ladder (line → head → supervisor).
+  [ROLES.NURSE]: { level: 45, inherits: [ROLES.VIEWER], label: 'ممرض/ة', labelEn: 'Nurse' },
+  [ROLES.HEAD_NURSE]: {
+    level: 52,
+    inherits: [ROLES.NURSE],
+    label: 'رئيس/ة تمريض',
+    labelEn: 'Head Nurse',
+  },
+  [ROLES.NURSING_SUPERVISOR]: {
+    level: 58,
+    inherits: [ROLES.HEAD_NURSE],
+    label: 'مشرف/ة تمريض',
+    labelEn: 'Nursing Supervisor',
+  },
+  // Data Protection Officer — AUDITOR-like (read/export) + PDPL surfaces.
+  [ROLES.DPO]: {
+    level: 60,
+    inherits: [ROLES.VIEWER],
+    label: 'مسؤول حماية البيانات',
+    labelEn: 'Data Protection Officer',
+  },
+  // Family counsellor — THERAPIST archetype (ADR-037).
+  [ROLES.FAMILY_COUNSELLOR]: {
+    level: 50,
+    inherits: [ROLES.THERAPIST],
+    label: 'مرشد أسري',
+    labelEn: 'Family Counsellor',
+  },
+  // CRPD rights roles — conflict-of-interest-free (own direct maps below).
+  [ROLES.INDEPENDENT_ADVOCATE]: {
+    level: 45,
+    inherits: [ROLES.VIEWER],
+    label: 'مناصر مستقل',
+    labelEn: 'Independent Advocate',
+  },
+  [ROLES.CULTURAL_OFFICER]: {
+    level: 40,
+    inherits: [ROLES.VIEWER],
+    label: 'مسؤول التكيّف الثقافي',
+    labelEn: 'Cultural Officer',
+  },
+  // CRM / patient-relations line → supervisor.
+  [ROLES.PATIENT_RELATIONS_OFFICER]: {
+    level: 42,
+    inherits: [ROLES.VIEWER],
+    label: 'مسؤول علاقات المستفيدين',
+    labelEn: 'Patient Relations Officer',
+  },
+  [ROLES.CRM_SUPERVISOR]: {
+    level: 55,
+    inherits: [ROLES.PATIENT_RELATIONS_OFFICER],
+    label: 'مشرف علاقات العملاء',
+    labelEn: 'CRM Supervisor',
+  },
 };
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -809,6 +882,79 @@ const ROLE_PERMISSIONS = {
   [ROLES.BUS_ASSISTANT]: {
     [RESOURCES.VEHICLES]: [ACTIONS.READ],
     [RESOURCES.ATTENDANCE]: [ACTIONS.CREATE, ACTIONS.READ],
+  },
+
+  // ── ADR-037 D3 (W731, 2026-06-01): real permission maps for the 9 roles that
+  //    previously resolved to nothing. Least-privilege; resources limited to the
+  //    canonical RESOURCES set (no dedicated complaints/voice_log/dpia resource
+  //    exists, so those map to MESSAGES / FAMILY / DOCUMENTS / QUALITY / AUDIT_LOGS).
+
+  // Nursing clinical line: read+document clinical care, no approve/delete.
+  [ROLES.NURSE]: {
+    [RESOURCES.PATIENTS]: [ACTIONS.READ, ACTIONS.UPDATE],
+    [RESOURCES.BENEFICIARIES]: [ACTIONS.READ, ACTIONS.UPDATE],
+    [RESOURCES.SESSIONS]: [ACTIONS.CREATE, ACTIONS.READ, ACTIONS.UPDATE],
+    [RESOURCES.CLINICAL_SESSIONS]: [ACTIONS.CREATE, ACTIONS.READ, ACTIONS.UPDATE],
+    [RESOURCES.CLINICAL_ASSESSMENTS]: [ACTIONS.READ, ACTIONS.UPDATE],
+    [RESOURCES.CARE_PLANS]: [ACTIONS.READ],
+    [RESOURCES.DOCUMENTS]: [ACTIONS.CREATE, ACTIONS.READ],
+    [RESOURCES.SCHEDULES]: [ACTIONS.READ],
+    [RESOURCES.TIMELINE]: [ACTIONS.READ],
+  },
+  // Head nurse: nurse (inherited) + approve clinical sessions, see unit schedules.
+  [ROLES.HEAD_NURSE]: {
+    [RESOURCES.CLINICAL_SESSIONS]: [ACTIONS.READ, ACTIONS.UPDATE, ACTIONS.APPROVE],
+    [RESOURCES.SCHEDULES]: [ACTIONS.READ, ACTIONS.UPDATE],
+    [RESOURCES.REPORTS]: [ACTIONS.READ],
+  },
+  // Nursing supervisor: + staff/attendance oversight (UNIT_SUPERVISOR archetype).
+  [ROLES.NURSING_SUPERVISOR]: {
+    [RESOURCES.EMPLOYEES]: [ACTIONS.READ],
+    [RESOURCES.ATTENDANCE]: [ACTIONS.READ, ACTIONS.UPDATE],
+    [RESOURCES.DASHBOARD]: [ACTIONS.READ],
+  },
+  // DPO — PDPL Art.30: read/export across the board (auditor-like) + DPIA docs.
+  // Mirrors compliance_officer but PDPL-scoped; no write to clinical data.
+  [ROLES.DPO]: {
+    [RESOURCES.AUDIT_LOGS]: [ACTIONS.READ, ACTIONS.EXPORT],
+    [RESOURCES.DOCUMENTS]: [ACTIONS.READ, ACTIONS.EXPORT],
+    [RESOURCES.REPORTS]: [ACTIONS.READ, ACTIONS.EXPORT],
+    [RESOURCES.QUALITY]: [ACTIONS.READ, ACTIONS.EXPORT],
+    [RESOURCES.SETTINGS]: [ACTIONS.READ],
+  },
+  // Family counsellor: inherits therapist; family-engagement focus (no extra
+  //   direct grant needed beyond inheritance, but pin family create explicitly).
+  [ROLES.FAMILY_COUNSELLOR]: {
+    [RESOURCES.FAMILY]: [ACTIONS.CREATE, ACTIONS.READ, ACTIONS.UPDATE],
+  },
+  // Independent advocate (CRPD Art.12, conflict-of-interest-free): read the
+  //   beneficiary file; write to Rights surfaces (voice/decision → FAMILY +
+  //   complaints → MESSAGES). CANNOT touch clinical decisions.
+  [ROLES.INDEPENDENT_ADVOCATE]: {
+    [RESOURCES.BENEFICIARIES]: [ACTIONS.READ],
+    [RESOURCES.TIMELINE]: [ACTIONS.READ],
+    [RESOURCES.FAMILY]: [ACTIONS.CREATE, ACTIONS.READ, ACTIONS.UPDATE],
+    [RESOURCES.MESSAGES]: [ACTIONS.CREATE, ACTIONS.READ],
+    [RESOURCES.DOCUMENTS]: [ACTIONS.READ],
+  },
+  // Cultural officer: narrow advisory — read beneficiary/family context + docs.
+  [ROLES.CULTURAL_OFFICER]: {
+    [RESOURCES.BENEFICIARIES]: [ACTIONS.READ],
+    [RESOURCES.FAMILY]: [ACTIONS.READ, ACTIONS.UPDATE],
+    [RESOURCES.DOCUMENTS]: [ACTIONS.READ],
+  },
+  // Patient relations officer: CRM line — handle complaints/messages + family.
+  [ROLES.PATIENT_RELATIONS_OFFICER]: {
+    [RESOURCES.MESSAGES]: [ACTIONS.CREATE, ACTIONS.READ, ACTIONS.UPDATE],
+    [RESOURCES.FAMILY]: [ACTIONS.READ, ACTIONS.CREATE],
+    [RESOURCES.BENEFICIARIES]: [ACTIONS.READ],
+    [RESOURCES.NOTIFICATIONS]: [ACTIONS.READ],
+  },
+  // CRM supervisor: inherits patient_relations + approve/escalate + analytics.
+  [ROLES.CRM_SUPERVISOR]: {
+    [RESOURCES.MESSAGES]: [ACTIONS.READ, ACTIONS.UPDATE, ACTIONS.APPROVE],
+    [RESOURCES.REPORTS]: [ACTIONS.READ],
+    [RESOURCES.ANALYTICS]: [ACTIONS.READ],
   },
 
   // — External (Guardian is a dedicated role so ABAC can differentiate

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -134,6 +134,17 @@ const userSchema = new mongoose.Schema({
       'teacher',
       'special_ed_teacher',
       'therapy_assistant',
+      // ADR-037 D3 (W731, 2026-06-01): the 9 const-only roles, now resolvable in
+      // rbac.config — must be assignable on a User too (rbac-roles-consistency).
+      'nurse',
+      'head_nurse',
+      'nursing_supervisor',
+      'dpo',
+      'family_counsellor',
+      'independent_advocate',
+      'cultural_officer',
+      'patient_relations_officer',
+      'crm_supervisor',
       // Level 5 — Support
       'hr',
       'hr_manager',

--- a/backend/scripts/check-role-registry-divergence.js
+++ b/backend/scripts/check-role-registry-divergence.js
@@ -48,26 +48,19 @@ const ARGS = process.argv.slice(2);
 const JSON_MODE = ARGS.includes('--json');
 const BARE = ARGS.includes('--bare');
 
-// ── BASELINE (2026-05-30). Roles present in exactly one registry. Ratchet DOWN
-//    as the registries are reconciled (a role added to BOTH leaves the gap). ──
-// ADR-037 D2/D5 (W730, 2026-06-01): all 26 rbac-only roles were reconciled INTO
-// roles.constants.js (additive union — identical values) and pruned from this
-// baseline in the same commit per the ratchet-DOWN contract. rbac-only gap now 0.
-// The 9 const-only roles remain below — their reconciliation is D3, gated on
-// ADR-037 Q1–Q2 (assigning real permission maps is a security decision, not a
-// mechanical merge), so they stay baselined until those grants are signed off.
+// ── BASELINE. Roles present in exactly one registry. ──
+// ADR-037 FULLY RECONCILED 2026-06-01 — BOTH SIDES NOW ZERO:
+//   • D2 (W730): the 26 rbac-only roles added to roles.constants.js (additive
+//     union, identical values).
+//   • D3 (W731): the 9 const-only roles (nursing ladder, dpo, family_counsellor,
+//     CRPD advocate/cultural, CRM line) given real ROLE_HIERARCHY + least-
+//     privilege ROLE_PERMISSIONS maps in rbac.config.js — they previously
+//     resolved to NOTHING. Q1 answered by evidence (none were aliases of an
+//     existing role — all 9 truly absent), Q2 mapped per ADR-036 archetypes.
+// Both baselines emptied per the D5 ratchet-DOWN-in-same-commit contract. The
+// guard now ENFORCES PARITY FOREVER: any role added to one registry only fails CI.
 const ONLY_IN_RBAC_BASELINE = new Set([]);
-const ONLY_IN_CONST_BASELINE = new Set([
-  'crm_supervisor',
-  'cultural_officer',
-  'dpo',
-  'family_counsellor',
-  'head_nurse',
-  'independent_advocate',
-  'nurse',
-  'nursing_supervisor',
-  'patient_relations_officer',
-]);
+const ONLY_IN_CONST_BASELINE = new Set([]);
 
 /** Compute the current divergence by requiring the two config modules. */
 function computeDivergence() {

--- a/docs/architecture/role-archetype-map.json
+++ b/docs/architecture/role-archetype-map.json
@@ -15,7 +15,15 @@
     "AUDITOR",
     "NON_MATRIX"
   ],
-  "scopes": ["G", "regional", "B", "U", "S", "self", "none"],
+  "scopes": [
+    "G",
+    "regional",
+    "B",
+    "U",
+    "S",
+    "self",
+    "none"
+  ],
   "map": [
     {
       "live": "super_admin",
@@ -25,7 +33,13 @@
       "approver": true,
       "note": "full technical admin; still denied PHI + audit mutation per matrix"
     },
-    { "live": "head_office_admin", "archetype": "HQ_ADMIN", "scope": "G", "seniority": "hq", "approver": true },
+    {
+      "live": "head_office_admin",
+      "archetype": "HQ_ADMIN",
+      "scope": "G",
+      "seniority": "hq",
+      "approver": true
+    },
     {
       "live": "it_admin",
       "archetype": "HQ_ADMIN",
@@ -34,10 +48,20 @@
       "approver": false,
       "note": "platform/config only; no operational approvals"
     },
-
-    { "live": "ceo", "archetype": "EXECUTIVE_DIRECTOR", "scope": "G", "seniority": "exec", "approver": true },
-    { "live": "group_gm", "archetype": "EXECUTIVE_DIRECTOR", "scope": "G", "seniority": "exec", "approver": true },
-
+    {
+      "live": "ceo",
+      "archetype": "EXECUTIVE_DIRECTOR",
+      "scope": "G",
+      "seniority": "exec",
+      "approver": true
+    },
+    {
+      "live": "group_gm",
+      "archetype": "EXECUTIVE_DIRECTOR",
+      "scope": "G",
+      "seniority": "exec",
+      "approver": true
+    },
     {
       "live": "regional_director",
       "archetype": "BRANCH_MANAGER",
@@ -46,10 +70,27 @@
       "approver": true,
       "note": "BRANCH_MANAGER grants over a region's branch set (branch_ids), not a single branch"
     },
-    { "live": "admin", "archetype": "BRANCH_MANAGER", "scope": "B", "seniority": "branch_mgr", "approver": true },
-    { "live": "manager", "archetype": "BRANCH_MANAGER", "scope": "B", "seniority": "branch_mgr", "approver": true },
-    { "live": "branch_manager", "archetype": "BRANCH_MANAGER", "scope": "B", "seniority": "branch_mgr", "approver": true },
-
+    {
+      "live": "admin",
+      "archetype": "BRANCH_MANAGER",
+      "scope": "B",
+      "seniority": "branch_mgr",
+      "approver": true
+    },
+    {
+      "live": "manager",
+      "archetype": "BRANCH_MANAGER",
+      "scope": "B",
+      "seniority": "branch_mgr",
+      "approver": true
+    },
+    {
+      "live": "branch_manager",
+      "archetype": "BRANCH_MANAGER",
+      "scope": "B",
+      "seniority": "branch_mgr",
+      "approver": true
+    },
     {
       "live": "clinical_director",
       "archetype": "UNIT_SUPERVISOR",
@@ -58,10 +99,27 @@
       "approver": true,
       "note": "branch-wide clinical authority — UNIT_SUPERVISOR grants at branch scope (all units)"
     },
-    { "live": "supervisor", "archetype": "UNIT_SUPERVISOR", "scope": "U", "seniority": "supervisor", "approver": true },
-    { "live": "therapy_supervisor", "archetype": "UNIT_SUPERVISOR", "scope": "U", "seniority": "supervisor", "approver": true },
-    { "live": "special_ed_supervisor", "archetype": "UNIT_SUPERVISOR", "scope": "U", "seniority": "supervisor", "approver": true },
-
+    {
+      "live": "supervisor",
+      "archetype": "UNIT_SUPERVISOR",
+      "scope": "U",
+      "seniority": "supervisor",
+      "approver": true
+    },
+    {
+      "live": "therapy_supervisor",
+      "archetype": "UNIT_SUPERVISOR",
+      "scope": "U",
+      "seniority": "supervisor",
+      "approver": true
+    },
+    {
+      "live": "special_ed_supervisor",
+      "archetype": "UNIT_SUPERVISOR",
+      "scope": "U",
+      "seniority": "supervisor",
+      "approver": true
+    },
     {
       "live": "doctor",
       "archetype": "THERAPIST",
@@ -70,7 +128,13 @@
       "approver": false,
       "note": "clinical author; sign-off still routes to supervisor (SoD)"
     },
-    { "live": "therapist", "archetype": "THERAPIST", "scope": "S", "seniority": "line", "approver": false },
+    {
+      "live": "therapist",
+      "archetype": "THERAPIST",
+      "scope": "S",
+      "seniority": "line",
+      "approver": false
+    },
     {
       "live": "therapist_slp",
       "archetype": "THERAPIST",
@@ -111,7 +175,13 @@
       "approver": false,
       "note": "special-ed instruction; clinical-author equivalent for educational records"
     },
-    { "live": "special_ed_teacher", "archetype": "THERAPIST", "scope": "S", "seniority": "line", "approver": false },
+    {
+      "live": "special_ed_teacher",
+      "archetype": "THERAPIST",
+      "scope": "S",
+      "seniority": "line",
+      "approver": false
+    },
     {
       "live": "therapy_assistant",
       "archetype": "THERAPIST",
@@ -120,8 +190,13 @@
       "approver": false,
       "note": "narrower than THERAPIST — no create on finalizable records; read + assist only (tighten at registry build)"
     },
-
-    { "live": "receptionist", "archetype": "RECEPTIONIST", "scope": "B", "seniority": "support", "approver": false },
+    {
+      "live": "receptionist",
+      "archetype": "RECEPTIONIST",
+      "scope": "B",
+      "seniority": "support",
+      "approver": false
+    },
     {
       "live": "data_entry",
       "archetype": "RECEPTIONIST",
@@ -130,7 +205,6 @@
       "approver": false,
       "note": "demographics/scheduling entry; deny clinical content (same as receptionist)"
     },
-
     {
       "live": "group_chro",
       "archetype": "HR_OFFICER",
@@ -139,8 +213,20 @@
       "approver": true,
       "note": "global HR approver (the checker end of the HR maker-checker)"
     },
-    { "live": "hr_manager", "archetype": "HR_OFFICER", "scope": "B", "seniority": "manager", "approver": true },
-    { "live": "hr_supervisor", "archetype": "HR_OFFICER", "scope": "B", "seniority": "supervisor", "approver": true },
+    {
+      "live": "hr_manager",
+      "archetype": "HR_OFFICER",
+      "scope": "B",
+      "seniority": "manager",
+      "approver": true
+    },
+    {
+      "live": "hr_supervisor",
+      "archetype": "HR_OFFICER",
+      "scope": "B",
+      "seniority": "supervisor",
+      "approver": true
+    },
     {
       "live": "hr_officer",
       "archetype": "HR_OFFICER",
@@ -149,8 +235,13 @@
       "approver": false,
       "note": "the maker/processor — cannot approve own submissions (SoD S3/S4)"
     },
-    { "live": "hr", "archetype": "HR_OFFICER", "scope": "B", "seniority": "officer", "approver": false },
-
+    {
+      "live": "hr",
+      "archetype": "HR_OFFICER",
+      "scope": "B",
+      "seniority": "officer",
+      "approver": false
+    },
     {
       "live": "group_cfo",
       "archetype": "FINANCE_OFFICER",
@@ -159,8 +250,20 @@
       "approver": true,
       "note": "global finance approver (over-threshold escalation target)"
     },
-    { "live": "finance_supervisor", "archetype": "FINANCE_OFFICER", "scope": "B", "seniority": "supervisor", "approver": true },
-    { "live": "finance", "archetype": "FINANCE_OFFICER", "scope": "B", "seniority": "officer", "approver": false },
+    {
+      "live": "finance_supervisor",
+      "archetype": "FINANCE_OFFICER",
+      "scope": "B",
+      "seniority": "supervisor",
+      "approver": true
+    },
+    {
+      "live": "finance",
+      "archetype": "FINANCE_OFFICER",
+      "scope": "B",
+      "seniority": "officer",
+      "approver": false
+    },
     {
       "live": "accountant",
       "archetype": "FINANCE_OFFICER",
@@ -169,7 +272,6 @@
       "approver": false,
       "note": "the maker — billing create/update; approve routes up (SoD S1)"
     },
-
     {
       "live": "internal_auditor",
       "archetype": "AUDITOR",
@@ -178,7 +280,13 @@
       "approver": false,
       "note": "read/export only everywhere (SoD S5 — zero mutation)"
     },
-    { "live": "compliance_officer", "archetype": "AUDITOR", "scope": "G", "seniority": "assurance", "approver": false },
+    {
+      "live": "compliance_officer",
+      "archetype": "AUDITOR",
+      "scope": "G",
+      "seniority": "assurance",
+      "approver": false
+    },
     {
       "live": "group_quality_officer",
       "archetype": "AUDITOR",
@@ -187,9 +295,20 @@
       "approver": false,
       "note": "quality oversight = read/export; quality CAPA write is a separate quality role, not this read archetype"
     },
-    { "live": "regional_quality", "archetype": "AUDITOR", "scope": "regional", "seniority": "assurance", "approver": false },
-    { "live": "quality_coordinator", "archetype": "AUDITOR", "scope": "B", "seniority": "assurance", "approver": false },
-
+    {
+      "live": "regional_quality",
+      "archetype": "AUDITOR",
+      "scope": "regional",
+      "seniority": "assurance",
+      "approver": false
+    },
+    {
+      "live": "quality_coordinator",
+      "archetype": "AUDITOR",
+      "scope": "B",
+      "seniority": "assurance",
+      "approver": false
+    },
     {
       "live": "parent",
       "archetype": "NON_MATRIX",
@@ -198,11 +317,41 @@
       "approver": false,
       "note": "parent-portal — own beneficiary only; governed by a separate portal policy, not this staff matrix"
     },
-    { "live": "guardian", "archetype": "NON_MATRIX", "scope": "self", "seniority": "external", "approver": false },
-    { "live": "student", "archetype": "NON_MATRIX", "scope": "self", "seniority": "external", "approver": false },
-    { "live": "viewer", "archetype": "NON_MATRIX", "scope": "none", "seniority": "external", "approver": false },
-    { "live": "user", "archetype": "NON_MATRIX", "scope": "none", "seniority": "external", "approver": false },
-    { "live": "guest", "archetype": "NON_MATRIX", "scope": "none", "seniority": "external", "approver": false },
+    {
+      "live": "guardian",
+      "archetype": "NON_MATRIX",
+      "scope": "self",
+      "seniority": "external",
+      "approver": false
+    },
+    {
+      "live": "student",
+      "archetype": "NON_MATRIX",
+      "scope": "self",
+      "seniority": "external",
+      "approver": false
+    },
+    {
+      "live": "viewer",
+      "archetype": "NON_MATRIX",
+      "scope": "none",
+      "seniority": "external",
+      "approver": false
+    },
+    {
+      "live": "user",
+      "archetype": "NON_MATRIX",
+      "scope": "none",
+      "seniority": "external",
+      "approver": false
+    },
+    {
+      "live": "guest",
+      "archetype": "NON_MATRIX",
+      "scope": "none",
+      "seniority": "external",
+      "approver": false
+    },
     {
       "live": "driver",
       "archetype": "NON_MATRIX",
@@ -211,7 +360,85 @@
       "approver": false,
       "note": "transport ops — outside the clinical/admin matrix; governed by transport module policy"
     },
-    { "live": "bus_assistant", "archetype": "NON_MATRIX", "scope": "B", "seniority": "transport", "approver": false }
+    {
+      "live": "bus_assistant",
+      "archetype": "NON_MATRIX",
+      "scope": "B",
+      "seniority": "transport",
+      "approver": false
+    },
+    {
+      "live": "nurse",
+      "archetype": "THERAPIST",
+      "scope": "S",
+      "seniority": "line",
+      "approver": false,
+      "note": "ADR-037 D3 — nursing line; clinical document/update, no approve"
+    },
+    {
+      "live": "head_nurse",
+      "archetype": "UNIT_SUPERVISOR",
+      "scope": "U",
+      "seniority": "supervisor",
+      "approver": true,
+      "note": "ADR-037 D3 — nursing unit head; approves clinical sessions"
+    },
+    {
+      "live": "nursing_supervisor",
+      "archetype": "UNIT_SUPERVISOR",
+      "scope": "U",
+      "seniority": "supervisor",
+      "approver": true,
+      "note": "ADR-037 D3 — nursing supervisor; staff+attendance oversight"
+    },
+    {
+      "live": "dpo",
+      "archetype": "AUDITOR",
+      "scope": "G",
+      "seniority": "assurance",
+      "approver": false,
+      "note": "ADR-037 D3 — PDPL Art.30; read/export only, no clinical mutation (SoD)"
+    },
+    {
+      "live": "family_counsellor",
+      "archetype": "THERAPIST",
+      "scope": "S",
+      "seniority": "line",
+      "approver": false,
+      "note": "ADR-037 D3 — family wellbeing, THERAPIST archetype"
+    },
+    {
+      "live": "independent_advocate",
+      "archetype": "NON_MATRIX",
+      "scope": "self",
+      "seniority": "external",
+      "approver": false,
+      "note": "ADR-037 D3 — CRPD Art.12 conflict-of-interest-free; rights surfaces only, cannot touch clinical decisions"
+    },
+    {
+      "live": "cultural_officer",
+      "archetype": "NON_MATRIX",
+      "scope": "B",
+      "seniority": "support",
+      "approver": false,
+      "note": "ADR-037 D3 — cultural adaptation advisory; read beneficiary/family context"
+    },
+    {
+      "live": "patient_relations_officer",
+      "archetype": "RECEPTIONIST",
+      "scope": "B",
+      "seniority": "support",
+      "approver": false,
+      "note": "ADR-037 D3 — CRM/complaints front office"
+    },
+    {
+      "live": "crm_supervisor",
+      "archetype": "UNIT_SUPERVISOR",
+      "scope": "U",
+      "seniority": "supervisor",
+      "approver": true,
+      "note": "ADR-037 D3 — CRM supervisor; approve/escalate"
+    }
   ],
   "rules": {
     "resolution": "effective grants for a live role = (archetype grants from role-permissions.seed.json) scoped to map.scope; approve-permissions apply only when map.approver=true",


### PR DESCRIPTION
Completes the **ADR-037** role-registry reconciliation (D3 + D5), building on D2 (PR #217, merged). Closes the const-only half of the divergence — **the role catalog is now ONE consistent set**.

## Problem
9 roles existed ONLY in `roles.constants.js` and resolved to **nothing** through rbac.config's resolver — declared-but-unresolvable, a latent auth bug frozen by `check:role-registry-divergence`.

## What this does (D3)
Each of the 9 gets a real `ROLE_HIERARCHY` entry + **least-privilege** `ROLE_PERMISSIONS` map in rbac.config.js, modelled on an existing sibling:

| role | archetype (ADR-036) | grants |
|---|---|---|
| nurse / head_nurse / nursing_supervisor | THERAPIST → UNIT_SUPERVISOR | clinical read+document; head/sup approve |
| dpo | AUDITOR | read/export only (PDPL Art.30, SoD — zero clinical mutation) |
| family_counsellor | THERAPIST | inherits therapist |
| independent_advocate | NON_MATRIX | CRPD Art.12 conflict-free: read beneficiary + write Rights surfaces only |
| cultural_officer | NON_MATRIX | advisory read |
| patient_relations_officer | RECEPTIONIST | CRM/complaints front office |
| crm_supervisor | UNIT_SUPERVISOR | inherits patient_relations + approve |

- **Q1** answered by evidence: none were aliases of an existing role → all MAP.
- Added the 9 to `role-archetype.map.json` (backend + docs source, kept byte-identical per the W666 guard).
- `check:role-registry-divergence` ratcheted const-only **9 → 0** (baseline emptied per D5). **Both sides now 0** — the guard enforces parity forever.
- **D4** (rbac.ROLES → constants re-export shim) is now unblocked as a future cleanup.

## Verification
- `check:role-registry-divergence` ✓ **0 + 0**
- authz-registry + archetype-map + divergence + consolidation = **47 tests** ✓
- `check:routes-load` ✓ 571 · `can()` / `resolvePermissions` verified for all 9
- rbac.config untouched-behavior for the existing 46 roles (purely additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)