### PR TITLE
feat(reporting): W762 activate the dormant Phase-10 reporting platform

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -862,6 +862,8 @@ on:
       - 'backend/tests/unit/ops-alerter.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/email-transport-wave735.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/reporting-scheduler-bootstrap-wave762.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1707,6 +1709,8 @@ on:
       - 'backend/tests/unit/ops-alerter.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/email-transport-wave735.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/reporting-scheduler-bootstrap-wave762.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/reporting-scheduler-bootstrap-wave762.test.js
+++ b/backend/__tests__/reporting-scheduler-bootstrap-wave762.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * W762 drift guard — reportingSchedulerBootstrap.
+ *
+ * Locks the wire that activates the dormant Phase-10 reporting platform
+ * (buildReportingPlatform + ReportsScheduler were fully built but never
+ * .start()'d → scheduled reports never ran; W225 dormant-capability pattern):
+ *   • env-gated on ENABLE_REPORT_SCHEDULER (inert default → {started:false})
+ *   • requires logger; throws without it
+ *   • builds the platform via services/reporting + node-cron (loadOptional) and
+ *     calls .start()
+ *   • fully guarded — wiring errors swallowed, never break boot
+ *   • wired into app.js
+ *
+ * Static source reads + an inert behavioral call (never starts a real cron).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const BOOT_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'startup', 'reportingSchedulerBootstrap.js'),
+  'utf8'
+);
+const APP_SRC = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+
+describe('W762 reportingSchedulerBootstrap — source shape', () => {
+  it('is env-gated on ENABLE_REPORT_SCHEDULER', () => {
+    expect(BOOT_SRC).toMatch(/process\.env\.ENABLE_REPORT_SCHEDULER\s*!==\s*'true'/);
+  });
+  it('builds the reporting platform + starts it', () => {
+    expect(BOOT_SRC).toMatch(/loadOptional\(\s*'\.\.\/services\/reporting'\s*\)/);
+    expect(BOOT_SRC).toMatch(/\.buildReportingPlatform\(/);
+    expect(BOOT_SRC).toMatch(/platform\.start\(\)/);
+  });
+  it('uses node-cron via loadOptional (setInterval fallback when absent)', () => {
+    expect(BOOT_SRC).toMatch(/loadOptional\(\s*'node-cron'\s*\)/);
+  });
+  it('feeds the W735-hardened email channel into communication', () => {
+    expect(BOOT_SRC).toMatch(/loadOptional\(\s*'\.\.\/services\/emailService'\s*\)/);
+    expect(BOOT_SRC).toMatch(/communication:\s*\{\s*emailService\s*\}/);
+  });
+  it('swallows wiring errors (never breaks boot)', () => {
+    expect(BOOT_SRC).toMatch(/wiring failed \(swallowed\)/);
+  });
+  it('exports wireReportingScheduler', () => {
+    expect(BOOT_SRC).toMatch(/module\.exports\s*=\s*\{\s*wireReportingScheduler\s*\}/);
+  });
+});
+
+describe('W762 reportingSchedulerBootstrap — inert default behavior', () => {
+  const { wireReportingScheduler } = require('../startup/reportingSchedulerBootstrap');
+  const silentLogger = { info: () => {}, warn: () => {}, error: () => {} };
+
+  it('throws without a logger', () => {
+    expect(() => wireReportingScheduler({}, {})).toThrow(/logger required/);
+  });
+
+  it('does NOT start when ENABLE_REPORT_SCHEDULER is unset (inert default)', () => {
+    const prev = process.env.ENABLE_REPORT_SCHEDULER;
+    delete process.env.ENABLE_REPORT_SCHEDULER;
+    try {
+      const res = wireReportingScheduler({ set: () => {} }, { logger: silentLogger });
+      expect(res).toEqual({ started: false });
+    } finally {
+      if (prev !== undefined) process.env.ENABLE_REPORT_SCHEDULER = prev;
+    }
+  });
+});
+
+describe('W762 — wired into app.js', () => {
+  it('app.js calls wireReportingScheduler', () => {
+    expect(APP_SRC).toMatch(
+      /reportingSchedulerBootstrap'\)\.wireReportingScheduler\(app,\s*\{\s*logger\s*\}\)/
+    );
+  });
+});

--- a/backend/app.js
+++ b/backend/app.js
@@ -2098,6 +2098,10 @@ require('./startup/clinicalSweepersBootstrap').wireClinicalSweepers(app, { logge
 // `no_backup_found` gap: feeds backups/mongodb (the dir dr-verify.js scans).
 // Inert until ENABLE_DB_BACKUP_CRON=true + mongodump present on host.
 require('./startup/databaseBackupBootstrap').wireDatabaseBackup(app, { logger });
+// W762 — activate the DORMANT Phase-10 reporting platform (engine + scheduler were
+// fully built but never .start()'d → scheduled reports never ran, ReportSchedule
+// had no consumer). Env-gated, default OFF (ENABLE_REPORT_SCHEDULER=true).
+require('./startup/reportingSchedulerBootstrap').wireReportingScheduler(app, { logger });
 // W695 — module-gap overdue/review sweepers for the W680-W693 arc (P&O follow-ups,
 // sensory-diet review-due, sponsorship expiry, VFSS pending results). All read-only,
 // independently env-gated (ENABLE_*_SWEEPER), default OFF.

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -512,3 +512,4 @@ __tests__/tenant-routes-wiring-wave721.test.js
 __tests__/ops-alert-model-wave733.test.js
 tests/unit/ops-alerter.test.js
 __tests__/email-transport-wave735.test.js
+__tests__/reporting-scheduler-bootstrap-wave762.test.js

--- a/backend/startup/reportingSchedulerBootstrap.js
+++ b/backend/startup/reportingSchedulerBootstrap.js
@@ -1,0 +1,95 @@
+'use strict';
+
+/**
+ * reportingSchedulerBootstrap.js — W762.
+ *
+ * Activates the DORMANT Phase-10 reporting platform. Everything is already
+ * built — `services/reporting/index.js::buildReportingPlatform()` wires the
+ * ReportingEngine + ReportsScheduler + ReportsOpsScheduler + channels +
+ * recipient resolver, and `scheduler/reports.scheduler.js` runs
+ * `engine.runInstance()` per periodicity off `config/report.catalog`'s
+ * PERIODICITY_CRON. But NOTHING ever called the factory's `.start()` at boot,
+ * so scheduled reports never executed and ReportSchedule rows had no consumer
+ * (W225 dormant-capability pattern — built, never wired).
+ *
+ * This bootstrap is the missing wire: it constructs the platform with prod deps
+ * (mongoose models + the W735-hardened email channel + node-cron) and starts it.
+ *
+ * GATED OFF BY DEFAULT — ships inert; nothing runs until an operator opts in:
+ *   ENABLE_REPORT_SCHEDULER='true'   → start the periodic + ops schedulers
+ *
+ * Fully guarded: any wiring error is logged and swallowed so a reporting-platform
+ * load problem can never break app boot.
+ */
+
+function loadOptional(modulePath) {
+  try {
+    return require(modulePath);
+  } catch {
+    return null;
+  }
+}
+
+function wireReportingScheduler(app, deps = {}) {
+  const { logger } = deps;
+  if (!logger) {
+    throw new Error('reportingSchedulerBootstrap.wireReportingScheduler: logger required');
+  }
+
+  if (process.env.ENABLE_REPORT_SCHEDULER !== 'true') {
+    logger.info(
+      '[startup] reporting scheduler disabled (set ENABLE_REPORT_SCHEDULER=true to activate periodic report execution)'
+    );
+    return { started: false };
+  }
+
+  try {
+    const platformMod = loadOptional('../services/reporting');
+    if (!platformMod || typeof platformMod.buildReportingPlatform !== 'function') {
+      logger.warn('[startup] reporting platform not available; scheduler not started');
+      return { started: false };
+    }
+
+    const cron = loadOptional('node-cron'); // undefined → factory falls back to setInterval
+    const mongoose = require('mongoose');
+
+    // Resolve models lazily by name — registered by boot time. A missing model
+    // degrades gracefully (the resolver/channels treat it as absent).
+    const model = name => {
+      try {
+        return mongoose.model(name);
+      } catch {
+        return null;
+      }
+    };
+
+    // The W735-hardened email transport is the platform's email channel.
+    const emailService = loadOptional('../services/emailService');
+
+    const platform = platformMod.buildReportingPlatform({
+      models: {
+        Notification: model('Notification'),
+        Beneficiary: model('Beneficiary'),
+        Guardian: model('Guardian'),
+        User: model('User'),
+        Employee: model('Employee'),
+        Session: model('Session'),
+      },
+      communication: { emailService },
+      cron, // undefined in test/no-cron envs → scheduler uses setInterval
+      logger,
+    });
+
+    platform.start();
+    app && app.set && app.set('reportingPlatform', platform); // expose for ops/status if needed
+    logger.info('[startup] W762 reporting scheduler started (periodic + ops schedulers active)');
+    return { started: true, platform };
+  } catch (err) {
+    logger.error('[startup] reporting scheduler wiring failed (swallowed)', {
+      error: err && err.message,
+    });
+    return { started: false, error: err && err.message };
+  }
+}
+
+module.exports = { wireReportingScheduler };


### PR DESCRIPTION
## What

Activates the **dormant Phase-10 reporting platform**. Everything was already built but never started at boot:

- `services/reporting/index.js::buildReportingPlatform()` wires the ReportingEngine + ReportsScheduler + ReportsOpsScheduler + channels + recipient resolver.
- `scheduler/reports.scheduler.js` runs `engine.runInstance()` per periodicity off `config/report.catalog`'s `PERIODICITY_CRON`.
- **But nothing ever called the factory's `.start()`** → scheduled reports never executed and `ReportSchedule` rows had no consumer (W225 dormant-capability pattern).

This PR adds the missing wire: `startup/reportingSchedulerBootstrap.js` constructs the platform with prod deps (mongoose models + the W735-hardened email channel + node-cron) and starts it.

## Safety

- **Env-gated, default OFF** — `ENABLE_REPORT_SCHEDULER=true` to activate. Ships inert.
- **Fully guarded** — any wiring/load error is logged and swallowed; can never break app boot.
- **Purely additive** — 182 insertions, 0 deletions. One new bootstrap + one wire line in `app.js` after the W676 backup bootstrap.

## Tests

Drift guard `reporting-scheduler-bootstrap-wave762.test.js` (9 tests, enumerated in `sprint-tests.txt`):
- env-gated inert default `{started:false}`
- throws without logger
- builds + `.start()`s the platform
- feeds the W735 email channel into `communication`
- swallows wiring errors
- wired into `app.js`

## Gates

`check:routes-load` ✓ (571 files) · `check:sprint-paths` ✓ (in sync) · W762 collision-free (pushed with `CHECK_WAVE_SKIP=1` only because main carries pre-existing squash-merge wave-dupes W556/W699/W706-721, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)