### PR TITLE
feat(backend): W780 wire legacy /api/v1/purchasing to Vendor, PO, and PR lifecycle

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -933,6 +933,9 @@ on:
       - 'backend/__tests__/reporting-scheduler-bootstrap-wave762.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/registry-mount-resilience-wave778.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-vendor-order-wave780.test.js'
+      - 'backend/__tests__/purchasing-routes-real-data-wave780.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1849,6 +1852,9 @@ on:
       - 'backend/__tests__/reporting-scheduler-bootstrap-wave762.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/registry-mount-resilience-wave778.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-vendor-order-wave780.test.js'
+      - 'backend/__tests__/purchasing-routes-real-data-wave780.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/purchasing-routes-real-data-wave780.test.js
+++ b/backend/__tests__/purchasing-routes-real-data-wave780.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * purchasing-routes-real-data-wave780.test.js — W780 drift guard.
+ * purchasing.routes must not return hollow vendor/order stubs.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PURCHASING = fs.readFileSync(
+  path.join(__dirname, '..', 'routes', 'purchasing.routes.js'),
+  'utf8'
+);
+
+describe('W780 — purchasing routes wired to adapter', () => {
+  it('no placeholder _id: new responses for vendors or orders', () => {
+    expect(PURCHASING).not.toMatch(/_id:\s*['"]new['"]/);
+  });
+
+  it('vendors GET delegates to adapter.listVendors', () => {
+    expect(PURCHASING).toMatch(/adapter\.listVendors/);
+    expect(PURCHASING).not.toMatch(/\/vendors[\s\S]*?data:\s*\[\s*\]/);
+  });
+
+  it('orders expose /approve before generic :id handlers', () => {
+    const approveIdx = PURCHASING.indexOf("'/orders/:id/approve'");
+    const getByIdIdx = PURCHASING.indexOf("router.get(\n  '/orders/:id'");
+    expect(approveIdx).toBeGreaterThan(-1);
+    expect(getByIdIdx).toBeGreaterThan(approveIdx);
+  });
+
+  it('orders use adapter for create, approve, receive', () => {
+    expect(PURCHASING).toMatch(/adapter\.createOrder/);
+    expect(PURCHASING).toMatch(/adapter\.approveOrder/);
+    expect(PURCHASING).toMatch(/adapter\.receiveOrder/);
+  });
+
+  it('PUT /requests/:id updates draft via adapter (no echo stub)', () => {
+    expect(PURCHASING).toMatch(/adapter\.updateRequest/);
+    expect(PURCHASING).not.toMatch(
+      /router\.put\([\s\S]*?\/requests\/:id[\s\S]*?\{\s*_id:\s*req\.params\.id,\s*\.\.\.req\.body\s*\}/
+    );
+  });
+
+  it('requests expose submit + convert-to-po and POST approve alias', () => {
+    expect(PURCHASING).toMatch(/adapter\.submitRequest/);
+    expect(PURCHASING).toMatch(/adapter\.convertRequestToPo/);
+    expect(PURCHASING).toMatch(/\/requests\/:id\/submit/);
+    expect(PURCHASING).toMatch(/\/requests\/:id\/convert-to-po/);
+    expect(PURCHASING).toMatch(/router\.post\(\s*\n\s*'\/requests\/:id\/approve'/);
+  });
+});

--- a/backend/__tests__/purchasing-vendor-order-wave780.test.js
+++ b/backend/__tests__/purchasing-vendor-order-wave780.test.js
@@ -1,0 +1,168 @@
+'use strict';
+
+/**
+ * purchasing-vendor-order-wave780.test.js — W780 Vendor + PO adapter behavioral.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(30000);
+
+const mongoose = require('mongoose');
+const fs = require('fs');
+const path = require('path');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const adapter = require('../services/purchasingAdapter.service');
+
+let mongod;
+
+beforeAll(async () => {
+  const URI_FILE = path.join(__dirname, '..', '.test-mongo-uri');
+  let uri;
+  if (fs.existsSync(URI_FILE)) {
+    uri = fs.readFileSync(URI_FILE, 'utf-8').trim();
+  } else {
+    mongod = await MongoMemoryServer.create({ instance: { dbName: 'w780-purchasing' } });
+    uri = mongod.getUri();
+  }
+  await mongoose.connect(uri);
+  require('../models/Vendor');
+  require('../models/inventory/PurchaseOrder');
+  require('../models/operations/PurchaseRequest.model');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+beforeEach(async () => {
+  const Vendor = require('../models/Vendor');
+  const Po = require('../models/inventory/PurchaseOrder');
+  const PR = require('../models/operations/PurchaseRequest.model');
+  await Vendor.deleteMany({});
+  await Po.deleteMany({});
+  await PR.deleteMany({});
+});
+
+describe('W780 behavioral — vendors', () => {
+  it('creates, lists, updates, and soft-deletes vendors', async () => {
+    const created = await adapter.createVendor({
+      name: 'مورد تجريبي',
+      email: 'v@test.local',
+      phone: '0500000000',
+      city: 'الرياض',
+      type: 'company',
+      paymentTerms: 'net30',
+    });
+    expect(created._id).toBeTruthy();
+    expect(created.name).toBe('مورد تجريبي');
+    expect(created.isActive).toBe(true);
+    expect(created.vendorNumber).toMatch(/^VND-/);
+
+    const list = await adapter.listVendors();
+    expect(list).toHaveLength(1);
+
+    const updated = await adapter.updateVendor(created._id, { isActive: false });
+    expect(updated.isActive).toBe(false);
+
+    await adapter.deleteVendor(created._id);
+    const after = await adapter.listVendors();
+    expect(after).toHaveLength(0);
+  });
+});
+
+describe('W780 behavioral — purchase orders', () => {
+  it('creates, approves, receives, and lists orders with legacy shape', async () => {
+    const actorId = new mongoose.Types.ObjectId();
+    const created = await adapter.createOrder(
+      {
+        vendor: 'مورد الأثاث',
+        items: [{ itemName: 'كرسي', quantity: 2, unitCost: 100 }],
+      },
+      actorId
+    );
+    expect(created.orderNumber).toMatch(/^PO-/);
+    expect(created.vendor).toBe('مورد الأثاث');
+    expect(created.status).toBe('draft');
+    expect(created.items).toBe(1);
+
+    const approved = await adapter.approveOrder(created._id, actorId);
+    expect(approved.status).toBe('approved');
+
+    const received = await adapter.receiveOrder(created._id, actorId);
+    expect(received.status).toBe('received');
+
+    const rows = await adapter.listOrders();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].totalAmount).toBeGreaterThan(0);
+  });
+});
+
+describe('W780 behavioral — PR draft update', () => {
+  it('updateRequest patches draft only', async () => {
+    const actorId = new mongoose.Types.ObjectId();
+    const created = await adapter.createRequest(
+      {
+        items: [{ itemName: 'قديم', quantity: 1, estimatedUnitPrice: 10 }],
+        requiredDate: new Date(Date.now() + 86400000).toISOString(),
+      },
+      actorId
+    );
+    const updated = await adapter.updateRequest(
+      created._id,
+      { items: [{ itemName: 'جديد', quantity: 2, estimatedUnitPrice: 15 }] },
+      actorId
+    );
+    expect(updated.title).toMatch(/جديد/);
+
+    await adapter.submitRequest(created._id, { actorId });
+    await expect(
+      adapter.updateRequest(created._id, { items: [{ itemName: 'x', quantity: 1 }] }, actorId)
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+  });
+});
+
+describe('W780 behavioral — PR submit + convert-to-po', () => {
+  it('approved PR converts to inventory PO via ops service', async () => {
+    const actorId = new mongoose.Types.ObjectId();
+    const created = await adapter.createRequest(
+      {
+        items: [{ itemName: 'حبر', quantity: 5, estimatedUnitPrice: 20 }],
+        requiredDate: new Date(Date.now() + 86400000).toISOString(),
+      },
+      actorId
+    );
+    await adapter.submitRequest(created._id, { actorId });
+    await adapter.approveRequest(created._id, {
+      approverId: actorId,
+      approverName: 'Test',
+      role: 'department_head',
+    });
+    const { request, order } = await adapter.convertRequestToPo(created._id, {
+      actorId,
+      supplierName: 'مورد الحبر',
+    });
+    expect(request.status).toBe('converted_to_po');
+    expect(order.orderNumber).toMatch(/^PO-/);
+    expect(order.vendor).toBe('مورد الحبر');
+
+    const orders = await adapter.listOrders();
+    expect(orders.some(o => String(o._id) === String(order._id))).toBe(true);
+  });
+});
+
+describe('W780 behavioral — stats', () => {
+  it('getStats counts vendors and spend from real collections', async () => {
+    const actorId = new mongoose.Types.ObjectId();
+    await adapter.createVendor({ name: 'A', email: 'a@t.com' });
+    const po = await adapter.createOrder(
+      { vendor: 'X', items: [{ itemName: 'pen', quantity: 1, unitCost: 50 }] },
+      actorId
+    );
+    await adapter.approveOrder(po._id, actorId);
+    const stats = await adapter.getStats();
+    expect(stats.totalVendors).toBeGreaterThanOrEqual(1);
+    expect(stats.activeOrders).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/backend/models/inventory/PurchaseOrder.js
+++ b/backend/models/inventory/PurchaseOrder.js
@@ -69,7 +69,7 @@ const purchaseOrderSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-purchaseOrderSchema.pre('save', async function (next) {
+purchaseOrderSchema.pre('save', async function () {
   if (!this.po_number) {
     const year = new Date().getFullYear();
     // Query the scoped model name so the counter is stable per-collection.
@@ -85,7 +85,6 @@ purchaseOrderSchema.pre('save', async function (next) {
   this.items.forEach(i => {
     i.total_cost = (i.quantity_ordered || 0) * (i.unit_cost || 0);
   });
-  next();
 });
 
 purchaseOrderSchema.index({ status: 1, order_date: -1 });

--- a/backend/routes/purchasing.routes.js
+++ b/backend/routes/purchasing.routes.js
@@ -1,6 +1,6 @@
 /**
  * Purchasing Routes — /api/v1/purchasing/*
- * W773 — adapter to Phase-16 purchaseRequest.service (ops/purchase-requests).
+ * W773 — PR adapter; W780 — vendors (Vendor) + orders (InventoryModulePurchaseOrder).
  */
 'use strict';
 
@@ -19,6 +19,32 @@ function wrap(fn) {
 function actor(req) {
   const u = req.user || {};
   return { id: u.id || u._id, name: u.name || u.fullName };
+}
+
+function invalidId(res) {
+  return res.status(400).json({ success: false, message: 'invalid_id' });
+}
+
+async function handleApproveRequest(req, res) {
+  if (!mongoose.isValidObjectId(req.params.id)) return invalidId(res);
+  const { id, name } = actor(req);
+  const roles = (req.user && req.user.roles) || [];
+  const data = await adapter.approveRequest(req.params.id, {
+    approverId: id,
+    approverName: name,
+    role: req.body.role || roles[0] || 'procurement_manager',
+  });
+  res.json({ success: true, data });
+}
+
+async function handleRejectRequest(req, res) {
+  if (!mongoose.isValidObjectId(req.params.id)) return invalidId(res);
+  const { id } = actor(req);
+  const data = await adapter.rejectRequest(req.params.id, {
+    approverId: id,
+    reason: req.body.reason || 'rejected',
+  });
+  res.json({ success: true, data });
 }
 
 router.get(
@@ -51,28 +77,50 @@ router.get(
 
 router.get(
   '/vendors',
-  wrap(async (_req, res) => res.json({ success: true, data: [] }))
+  wrap(async (req, res) => {
+    const data = await adapter.listVendors(req.query);
+    res.json({ success: true, data });
+  })
 );
 router.get(
   '/vendors/:id',
-  wrap(async (req, res) => res.json({ success: true, data: { _id: req.params.id } }))
+  wrap(async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'invalid_id' });
+    }
+    const data = await adapter.getVendor(req.params.id);
+    res.json({ success: true, data });
+  })
 );
 router.post(
   '/vendors',
   authorize('admin', 'manager', 'procurement_manager'),
-  wrap(async (req, res) =>
-    res.status(201).json({ success: true, data: { _id: 'new', ...req.body } })
-  )
+  wrap(async (req, res) => {
+    const data = await adapter.createVendor(req.body);
+    res.status(201).json({ success: true, data });
+  })
 );
 router.put(
   '/vendors/:id',
   authorize('admin', 'manager', 'procurement_manager'),
-  wrap(async (req, res) => res.json({ success: true, data: { _id: req.params.id, ...req.body } }))
+  wrap(async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'invalid_id' });
+    }
+    const data = await adapter.updateVendor(req.params.id, req.body);
+    res.json({ success: true, data });
+  })
 );
 router.delete(
   '/vendors/:id',
   authorize('admin', 'manager', 'procurement_manager'),
-  wrap(async (req, res) => res.json({ success: true, data: { deleted: true, _id: req.params.id } }))
+  wrap(async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'invalid_id' });
+    }
+    const data = await adapter.deleteVendor(req.params.id);
+    res.json({ success: true, data });
+  })
 );
 
 router.get(
@@ -110,94 +158,218 @@ router.post(
 
 router.put(
   '/requests/:id',
-  authorize('admin', 'manager', 'procurement_manager'),
-  wrap(async (req, res) => res.json({ success: true, data: { _id: req.params.id, ...req.body } }))
+  authorize('admin', 'manager', 'procurement_manager', 'department_head', 'staff'),
+  wrap(async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) return invalidId(res);
+    const { id } = actor(req);
+    const data = await adapter.updateRequest(
+      req.params.id,
+      { ...req.body, ...branchFilter(req) },
+      id
+    );
+    res.json({ success: true, data });
+  })
 );
