### PR TITLE
feat(ops): W733 durable OpsAlert sink — backup/DR alerts can never silently drop

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -857,6 +857,9 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/adjunct-therapy-api-wave699.test.js'
       - 'backend/__tests__/prosthetic-orthotic-api-wave699.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/ops-alert-model-wave733.test.js'
+      - 'backend/tests/unit/ops-alerter.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1697,6 +1700,9 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/adjunct-therapy-api-wave699.test.js'
       - 'backend/__tests__/prosthetic-orthotic-api-wave699.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/ops-alert-model-wave733.test.js'
+      - 'backend/tests/unit/ops-alerter.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/ops-alert-model-wave733.test.js
+++ b/backend/__tests__/ops-alert-model-wave733.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+/**
+ * Behavioral guard — OpsAlert (W733).
+ *
+ * Boots in-memory Mongo, unmocks mongoose, asserts the Wave-18 __invariants
+ * actually fire + the durable-sink shape persists. Pairs with the static
+ * coverage in tests/unit/ops-alerter.test.js.
+ */
+
+const mongoose = require('mongoose');
+
+jest.unmock('mongoose');
+
+let mongod;
+let OpsAlert;
+
+beforeAll(async () => {
+  const { MongoMemoryServer } = require('mongodb-memory-server');
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  OpsAlert = require('../models/OpsAlert');
+}, 60000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+});
+
+describe('OpsAlert behavioral (W733)', () => {
+  test('persists a minimal open alert + computes isOpen + sets TTL', async () => {
+    const doc = await OpsAlert.create({
+      kind: 'backup_failed',
+      severity: 'high',
+      subject: 'nightly mongodump failed',
+    });
+    expect(doc._id).toBeDefined();
+    expect(doc.status).toBe('open');
+    expect(doc.isOpen).toBe(true);
+    expect(doc.delivery).toBe('pending');
+    expect(doc.expiresAt instanceof Date).toBe(true);
+    expect(doc.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  test('rejects an invalid severity', async () => {
+    const doc = new OpsAlert({ kind: 'k', severity: 'apocalyptic', subject: 's' });
+    await expect(doc.save()).rejects.toThrow(/severity/);
+  });
+
+  test('rejects status=acknowledged without acknowledgedAt', async () => {
+    const doc = new OpsAlert({ kind: 'k', severity: 'high', subject: 's', status: 'acknowledged' });
+    await expect(doc.save()).rejects.toThrow(/acknowledgedAt/);
+  });
+
+  test('rejects status=resolved without resolvedAt', async () => {
+    const doc = new OpsAlert({ kind: 'k', severity: 'high', subject: 's', status: 'resolved' });
+    await expect(doc.save()).rejects.toThrow(/resolvedAt/);
+  });
+
+  test('accepts a full acknowledge → resolve lifecycle', async () => {
+    const doc = await OpsAlert.create({ kind: 'dr_verify_failed', severity: 'critical', subject: 's' });
+    doc.status = 'acknowledged';
+    doc.acknowledgedAt = new Date();
+    await doc.save();
+    expect(doc.status).toBe('acknowledged');
+    doc.status = 'resolved';
+    doc.resolvedAt = new Date();
+    await doc.save();
+    expect(doc.isOpen).toBe(false);
+  });
+
+  test('records the best-effort delivery outcome', async () => {
+    const doc = await OpsAlert.create({
+      kind: 'backup_failed',
+      severity: 'high',
+      subject: 's',
+      delivery: 'no_recipients',
+    });
+    expect(doc.delivery).toBe('no_recipients');
+  });
+});

--- a/backend/models/OpsAlert.js
+++ b/backend/models/OpsAlert.js
@@ -1,0 +1,110 @@
+'use strict';
+
+/**
+ * OpsAlert — W733.
+ *
+ * Durable, queryable sink for OPERATIONAL alerts (backup failure, DR-verify
+ * failure, scheduler crash, …). The ROOT fix for the silent-drop gap:
+ *
+ *   Before: sendOpsAlert() only tried email/SMS. On prod, SMTP is uncredentialed
+ *   (SMTP_USER/SMTP_PASS unset) → unifiedNotifier skips → the alert was LOST,
+ *   leaving only a logger.error line in pm2 logs no one watches. A backup could
+ *   fail nightly and nobody would know.
+ *
+ *   After: every sendOpsAlert() FIRST persists an OpsAlert row (guaranteed,
+ *   needs no external secret), THEN attempts email/SMS as best-effort delivery.
+ *   So an ops failure is ALWAYS captured + surfaceable in the admin UI, and
+ *   email/SMS become a bonus channel that lights up the moment creds exist —
+ *   never a single point of failure.
+ *
+ * Lifecycle: open → acknowledged → resolved. TTL-expired after 90 days (PDPL —
+ * operational metadata, no PHI).
+ *
+ * Wave-18 invariants:
+ *   • kind + severity non-empty ; severity ∈ SEVERITIES ; status ∈ STATUSES
+ *   • status=acknowledged → acknowledgedAt required
+ *   • status=resolved → resolvedAt required
+ */
+
+const mongoose = require('mongoose');
+
+const SEVERITIES = ['low', 'medium', 'high', 'critical'];
+const STATUSES = ['open', 'acknowledged', 'resolved'];
+
+// Delivery outcome of the best-effort email/SMS fan-out attached to this alert.
+const DELIVERY = ['pending', 'delivered', 'failed', 'no_recipients', 'skipped'];
+
+const OpsAlertSchema = new mongoose.Schema(
+  {
+    kind: { type: String, required: true, index: true, maxlength: 80 }, // backup_failed / dr_verify_failed / scheduler_crash / selftest
+    severity: { type: String, enum: SEVERITIES, required: true, default: 'high', index: true },
+    subject: { type: String, required: true, maxlength: 500 },
+    body: { type: String, default: '', maxlength: 4000 },
+    metadata: { type: mongoose.Schema.Types.Mixed, default: {} },
+
+    status: { type: String, enum: STATUSES, required: true, default: 'open', index: true },
+
+    // Best-effort external delivery (email/SMS) outcome — the alert is durable
+    // regardless of this.
+    delivery: { type: String, enum: DELIVERY, default: 'pending' },
+    deliveryDetail: { type: String, default: '', maxlength: 1000 },
+
+    firstObservedAt: { type: Date, required: true, default: Date.now },
+    lastObservedAt: { type: Date, required: true, default: Date.now },
+    observedCount: { type: Number, default: 1 },
+
+    acknowledgedAt: { type: Date, default: null },
+    acknowledgedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+    resolvedAt: { type: Date, default: null },
+    resolvedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+
+    // 90-day TTL — operational metadata, no PHI (PDPL-aligned retention).
+    expiresAt: {
+      type: Date,
+      default: () => new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
+      index: { expires: 0 },
+    },
+  },
+  { timestamps: true, collection: 'ops_alerts' }
+);
+
+OpsAlertSchema.index({ status: 1, severity: 1, lastObservedAt: -1 });
+OpsAlertSchema.index({ kind: 1, lastObservedAt: -1 });
+
+OpsAlertSchema.add({
+  __invariants: { type: mongoose.Schema.Types.Mixed, select: false, default: null },
+});
+
+OpsAlertSchema.path('__invariants').validate(function () {
+  let ok = true;
+  if (!SEVERITIES.includes(this.severity)) {
+    this.invalidate('severity', `must be one of ${SEVERITIES.join(',')}`);
+    ok = false;
+  }
+  if (!STATUSES.includes(this.status)) {
+    this.invalidate('status', `must be one of ${STATUSES.join(',')}`);
+    ok = false;
+  }
+  if (this.status === 'acknowledged' && !this.acknowledgedAt) {
+    this.invalidate('acknowledgedAt', 'acknowledgedAt required when status=acknowledged');
+    ok = false;
+  }
+  if (this.status === 'resolved' && !this.resolvedAt) {
+    this.invalidate('resolvedAt', 'resolvedAt required when status=resolved');
+    ok = false;
+  }
+  return ok;
+});
+
+OpsAlertSchema.virtual('isOpen').get(function () {
+  return this.status === 'open';
+});
+
+OpsAlertSchema.set('toJSON', { virtuals: true });
+OpsAlertSchema.set('toObject', { virtuals: true });
+
+module.exports = mongoose.models.OpsAlert || mongoose.model('OpsAlert', OpsAlertSchema);
+
+module.exports.SEVERITIES = SEVERITIES;
+module.exports.STATUSES = STATUSES;
+module.exports.DELIVERY = DELIVERY;

--- a/backend/services/ops-alerter.js
+++ b/backend/services/ops-alerter.js
@@ -1,17 +1,24 @@
 /**
- * ops-alerter.js — thin wrapper that fans out an operational alert
- * (backup failure, DR verification failure, scheduler crash, …) to
- * the on-call admin via the existing unifiedNotifier.
+ * ops-alerter.js — fans out an operational alert (backup failure, DR
+ * verification failure, scheduler crash, …) to the on-call admin.
  *
- * Recipients come from env, so the alerter works even if the DB is
- * the thing that failed:
+ * W733 ROOT FIX — durable-first, deliver-best-effort:
+ *   1. ALWAYS persist an OpsAlert row (guaranteed sink — needs no external
+ *      secret; survives even when the DB-less email transport is down). This
+ *      closes the silent-drop gap: on prod SMTP_USER/SMTP_PASS are unset, so the
+ *      old email-only path lost every alert to a pm2 log line nobody watches.
+ *   2. THEN best-effort fan-out to OPS_ALERT_EMAIL / OPS_ALERT_PHONE via the
+ *      existing unifiedNotifier. Delivery outcome is written back onto the row.
+ *
+ * Recipients come from env (so the alerter works even if the DB is the thing
+ * that failed):
  *   OPS_ALERT_EMAIL       comma-separated emails
  *   OPS_ALERT_PHONE       comma-separated phones (whatsapp/sms)
  *   OPS_ALERT_CHANNELS    optional override, default "auto"
  *
- * If no recipients are configured the call is a no-op (logged at warn).
- * Errors inside the alerter NEVER throw — alerting must not mask the
- * original failure that triggered it.
+ * Errors inside the alerter NEVER throw — alerting must not mask the original
+ * failure that triggered it. The DB persist is itself wrapped: if it fails, we
+ * still attempt delivery and log, never throw.
  */
 
 'use strict';
@@ -25,20 +32,79 @@ function splitCsv(v) {
     .filter(Boolean);
 }
 
+// Map the caller's free severity onto the OpsAlert enum (low/medium/high/critical).
+function normalizeSeverity(s) {
+  const v = String(s || 'high').toLowerCase();
+  if (['low', 'medium', 'high', 'critical'].includes(v)) return v;
+  if (v === 'warning' || v === 'warn') return 'medium';
+  return 'high';
+}
+
+/**
+ * Durably record the alert. Returns the persisted doc (or null if persistence
+ * is unavailable — e.g. mongoose not connected). NEVER throws.
+ */
+async function persistOpsAlert({ kind, severity, subject, body, metadata }) {
+  try {
+    // Lazy require so a missing connection degrades gracefully (the call is
+    // wrapped) and so unit tests can mock the model module. The model file
+    // itself guards with `mongoose.models.OpsAlert || mongoose.model(...)`.
+    const OpsAlert = require('../models/OpsAlert');
+    const doc = await OpsAlert.create({
+      kind,
+      severity: normalizeSeverity(severity),
+      subject,
+      body: body || '',
+      metadata: metadata || {},
+      status: 'open',
+      delivery: 'pending',
+    });
+    return doc;
+  } catch (err) {
+    logger.error('[ops-alerter] durable persist failed (swallowed)', {
+      kind,
+      subject,
+      error: err.message,
+    });
+    return null;
+  }
+}
+
 async function sendOpsAlert({ kind, severity = 'high', subject, body, metadata }) {
+  // 1) Durable sink FIRST — the alert is now captured no matter what follows.
+  const record = await persistOpsAlert({ kind, severity, subject, body, metadata });
+
   const emails = splitCsv(process.env.OPS_ALERT_EMAIL);
   const phones = splitCsv(process.env.OPS_ALERT_PHONE);
   const channelOverride = process.env.OPS_ALERT_CHANNELS;
 
+  // Helper to stamp the delivery outcome back onto the durable row (best-effort).
+  async function recordDelivery(delivery, detail) {
+    if (!record) return;
+    try {
+      record.delivery = delivery;
+      if (detail) record.deliveryDetail = String(detail).slice(0, 1000);
+      await record.save();
+    } catch (err) {
+      logger.error('[ops-alerter] delivery-status update failed (swallowed)', {
+        kind,
+        error: err.message,
+      });
+    }
+  }
+
   if (emails.length === 0 && phones.length === 0) {
     logger.warn(
-      '[ops-alerter] no recipients configured (OPS_ALERT_EMAIL / OPS_ALERT_PHONE) — alert dropped',
-      {
-        kind,
-        subject,
-      }
+      '[ops-alerter] no external recipients (OPS_ALERT_EMAIL / OPS_ALERT_PHONE) — alert persisted (OpsAlert) but not emailed/SMSed',
+      { kind, subject, opsAlertId: record && String(record._id) }
     );
-    return { success: false, reason: 'no_recipients' };
+    await recordDelivery('no_recipients');
+    return {
+      success: false,
+      reason: 'no_recipients',
+      persisted: !!record,
+      opsAlertId: record && String(record._id),
+    };
   }
 
   const fullSubject = `[${severity.toUpperCase()}][${kind}] ${subject}`;
@@ -69,13 +135,21 @@ async function sendOpsAlert({ kind, severity = 'high', subject, body, metadata }
   }
 
   const anySuccess = results.some(r => r.success);
+  await recordDelivery(anySuccess ? 'delivered' : 'failed', anySuccess ? '' : 'all channels failed');
   logger.info('[ops-alerter] dispatched', {
     kind,
     severity,
     recipients: recipients.length,
     success: anySuccess,
+    persisted: !!record,
+    opsAlertId: record && String(record._id),
   });
-  return { success: anySuccess, results };
+  return {
+    success: anySuccess,
+    results,
+    persisted: !!record,
+    opsAlertId: record && String(record._id),
+  };
 }
 
 module.exports = { sendOpsAlert };

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -509,3 +509,5 @@ __tests__/scoring-mental-health-pain-wave706.test.js
 __tests__/scoring-mobility-caregiver-wave708.test.js
 __tests__/scoring-neuro-disability-wave721.test.js
 __tests__/tenant-routes-wiring-wave721.test.js
+__tests__/ops-alert-model-wave733.test.js
+tests/unit/ops-alerter.test.js

--- a/backend/tests/unit/ops-alerter.test.js
+++ b/backend/tests/unit/ops-alerter.test.js
@@ -12,6 +12,14 @@ jest.mock('../../services/unifiedNotifier', () => ({
   notify: (...args) => mockNotify(...args),
 }));
 
+// W733: durable OpsAlert sink. Mock the model so unit tests assert the
+// persist-first behavior without a live mongoose connection.
+const mockCreate = jest.fn();
+const mockSave = jest.fn();
+jest.mock('../../models/OpsAlert', () => ({
+  create: (...args) => mockCreate(...args),
+}));
+
 describe('services/ops-alerter', () => {
   let sendOpsAlert;
   const origEnv = { ...process.env };
@@ -19,6 +27,10 @@ describe('services/ops-alerter', () => {
   beforeEach(() => {
     jest.resetModules();
     mockNotify.mockReset();
+    mockCreate.mockReset();
+    mockSave.mockReset();
+    mockSave.mockResolvedValue(undefined);
+    mockCreate.mockResolvedValue({ _id: 'ops-1', save: mockSave });
     process.env = { ...origEnv };
     delete process.env.OPS_ALERT_EMAIL;
     delete process.env.OPS_ALERT_PHONE;
@@ -30,10 +42,34 @@ describe('services/ops-alerter', () => {
     process.env = origEnv;
   });
 
-  test('drops alert with no_recipients reason when env unset', async () => {
+  test('persists durably + reports no_recipients when env unset (no silent drop)', async () => {
     const r = await sendOpsAlert({ kind: 'k', subject: 's', body: 'b' });
-    expect(r).toEqual({ success: false, reason: 'no_recipients' });
+    expect(r.success).toBe(false);
+    expect(r.reason).toBe('no_recipients');
+    expect(r.persisted).toBe(true);
+    expect(r.opsAlertId).toBe('ops-1');
+    expect(mockCreate).toHaveBeenCalledTimes(1);
     expect(mockNotify).not.toHaveBeenCalled();
+    expect(mockSave).toHaveBeenCalledTimes(1); // delivery outcome stamped back
+  });
+
+  test('persists the alert with normalized fields even with no external sink', async () => {
+    await sendOpsAlert({ kind: 'backup_failed', severity: 'critical', subject: 's', body: 'b' });
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const arg = mockCreate.mock.calls[0][0];
+    expect(arg.kind).toBe('backup_failed');
+    expect(arg.severity).toBe('critical');
+    expect(arg.status).toBe('open');
+  });
+
+  test('never throws when the durable persist itself fails', async () => {
+    mockCreate.mockRejectedValue(new Error('db-down'));
+    process.env.OPS_ALERT_EMAIL = 'a@x.com';
+    mockNotify.mockResolvedValue({ success: true, results: [] });
+    const r = await sendOpsAlert({ kind: 'k', subject: 's', body: 'b' });
+    expect(r.persisted).toBe(false);
+    expect(r.success).toBe(true);
+    expect(mockNotify).toHaveBeenCalledTimes(1);
   });
 
   test('dispatches to each configured email + phone', async () => {


### PR DESCRIPTION
## Root-and-final fix for the silent-drop alert gap

While wiring `OPS_ALERT_*` on prod I discovered the alerter was **email-only**, and prod has **no SMTP credentials** (`SMTP_USER`/`SMTP_PASS` unset) → `unifiedNotifier` skips → **every backup-failure alert was lost** to a pm2 log line nobody watches. A nightly `mongodump` could fail forever, unseen.

## Fix — durable-first, deliver-best-effort
- **new `models/OpsAlert.js`**: persisted, queryable, lifecycle (open→acknowledged→resolved) sink — severity + delivery-outcome + 90-day TTL (PDPL, no PHI). Wave-18 invariants + `isOpen` virtual.
- **`ops-alerter.js`**: ALWAYS persists an OpsAlert **first** (no external secret needed), **then** best-effort email/SMS, stamping the outcome (`delivered`/`failed`/`no_recipients`) back on the row. Never throws. Return gains `{ persisted, opsAlertId }` (backward-compatible).
- **tests**: unit suite updated for the persist-first contract (no-recipients now PERSISTS, not drops) + new MongoMemoryServer behavioral guard. **13 tests**.

## Effect
Backup/DR-verify/scheduler failures are now **always captured + surfaceable in-app**, regardless of email creds. Email/SMS become a *bonus* channel that lights up the moment SMTP creds are provisioned — no longer a single point of failure. Companion prod change already live: `OPS_ALERT_EMAIL` → owner inbox.

## Verify
- `check:routes-load` ✓ 571 · `sync:sprint-paths` ✓ · 13 tests green.
- Note: the pre-existing `tests/unit/env-vars-documented` failure on main (99 undocumented, ceiling 0) is unrelated parallel-agent debt — this PR adds **no** new env var.

## Still owner-gated (separate, broader)
Actual email **delivery** on prod needs `SMTP_USER`+`SMTP_PASS` (Gmail app-password) — currently ALL prod transactional email silently no-ops. This PR makes ops alerts durable despite that; provisioning SMTP is a follow-up secret only the owner can supply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)