### PR TITLE
feat(email): W735 harden email transport — provider-aware, secret-tolerant, no races

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -860,6 +860,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/ops-alert-model-wave733.test.js'
       - 'backend/tests/unit/ops-alerter.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/email-transport-wave735.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1703,6 +1705,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/ops-alert-model-wave733.test.js'
       - 'backend/tests/unit/ops-alerter.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/email-transport-wave735.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/email-transport-wave735.test.js
+++ b/backend/__tests__/email-transport-wave735.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * W735 — email transport hardening (utils/emailService.setupEmailTransporter).
+ *
+ * Verifies provider resolution (SendGrid → SMTP → none), numeric port + correct
+ * `secure` for 465, the structured emailStatus(), resettable cache, and the
+ * creds-fingerprint rebuild. nodemailer.createTransport is mocked — no network.
+ */
+
+const mockCreateTransport = jest.fn(() => ({ verify: jest.fn().mockResolvedValue(true) }));
+jest.mock('nodemailer', () => ({ createTransport: (...a) => mockCreateTransport(...a) }));
+jest.mock('../utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+describe('W735 email transport', () => {
+  let email;
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.resetModules();
+    mockCreateTransport.mockClear();
+    process.env = { ...origEnv };
+    for (const k of ['SENDGRID_API_KEY', 'SMTP_USER', 'SMTP_PASS', 'SMTP_HOST', 'SMTP_PORT']) {
+      delete process.env[k];
+    }
+    email = require('../utils/emailService');
+    email.resetEmailTransporter();
+  });
+
+  afterAll(() => {
+    process.env = origEnv;
+  });
+
+  test('returns null + structured reason when nothing is configured (no silent throw)', () => {
+    const t = email.setupEmailTransporter();
+    expect(t).toBeNull();
+    const s = email.emailStatus();
+    expect(s.configured).toBe(false);
+    expect(s.provider).toBe('none');
+    expect(s.reason).toMatch(/no_credentials/);
+  });
+
+  test('prefers SendGrid when SENDGRID_API_KEY is set', () => {
+    process.env.SENDGRID_API_KEY = 'SG.abc123xyz';
+    const t = email.setupEmailTransporter();
+    expect(t).not.toBeNull();
+    expect(email.emailStatus().provider).toBe('sendgrid');
+    const cfg = mockCreateTransport.mock.calls[0][0];
+    expect(cfg.host).toBe('smtp.sendgrid.net');
+    expect(cfg.auth.user).toBe('apikey');
+  });
+
+  test('SMTP: port is numeric and secure is true only for 465', () => {
+    process.env.SMTP_USER = 'u@x.com';
+    process.env.SMTP_PASS = 'pw';
+    process.env.SMTP_PORT = '465';
+    email.setupEmailTransporter();
+    const cfg = mockCreateTransport.mock.calls[0][0];
+    expect(cfg.port).toBe(465);
+    expect(typeof cfg.port).toBe('number'); // was a string before W735
+    expect(cfg.secure).toBe(true); // was hardcoded false before W735
+    expect(email.emailStatus().provider).toBe('smtp');
+  });
+
+  test('SMTP: port 587 → secure false', () => {
+    process.env.SMTP_USER = 'u@x.com';
+    process.env.SMTP_PASS = 'pw';
+    process.env.SMTP_PORT = '587';
+    email.setupEmailTransporter();
+    expect(mockCreateTransport.mock.calls[0][0].secure).toBe(false);
+  });
+
+  test('caches the transporter (one build) until creds change, then rebuilds', () => {
+    process.env.SMTP_USER = 'u@x.com';
+    process.env.SMTP_PASS = 'pw';
+    email.setupEmailTransporter();
+    email.setupEmailTransporter();
+    expect(mockCreateTransport).toHaveBeenCalledTimes(1); // cached
+    process.env.SENDGRID_API_KEY = 'SG.now-configured'; // creds change
+    email.setupEmailTransporter();
+    expect(mockCreateTransport).toHaveBeenCalledTimes(2); // rebuilt on fingerprint change
+    expect(email.emailStatus().provider).toBe('sendgrid');
+  });
+
+  test('resetEmailTransporter clears the cache', () => {
+    process.env.SMTP_USER = 'u@x.com';
+    process.env.SMTP_PASS = 'pw';
+    email.setupEmailTransporter();
+    email.resetEmailTransporter();
+    expect(email.emailStatus().configured).toBe(false);
+    email.setupEmailTransporter();
+    expect(mockCreateTransport).toHaveBeenCalledTimes(2); // rebuilt after reset
+  });
+});