+
+const REQUEST_APPROVE_ROLES = [
+  'admin',
+  'manager',
+  'procurement_manager',
+  'department_head',
+  'cfo',
+  'ceo',
+];
 
 router.patch(
   '/requests/:id/approve',
-  authorize('admin', 'manager', 'procurement_manager', 'department_head', 'cfo', 'ceo'),
+  authorize(...REQUEST_APPROVE_ROLES),
+  wrap(handleApproveRequest)
+);
+router.post(
+  '/requests/:id/approve',
+  authorize(...REQUEST_APPROVE_ROLES),
+  wrap(handleApproveRequest)
+);
+
+router.patch(
+  '/requests/:id/reject',
+  authorize(...REQUEST_APPROVE_ROLES),
+  wrap(handleRejectRequest)
+);
+router.post('/requests/:id/reject', authorize(...REQUEST_APPROVE_ROLES), wrap(handleRejectRequest));
+
+router.post(
+  '/requests/:id/submit',
+  authorize('admin', 'manager', 'procurement_manager', 'department_head', 'staff'),
   wrap(async (req, res) => {
-    if (!mongoose.isValidObjectId(req.params.id)) {
-      return res.status(400).json({ success: false, message: 'invalid_id' });
-    }
-    const { id, name } = actor(req);
-    const roles = (req.user && req.user.roles) || [];
-    const data = await adapter.approveRequest(req.params.id, {
-      approverId: id,
-      approverName: name,
-      role: req.body.role || roles[0] || 'procurement_manager',
+    if (!mongoose.isValidObjectId(req.params.id)) return invalidId(res);
+    const { id } = actor(req);
+    const data = await adapter.submitRequest(req.params.id, {
+      actorId: id,
+      notes: req.body.notes,
     });
     res.json({ success: true, data });
   })
 );
 
+router.post(
+  '/requests/:id/convert-to-po',
+  authorize('admin', 'manager', 'procurement_manager'),
+  wrap(async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) return invalidId(res);
+    const { id } = actor(req);
+    const data = await adapter.convertRequestToPo(req.params.id, {
+      actorId: id,
+      supplierId: req.body.supplierId || req.body.vendorId,
+      supplierName: req.body.supplierName || req.body.vendor,
+    });
+    res.status(201).json({ success: true, data });
+  })
+);
+
+router.get(
+  '/orders',
+  wrap(async (req, res) => {
+    const scope = branchFilter(req);
+    const data = await adapter.listOrders({
+      ...req.query,
+      branchId: scope.branchId || req.query.branchId,
+    });
+    res.json({ success: true, data });
+  })
+);
+
+router.post(
+  '/orders',
+  authorize('admin', 'manager', 'procurement_manager'),
+  wrap(async (req, res) => {
+    const { id } = actor(req);
+    const data = await adapter.createOrder({ ...req.body, ...branchFilter(req) }, id);
+    res.status(201).json({ success: true, data });
+  })
+);
+
 router.patch(
-  '/requests/:id/reject',
-  authorize('admin', 'manager', 'procurement_manager', 'department_head', 'cfo', 'ceo'),
+  '/orders/:id/approve',
+  authorize('admin', 'manager', 'procurement_manager'),
   wrap(async (req, res) => {
     if (!mongoose.isValidObjectId(req.params.id)) {
       return res.status(400).json({ success: false, message: 'invalid_id' });
     }
     const { id } = actor(req);
-    const data = await adapter.rejectRequest(req.params.id, {
-      approverId: id,
-      reason: req.body.reason || 'rejected',
-    });
+    const data = await adapter.approveOrder(req.params.id, id);
     res.json({ success: true, data });
   })
 );
 
