### PR TITLE
feat(ops): W737 wire backup-failure → durable ops alert

### DIFF
--- a/backend/__tests__/db-backup-cron-wave676.test.js
+++ b/backend/__tests__/db-backup-cron-wave676.test.js
@@ -73,3 +73,20 @@ describe('W676 — wired into app.js', () => {
     );
   });
 });
+
+describe('W737 — backup failure fires a durable ops alert', () => {
+  it('both failure branches call safeOpsAlert (no more silent log-only failure)', () => {
+    // the soft-fail (res.success false) branch + the thrown-exception branch
+    const alertCalls = (BOOT_SRC.match(/safeOpsAlert\(/g) || []).length;
+    expect(alertCalls).toBeGreaterThanOrEqual(3); // 1 def + 2 call sites
+  });
+  it('safeOpsAlert lazy-requires ops-alerter and is fully swallowed', () => {
+    expect(BOOT_SRC).toMatch(/require\(\s*'\.\.\/services\/ops-alerter'\s*\)/);
+    expect(BOOT_SRC).toMatch(/async function safeOpsAlert/);
+    expect(BOOT_SRC).toMatch(/ops-alert dispatch failed \(swallowed\)/);
+  });
+  it('alerts are critical severity + kind=backup_failed', () => {
+    expect(BOOT_SRC).toMatch(/kind:\s*'backup_failed'/);
+    expect(BOOT_SRC).toMatch(/severity:\s*'critical'/);
+  });
+});

--- a/backend/startup/databaseBackupBootstrap.js
+++ b/backend/startup/databaseBackupBootstrap.js
@@ -61,6 +61,20 @@ function wireDatabaseBackup(app, deps = {}) {
   const schedule = process.env.DB_BACKUP_CRON_SCHEDULE || '0 2 * * *';
   const TZ = { timezone: 'Asia/Riyadh' };
 
+  // W737: fire a durable ops alert (OpsAlert row + best-effort email/SMS) on a
+  // backup failure. Lazy-required + fully guarded — alerting must NEVER throw
+  // inside the cron and mask the original backup failure.
+  async function safeOpsAlert(payload) {
+    try {
+      const { sendOpsAlert } = require('../services/ops-alerter');
+      await sendOpsAlert(payload);
+    } catch (alertErr) {
+      logger.error('[db-backup] ops-alert dispatch failed (swallowed)', {
+        error: alertErr && alertErr.message,
+      });
+    }
+  }
+
   cron.schedule(
     schedule,
     async () => {
@@ -74,7 +88,16 @@ function wireDatabaseBackup(app, deps = {}) {
             `[db-backup] backup complete: ${(res.meta && res.meta.backupName) || res.backupPath}`
           );
         } else {
-          logger.error(`[db-backup] backup failed: ${(res && res.error) || 'unknown error'}`);
+          const reason = (res && res.error) || 'unknown error';
+          logger.error(`[db-backup] backup failed: ${reason}`);
+          // W737: durable + on-call alert (never silently lost — see W733/W735).
+          await safeOpsAlert({
+            kind: 'backup_failed',
+            severity: 'critical',
+            subject: 'Nightly DB backup FAILED',
+            body: `The scheduled MongoDB backup did not complete.\nReason: ${reason}\nSchedule: ${schedule} Asia/Riyadh.\nAction: verify mongodump + disk space on the VPS, then re-run npm run db:backup.`,
+            metadata: { reason, schedule, stage: 'createBackup' },
+          });
         }
         try {
           const pruned = cleanupOldBackups();
@@ -84,6 +107,14 @@ function wireDatabaseBackup(app, deps = {}) {
         }
       } catch (err) {
         logger.error('[db-backup] scheduled backup failed', err);
+        // W737: a thrown backup error is the worst case — alert durably.
+        await safeOpsAlert({
+          kind: 'backup_failed',
+          severity: 'critical',
+          subject: 'Nightly DB backup CRASHED',
+          body: `The scheduled MongoDB backup threw an exception.\nError: ${err && err.message}\nSchedule: ${schedule} Asia/Riyadh.`,
+          metadata: { error: err && err.message, schedule, stage: 'exception' },
+        });
       }
     },
     TZ


### PR DESCRIPTION
Connects the W676 backup cron to the alerting system (W733 durable OpsAlert + W735 hardened email) — closing the last link of the DR chain.

## Gap
The backup cron only `logger.error`'d on failure. So even with the durable sink + hardened email in place, a **failed nightly backup still paged no one** (just a pm2 log line). The producer was never wired to the alerter.

## Fix
Both failure branches — soft-fail (`res.success=false`) **and** thrown exception — now call a guarded `safeOpsAlert()` → `sendOpsAlert({ kind:'backup_failed', severity:'critical', ... })`:
- **durable OpsAlert row** written always (no secret needed), **plus** best-effort email/SMS.
- `safeOpsAlert` lazy-requires ops-alerter and swallows its own errors — alerting must never throw inside the cron and mask the original backup failure.
- W676 drift guard extended (+3 assertions → 10 tests): both branches alert, lazy-require + swallow contract, critical/`backup_failed` shape.

## Result — DR chain now end-to-end
`backup fails → durable OpsAlert (always, surfaceable in-app) → email/SMS the moment SENDGRID_API_KEY or SMTP creds exist`. `check:routes-load` ✓ (test already sprint-enumerated under W676).

🤖 Generated with [Claude Code](https://claude.com/claude-code)