--- a/backend/services/emailService.js
+++ b/backend/services/emailService.js
@@ -38,6 +38,8 @@ async function sendEmail({ to, subject, body, html, text, ...rest } = {}) {
 Object.assign(sendEmail, {
   sendEmail,
   setupEmailTransporter: utilsEmail.setupEmailTransporter,
+  resetEmailTransporter: utilsEmail.resetEmailTransporter,
+  emailStatus: utilsEmail.emailStatus,
   sendNewCommunicationEmail: utilsEmail.sendNewCommunicationEmail,
   sendApprovalRequestEmail: utilsEmail.sendApprovalRequestEmail,
   sendStatusChangeEmail: utilsEmail.sendStatusChangeEmail,

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -511,3 +511,4 @@ __tests__/scoring-neuro-disability-wave721.test.js
 __tests__/tenant-routes-wiring-wave721.test.js
 __tests__/ops-alert-model-wave733.test.js
 tests/unit/ops-alerter.test.js
+__tests__/email-transport-wave735.test.js

--- a/backend/utils/emailService.js
+++ b/backend/utils/emailService.js
@@ -1,44 +1,111 @@
 const nodemailer = require('nodemailer');
 const logger = require('./logger');
 
-// إنشاء transporter
+// W735: cached transporter + a structured reason for diagnostics. The cache key
+// is the resolved provider+creds fingerprint, so a credential change at runtime
+// (e.g. after a pm2 restart that re-reads .env) rebuilds instead of serving a
+// stale/null transporter forever (the old `if (transporter) return` bug).
 let transporter = null;
+let transporterFingerprint = null;
+let lastStatus = { configured: false, provider: 'none', reason: 'not_initialized' };
+
+/** Snapshot of why email is/ isn't configured — for ops diagnostics + self-tests. */
+function emailStatus() {
+  return { ...lastStatus };
+}
+
+/** Reset the cached transporter (forces re-resolution on next setup). */
+function resetEmailTransporter() {
+  transporter = null;
+  transporterFingerprint = null;
+  lastStatus = { configured: false, provider: 'none', reason: 'reset' };
+}
+
+function currentFingerprint() {
+  // What inputs determine the transport — change ⇒ rebuild.
+  return [
+    process.env.SENDGRID_API_KEY ? 'sg:' + process.env.SENDGRID_API_KEY.slice(-6) : '',
+    process.env.SMTP_HOST || '',
+    process.env.SMTP_PORT || '',
+    process.env.SMTP_USER || '',
+    process.env.SMTP_PASS ? 'pw' : '',
+  ].join('|');
+}
 
 /**
- * إعداد البريد الإلكتروني
+ * إعداد البريد الإلكتروني — provider-aware, secret-tolerant.
+ *
+ * Resolution order:
+ *   1. SendGrid (SENDGRID_API_KEY) — API transport, easiest to credential.
+ *   2. SMTP (SMTP_USER + SMTP_PASS) — Gmail/relay; numeric port + correct
+ *      `secure` for 465.
+ *   3. none → returns null with a structured reason (caller skips gracefully).
+ *
+ * W735 fixes: string-port → Number; secure auto-derived from port; SendGrid
+ * fallback; resettable cache keyed on a creds fingerprint; no fire-and-forget
+ * verify race (verify is best-effort + non-nulling — a transient verify blip no
+ * longer discards a working transporter).
  */
 function setupEmailTransporter() {
-  if (transporter) return transporter;
+  const fp = currentFingerprint();
+  if (transporter && transporterFingerprint === fp) return transporter;
+  // inputs changed (or first call) → rebuild
+  transporter = null;
+  transporterFingerprint = fp;
 
-  const emailConfig = {
-    host: process.env.SMTP_HOST || 'smtp.gmail.com',
-    port: process.env.SMTP_PORT || 587,
-    secure: false, // true for 465, false for other ports
-    auth: {
-      user: process.env.SMTP_USER,
-      pass: process.env.SMTP_PASS,
-    },
-  };
-
-  // إذا لم تكن الإعدادات موجودة، استخدم Ethereal (للتطوير)
-  if (!process.env.SMTP_USER || !process.env.SMTP_PASS) {
-    logger.warn('⚠️  Email credentials not configured. Using test account.');
-    return null;
+  // 1) SendGrid API transport (preferred — single API key, no SMTP auth dance).
+  if (process.env.SENDGRID_API_KEY) {
+    try {
+      transporter = nodemailer.createTransport({
+        host: 'smtp.sendgrid.net',
+        port: 587,
+        secure: false,
+        auth: { user: 'apikey', pass: process.env.SENDGRID_API_KEY },
+      });
+      lastStatus = { configured: true, provider: 'sendgrid', reason: 'ok' };
+      return transporter;
+    } catch (err) {
+      logger.error('[emailService] SendGrid transport build failed', { error: err.message });
+      // fall through to SMTP
+    }
   }
 
-  transporter = nodemailer.createTransport(emailConfig);
+  // 2) SMTP (Gmail / generic relay).
+  if (process.env.SMTP_USER && process.env.SMTP_PASS) {
+    const port = Number(process.env.SMTP_PORT) || 587;
+    transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST || 'smtp.gmail.com',
+      port,
+      secure: port === 465, // implicit TLS only on 465 (was hardcoded false — broke SSL)
+      auth: { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS },
+    });
+    lastStatus = { configured: true, provider: 'smtp', reason: 'ok' };
 
-  // التحقق من الاتصال
-  transporter.verify((error, _success) => {
-    if (error) {
-      logger.error('❌ Email configuration error:', error);
-      transporter = null;
-    } else {
-      // console.log('✅ Email server is ready to send messages');
+    // Best-effort connectivity check — log only, never null a built transporter
+    // (the old code nulled it from an async callback AFTER returning it = race).
+    if (typeof transporter.verify === 'function') {
+      Promise.resolve()
+        .then(() => transporter.verify())
+        .then(() => logger.info('[emailService] SMTP transport verified'))
+        .catch(err =>
+          logger.warn('[emailService] SMTP verify failed (transport kept; will retry on send)', {
+            error: err.message,
+          })
+        );
     }
-  });
+    return transporter;
+  }
 
-  return transporter;
+  // 3) Nothing configured.
+  lastStatus = {
+    configured: false,
+    provider: 'none',
+    reason: 'no_credentials (set SENDGRID_API_KEY, or SMTP_USER + SMTP_PASS)',
+  };
+  logger.warn(
+    '⚠️  Email transport not configured — set SENDGRID_API_KEY or SMTP_USER+SMTP_PASS. Email will be skipped (durably logged where applicable).'
+  );
+  return null;
 }
 
 /**
@@ -251,6 +318,8 @@ async function sendStatusChangeEmail(communication, recipientEmail, oldStatus, n
 
 module.exports = {
   setupEmailTransporter,
+  resetEmailTransporter,
+  emailStatus,
   sendNewCommunicationEmail,
   sendApprovalRequestEmail,
   sendStatusChangeEmail,


### PR DESCRIPTION
Develops the email unit (`utils/emailService.setupEmailTransporter`) — the layer behind the prod "all transactional email silently no-ops" gap. **Six real defects fixed, none needing a secret:**

| # | defect | fix |
|---|---|---|
| 1 | Gmail-SMTP only | **provider fallback**: SendGrid (`SENDGRID_API_KEY`) → SMTP (`SMTP_USER`+`SMTP_PASS`) → none. SendGrid = API key, far easier to credential than a Gmail app-password |
| 2 | `port` was the string `'587'` | `Number(SMTP_PORT)` |
| 3 | `secure` hardcoded `false` (broke 465 SSL) | `secure = (port === 465)` |
| 4 | `verify(cb)` nulled the transporter from an async callback **after** caching it (race — a transient blip discarded a working transport) | verify is best-effort + log-only, never nulls |
| 5 | `if (transporter) return` cached forever — creds change never re-resolved | **resettable cache** keyed on a creds fingerprint → rebuilds after a pm2-restart .env reload |
| 6 | no signal for *why* email is down | `emailStatus(){configured,provider,reason}` + `resetEmailTransporter()`, surfaced through `services/emailService` for ops diagnostics |

Backward-compatible (returns transporter-or-null; all exports preserved). **6 new unit tests** (provider resolution, port/secure, status, reset, fingerprint rebuild — nodemailer mocked, no network); existing email + ops-alerter + notify suites still green (**35 tests**).

Companion to **W733** (durable OpsAlert sink): together, ops alerts are durable AND the moment `SENDGRID_API_KEY` (or SMTP creds) is set, delivery lights up correctly — no code change needed at that point.

Guards: `sync:sprint-paths` ✓ · `check:routes-load` ✓ (571) · 41 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)