-router.get(
-  '/orders',
-  wrap(async (_req, res) => {
-    const data = await adapter.listOrders();
-    res.json({ success: true, data });
-  })
-);
-
-router.get(
-  '/orders/:id',
-  wrap(async (req, res) => res.json({ success: true, data: { _id: req.params.id } }))
-);
-router.post(
-  '/orders',
-  authorize('admin', 'manager', 'procurement_manager'),
-  wrap(async (req, res) =>
-    res.status(201).json({ success: true, data: { _id: 'new', status: 'draft', ...req.body } })
-  )
-);
-router.put(
-  '/orders/:id',
-  authorize('admin', 'manager', 'procurement_manager'),
-  wrap(async (req, res) => res.json({ success: true, data: { _id: req.params.id, ...req.body } }))
-);
-router.patch(
-  '/orders/:id/status',
-  authorize('admin', 'manager', 'procurement_manager'),
-  wrap(async (req, res) =>
-    res.json({ success: true, data: { _id: req.params.id, status: req.body.status } })
-  )
-);
 router.patch(
   '/orders/:id/receive',
   authorize('admin', 'manager', 'procurement_manager'),
-  wrap(async (req, res) =>
-    res.json({
-      success: true,
-      data: { _id: req.params.id, status: 'received', receivedAt: new Date() },
-    })
-  )
+  wrap(async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'invalid_id' });
+    }
+    const { id } = actor(req);
+    const data = await adapter.receiveOrder(req.params.id, id);
+    res.json({ success: true, data });
+  })
 );
+
+router.patch(
+  '/orders/:id/status',
+  authorize('admin', 'manager', 'procurement_manager'),
+  wrap(async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'invalid_id' });
+    }
+    const { id } = actor(req);
+    const Po = require('../models/inventory/PurchaseOrder');
+    const doc = await Po.findOneAndUpdate(
+      { _id: req.params.id, deleted_at: null },
+      { status: req.body.status, updated_by: id },
+      { new: true }
+    );
+    if (!doc) {
+      return res.status(404).json({ success: false, message: 'order_not_found' });
+    }
+    const data = await adapter.getOrder(req.params.id);
+    res.json({ success: true, data });
+  })
+);
+
+router.get(
+  '/orders/:id',
+  wrap(async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'invalid_id' });
+    }
+    const data = await adapter.getOrder(req.params.id);
+    res.json({ success: true, data });
+  })
+);
+
+router.put(
+  '/orders/:id',
+  authorize('admin', 'manager', 'procurement_manager'),
+  wrap(async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'invalid_id' });
+    }
+    const { id } = actor(req);
+    const Po = require('../models/inventory/PurchaseOrder');
+    const patch = { updated_by: id };
+    if (req.body.vendor != null) patch.supplier_name = req.body.vendor;
+    if (req.body.supplierName != null) patch.supplier_name = req.body.supplierName;
+    if (req.body.deliveryDate != null) patch.expected_delivery_date = req.body.deliveryDate;
+    if (req.body.notes != null) patch.notes = req.body.notes;
+    const doc = await Po.findOneAndUpdate({ _id: req.params.id, deleted_at: null }, patch, {
+      new: true,
+    });
+    if (!doc) {
+      return res.status(404).json({ success: false, message: 'order_not_found' });
+    }
+    const data = await adapter.getOrder(req.params.id);
+    res.json({ success: true, data });
+  })
+);
+
 router.delete(
   '/orders/:id',
   authorize('admin', 'manager', 'procurement_manager'),
-  wrap(async (req, res) => res.json({ success: true, data: { deleted: true, _id: req.params.id } }))
+  wrap(async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'invalid_id' });
+    }
+    const Po = require('../models/inventory/PurchaseOrder');
+    const doc = await Po.findOneAndUpdate(
+      { _id: req.params.id, deleted_at: null },
+      { deleted_at: new Date() },
+      { new: true }
+    );
+    if (!doc) {
+      return res.status(404).json({ success: false, message: 'order_not_found' });
+    }
+    res.json({ success: true, data: { deleted: true, _id: doc._id } });
+  })
 );
 
 router.use((err, _req, res, _next) => {
-  if (err.status === 404) {
+  if (err.status === 404 || err.code === 'NOT_FOUND') {
     return res.status(404).json({ success: false, message: err.message || 'not_found' });
+  }
+  if (err.code === 'ILLEGAL_TRANSITION' || err.code === 'CONFLICT') {
+    return res.status(409).json({
+      success: false,
+      message: err.message,
+      code: err.code,
+    });
+  }
+  if (err.code === 'MISSING_FIELD') {
+    return res.status(422).json({
+      success: false,
+      message: err.message,
+      fields: err.fields,
+    });
   }
   return safeError(res, err, 'purchasing');
 });

--- a/backend/services/purchasingAdapter.service.js
+++ b/backend/services/purchasingAdapter.service.js
@@ -2,9 +2,24 @@
 
 /**
  * Legacy /api/v1/purchasing/* adapter — delegates PR workflow to Phase-16 ops.
- * Frontend: procurement.service.js + operationsService.js (legacy React).
- * Canonical ops surface: /api/v1/ops/purchase-requests.
+ * W773: purchase requests → purchaseRequest.service.
+ * W780: vendors → Vendor model; orders → InventoryModulePurchaseOrder.
  */
+
+function getVendorModel() {
+  return require('../models/Vendor');
+}
+
+function getPoModel() {
+  try {
+    const boot = require('../startup/operationsBootstrap');
+    const wired = boot._getPurchaseRequestService?.();
+    if (wired && wired._deps?.poModel) return wired._deps.poModel;
+  } catch {
+    /* fall through */
+  }
+  return require('../models/inventory/PurchaseOrder');
+}
 
 function getPrService() {
   try {
@@ -16,8 +31,64 @@ function getPrService() {
   }
   const { createPurchaseRequestService } = require('./operations/purchaseRequest.service');
   const PR = require('../models/operations/PurchaseRequest.model');
-  const PO = require('../models/inventory/PurchaseOrder');
+  const PO = getPoModel();
   return createPurchaseRequestService({ prModel: PR, poModel: PO });
+}
+
+const PO_STATUS_TO_LEGACY = {
+  draft: 'draft',
+  pending_approval: 'pending',
+  approved: 'approved',
+  sent: 'ordered',
+  partial: 'ordered',
+  received: 'received',
+  cancelled: 'cancelled',
+  closed: 'received',
+};
+
+function legacyPoStatus(status) {
+  return PO_STATUS_TO_LEGACY[status] || status;
+}
+
+function mapVendorToLegacy(doc) {
+  if (!doc) return doc;
+  const o = typeof doc.toObject === 'function' ? doc.toObject() : { ...doc };
+  const idStr = String(o._id);
+  return {
+    ...o,
+    _id: o._id,
+    vendorNumber: o.vendorNumber || `VND-${idStr.slice(-6).toUpperCase()}`,
+    name: o.name,
+    type: o.type || o.category || 'company',
+    email: o.email || '',
+    phone: o.phone || '',
+    city: o.city || o.address || '',
+    rating: o.rating ?? 0,
+    isActive: o.isActive ?? o.status === 'active',
+    paymentTerms: o.paymentTerms || 'net30',
+    creditLimit: o.creditLimit ?? 0,
+    totalOrders: o.totalOrders ?? 0,
+    totalAmount: o.totalAmount ?? 0,
+  };
+}
+
+function mapPoToLegacy(doc) {
+  if (!doc) return doc;
+  const o = typeof doc.toObject === 'function' ? doc.toObject() : { ...doc };
+  const orderDate = o.order_date ? new Date(o.order_date) : new Date();
+  const delivery = o.expected_delivery_date ? new Date(o.expected_delivery_date) : null;
+  return {
+    ...o,
+    _id: o._id,
+    orderNumber: o.orderNumber || o.po_number || String(o._id),
+    vendor: o.vendor || o.supplier_name || '',
+    date: orderDate.toISOString().slice(0, 10),
+    deliveryDate: delivery ? delivery.toISOString().slice(0, 10) : '',
+    items: Array.isArray(o.items) ? o.items.length : o.items || 0,
+    totalAmount: o.totalAmount ?? o.total_amount ?? 0,
+    status: legacyPoStatus(o.status),
+    department: o.department || '',
+  };
 }
 
 function mapPrToLegacyRequest(doc) {
@@ -36,6 +107,85 @@ function mapPrToLegacyRequest(doc) {
       o.department ||
       'Purchase request',
   };
+}
+
+async function listVendors(query = {}) {
+  const Vendor = getVendorModel();
+  const filter = { isDeleted: { $ne: true } };
+  if (query.status) filter.status = query.status;
+  const rows = await Vendor.find(filter)
+    .sort({ name: 1 })
+    .limit(query.limit ? Number(query.limit) : 200)
+    .lean();
+  return rows.map(mapVendorToLegacy);
+}
+
+async function getVendor(id) {
+  const Vendor = getVendorModel();
+  const doc = await Vendor.findOne({ _id: id, isDeleted: { $ne: true } });
+  if (!doc) {
+    const err = new Error('vendor_not_found');
+    err.status = 404;
+    throw err;
+  }
+  return mapVendorToLegacy(doc);
+}
+
+async function createVendor(body) {
+  const Vendor = getVendorModel();
+  const count = await Vendor.countDocuments();
+  const doc = await Vendor.create({
+    name: body.name,
+    category: body.type || body.category,
+    contactPerson: body.contactPerson,
+    phone: body.phone,
+    email: body.email,
+    address: body.city || body.address,
+    paymentTerms: body.paymentTerms,
+    rating: body.rating ?? 0,
+    status: body.isActive === false ? 'inactive' : 'active',
+    notes: body.creditLimit ? `creditLimit:${body.creditLimit}` : undefined,
+  });
+  const legacy = mapVendorToLegacy(doc);
+  legacy.vendorNumber = `VND-${String(count + 1).padStart(3, '0')}`;
+  return legacy;
+}
+
+async function updateVendor(id, body) {
+  const Vendor = getVendorModel();
+  const patch = {};
+  if (body.name != null) patch.name = body.name;
+  if (body.email != null) patch.email = body.email;
+  if (body.phone != null) patch.phone = body.phone;
+  if (body.city != null || body.address != null) patch.address = body.city || body.address;
+  if (body.type != null || body.category != null) patch.category = body.type || body.category;
+  if (body.paymentTerms != null) patch.paymentTerms = body.paymentTerms;
+  if (body.rating != null) patch.rating = body.rating;
+  if (body.isActive != null) patch.status = body.isActive ? 'active' : 'inactive';
+  const doc = await Vendor.findOneAndUpdate({ _id: id, isDeleted: { $ne: true } }, patch, {
+    new: true,
+  });
+  if (!doc) {
+    const err = new Error('vendor_not_found');
+    err.status = 404;
+    throw err;
+  }
+  return mapVendorToLegacy(doc);
+}
+
+async function deleteVendor(id) {
+  const Vendor = getVendorModel();
+  const doc = await Vendor.findOneAndUpdate(
+    { _id: id, isDeleted: { $ne: true } },
+    { isDeleted: true, status: 'inactive' },
+    { new: true }
+  );
+  if (!doc) {
+    const err = new Error('vendor_not_found');
+    err.status = 404;
+    throw err;
+  }
+  return { deleted: true, _id: doc._id };
 }
 
 async function listRequests(query = {}) {
@@ -59,6 +209,43 @@ async function getRequest(id) {
   return mapPrToLegacyRequest(doc);
 }
 
+async function updateRequest(id, body, actorId) {
+  const PR = require('../models/operations/PurchaseRequest.model');
+  const pr = await PR.findById(id);
+  if (!pr) {
+    const err = new Error('request_not_found');
+    err.status = 404;
+    throw err;
+  }
+  if (pr.status !== 'draft') {
+    const err = new Error('only_draft_requests_editable');
+    err.code = 'CONFLICT';
+    throw err;
+  }
+  if (body.requiredDate != null) pr.requiredDate = body.requiredDate;
+  if (body.neededBy != null) pr.requiredDate = body.neededBy;
+  if (body.priority != null) pr.priority = body.priority;
+  if (body.department != null) pr.department = body.department;
+  if (body.branchId != null) pr.branchId = body.branchId;
+  if (body.justification != null) pr.justification = body.justification;
+  if (body.notes != null) pr.justification = body.notes;
+  if (body.title != null) pr.justification = body.title;
+  if (body.purchaseMethod != null) pr.purchaseMethod = body.purchaseMethod;
+  if (Array.isArray(body.items) && body.items.length) {
+    pr.items = body.items.map(it => ({
+      itemName: it.itemName || it.name || 'Item',
+      itemCode: it.itemCode,
+      quantity: it.quantity ?? 1,
+      unit: it.unit || 'ea',
+      estimatedUnitPrice: it.estimatedUnitPrice ?? it.estimatedUnitCost ?? it.unitCost ?? 0,
+      notes: it.notes,
+    }));
+  }
+  if (actorId) pr.updatedBy = actorId;
+  await pr.save();
+  return mapPrToLegacyRequest(pr);
+}
+
 async function createRequest(body, actorId) {
   const requiredDate =
     body.requiredDate ||
@@ -72,7 +259,8 @@ async function createRequest(body, actorId) {
           itemName: body.itemName || body.description || body.title || 'Requested item',
           quantity: body.quantity || 1,
           unit: body.unit || 'ea',
-          estimatedUnitCost: body.estimatedUnitCost || body.unitCost || 0,
+          estimatedUnitPrice:
+            body.estimatedUnitPrice ?? body.estimatedUnitCost ?? body.unitCost ?? 0,
         },
       ];
   const draft = await getPrService().createDraft(
@@ -109,7 +297,123 @@ async function rejectRequest(id, { approverId, reason }) {
   return mapPrToLegacyRequest(doc);
 }
 
+async function submitRequest(id, { actorId, notes }) {
+  const doc = await getPrService().submit(id, { actorId, notes });
+  return mapPrToLegacyRequest(doc);
+}
+
+async function convertRequestToPo(id, { actorId, supplierId, supplierName }) {
+  const { purchaseRequest, purchaseOrder } = await getPrService().convertToPo(id, {
+    actorId,
+    supplierId,
+    supplierName,
+  });
+  return {
+    request: mapPrToLegacyRequest(purchaseRequest),
+    order: mapPoToLegacy(purchaseOrder),
+  };
+}
+
+async function listOrders(query = {}) {
+  const Po = getPoModel();
+  const filter = { deleted_at: null };
+  if (query.branchId) filter.branch_id = query.branchId;
+  if (query.status) {
+    const inv = Object.entries(PO_STATUS_TO_LEGACY).find(([, leg]) => leg === query.status);
+    if (inv) filter.status = inv[0];
+    else filter.status = query.status;
+  }
+  const rows = await Po.find(filter)
+    .sort({ order_date: -1 })
+    .limit(query.limit ? Number(query.limit) : 200)
+    .lean();
+  return rows.map(mapPoToLegacy);
+}
+
+async function getOrder(id) {
+  const Po = getPoModel();
+  const doc = await Po.findOne({ _id: id, deleted_at: null });
+  if (!doc) {
+    const err = new Error('order_not_found');
+    err.status = 404;
+    throw err;
+  }
+  return mapPoToLegacy(doc);
+}
+
+async function createOrder(body, actorId) {
+  const Po = getPoModel();
+  const items = (body.items || []).map(it => ({
+    item_name_ar: it.itemName || it.item_name_ar || it.name || 'Item',
+    item_code: it.itemCode || it.item_code,
+    quantity_ordered: it.quantity || it.quantity_ordered || 1,
+    unit_cost: it.unitCost || it.unit_cost || it.price || 0,
+    unit_of_measure: it.unit || it.unit_of_measure || 'ea',
+  }));
+  if (!items.length) {
+    items.push({
+      item_name_ar: body.description || 'General purchase',
+      quantity_ordered: 1,
+      unit_cost: body.totalAmount || 0,
+    });
+  }
+  const doc = await Po.create({
+    supplier_id: body.supplierId || body.vendorId,
+    supplier_name: body.supplierName || body.vendor,
+    status: 'draft',
+    items,
+    branch_id: body.branchId,
+    expected_delivery_date: body.deliveryDate || body.expected_delivery_date,
+    payment_terms: body.paymentTerms,
+    notes: body.notes,
+    created_by: actorId,
+    updated_by: actorId,
+  });
+  return mapPoToLegacy(doc);
+}
+
+async function approveOrder(id, actorId) {
+  const Po = getPoModel();
+  const doc = await Po.findOneAndUpdate(
+    { _id: id, deleted_at: null, status: { $in: ['draft', 'pending_approval'] } },
+    {
+      status: 'approved',
+      approved_by: actorId,
+      approved_at: new Date(),
+      updated_by: actorId,
+    },
+    { new: true }
+  );
+  if (!doc) {
+    const err = new Error('order_not_found');
+    err.status = 404;
+    throw err;
+  }
+  return mapPoToLegacy(doc);
+}
+
+async function receiveOrder(id, actorId) {
+  const Po = getPoModel();
+  const doc = await Po.findOneAndUpdate(
+    { _id: id, deleted_at: null },
+    {
+      status: 'received',
+      actual_delivery_date: new Date(),
+      updated_by: actorId,
+    },
+    { new: true }
+  );
+  if (!doc) {
+    const err = new Error('order_not_found');
+    err.status = 404;
+    throw err;
+  }
+  return mapPoToLegacy(doc);
+}
+
 async function getStats() {
+  const Vendor = getVendorModel();
+  const Po = getPoModel();
   const rows = await listRequests({ limit: 500 });
   const pendingStatuses = new Set([
     'draft',
@@ -118,30 +422,46 @@ async function getStats() {
     'returned_for_clarification',
   ]);
   const pendingRequests = rows.filter(r => pendingStatuses.has(r.status)).length;
-  const approved = rows.filter(
-    r => r.status === 'approved' || r.status === 'converted_to_po'
-  ).length;
+  const [totalVendors, activeOrders, spendAgg] = await Promise.all([
+    Vendor.countDocuments({ isDeleted: { $ne: true }, status: 'active' }),
+    Po.countDocuments({
+      deleted_at: null,
+      status: { $in: ['approved', 'sent', 'partial', 'received', 'closed'] },
+    }),
+    Po.aggregate([
+      { $match: { deleted_at: null, status: { $in: ['received', 'closed', 'approved', 'sent'] } } },
+      { $group: { _id: null, total: { $sum: '$total_amount' } } },
+    ]),
+  ]);
+  const totalSpend = spendAgg[0]?.total || 0;
   return {
-    totalVendors: 0,
-    activeOrders: approved,
+    totalVendors,
+    activeOrders,
     pendingRequests,
-    totalSpend: 0,
+    totalSpend,
     monthlyBudget: 0,
     savingsAchieved: 0,
   };
 }
 
-async function listOrders() {
-  const rows = await listRequests({ limit: 500 });
-  return rows.filter(r => r.status === 'converted_to_po' || r.status === 'approved');
-}
-
 module.exports = {
+  listVendors,
+  getVendor,
+  createVendor,
+  updateVendor,
+  deleteVendor,
   listRequests,
   getRequest,
+  updateRequest,
   createRequest,
   approveRequest,
   rejectRequest,
-  getStats,
+  submitRequest,
+  convertRequestToPo,
   listOrders,
+  getOrder,
+  createOrder,
+  approveOrder,
+  receiveOrder,
+  getStats,
 };

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -104,6 +104,8 @@ __tests__/rehab-licenses-behavioral-wave772.test.js
 __tests__/rehab-licenses-route-wired-wave772.test.js
 __tests__/stub-surface-cleanup-wave773.test.js
 __tests__/purchasing-adapter-behavioral-wave773.test.js
+__tests__/purchasing-vendor-order-wave780.test.js
+__tests__/purchasing-routes-real-data-wave780.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js


### PR DESCRIPTION
## Summary
- Replace hollow vendor/order stubs in purchasing.routes with Mongo-backed adapter (Vendor + InventoryModulePurchaseOrder).
- Wire full PR lifecycle: submit, approve (PATCH+POST), reject, convert-to-po, draft-only PUT update.
- Fix InventoryModulePurchaseOrder pre-save hook (async without next).
- Drift guards + behavioral tests (12 assertions); sprint-tests.yml synced.

## Test plan
- [ ] CI sprint + Admin API Smoke
- [ ] cd backend && npx jest __tests__/purchasing-vendor-order-wave780.test.js __tests__/purchasing-routes-real-data-wave780.test.js __tests__/purchasing-adapter-behavioral-wave773.test.js
- [ ] Legacy frontend: PurchasingManagement vendors/orders/requests

Made with [Cursor](https://cursor.com)