### PR TITLE
feat(backend): W781 purchasing receipts and vendor contracts

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -936,6 +936,9 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-vendor-order-wave780.test.js'
       - 'backend/__tests__/purchasing-routes-real-data-wave780.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-receipts-contracts-wave781.test.js'
+      - 'backend/__tests__/purchasing-routes-receipts-contracts-wave781.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1855,6 +1858,9 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-vendor-order-wave780.test.js'
       - 'backend/__tests__/purchasing-routes-real-data-wave780.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-receipts-contracts-wave781.test.js'
+      - 'backend/__tests__/purchasing-routes-receipts-contracts-wave781.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/purchasing-receipts-contracts-wave781.test.js
+++ b/backend/__tests__/purchasing-receipts-contracts-wave781.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+/**
+ * purchasing-receipts-contracts-wave781.test.js — W781 GRN + vendor contracts.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(30000);
+
+const mongoose = require('mongoose');
+const fs = require('fs');
+const path = require('path');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const adapter = require('../services/purchasingAdapter.service');
+
+let mongod;
+
+beforeAll(async () => {
+  const URI_FILE = path.join(__dirname, '..', '.test-mongo-uri');
+  let uri;
+  if (fs.existsSync(URI_FILE)) {
+    uri = fs.readFileSync(URI_FILE, 'utf-8').trim();
+  } else {
+    mongod = await MongoMemoryServer.create({ instance: { dbName: 'w781-purchasing' } });
+    uri = mongod.getUri();
+  }
+  await mongoose.connect(uri);
+  require('../models/inventory/PurchaseReceipt');
+  require('../models/VendorSupplyContract');
+  require('../models/inventory/PurchaseOrder');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+beforeEach(async () => {
+  const Receipt = require('../models/inventory/PurchaseReceipt');
+  const Contract = require('../models/VendorSupplyContract');
+  const Po = require('../models/inventory/PurchaseOrder');
+  await Receipt.deleteMany({});
+  await Contract.deleteMany({});
+  await Po.deleteMany({});
+});
+
+describe('W781 behavioral — purchase receipts', () => {
+  it('creates and lists receipts with legacy GRN shape', async () => {
+    const actorId = new mongoose.Types.ObjectId();
+    const created = await adapter.createReceipt(
+      {
+        vendor: 'مورد تجريبي',
+        warehouse: 'المستودع الرئيسي',
+        items: [{ itemName: 'ورق', quantity_ordered: 10, quantity_received: 10, unitCost: 5 }],
+        qualityCheck: 'passed',
+        receivedBy: 'فهد',
+      },
+      actorId
+    );
+    expect(created.receiptNumber).toMatch(/^GRN-/);
+    expect(created.vendor).toBe('مورد تجريبي');
+    expect(created.status).toBe('complete');
+    expect(created.items).toBe(1);
+
+    const rows = await adapter.listReceipts();
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe('W781 behavioral — vendor contracts', () => {
+  it('creates contract and lists expiring within horizon', async () => {
+    const soon = new Date(Date.now() + 20 * 86400000);
+    const created = await adapter.createContract({
+      vendor: 'شركة التوريد',
+      type: 'annual',
+      startDate: new Date(Date.now() - 86400000),
+      endDate: soon,
+      value: 250000,
+      category: 'مستلزمات',
+      autoRenew: true,
+    });
+    expect(created.contractNumber).toMatch(/^CNT-/);
+    expect(created.status).toBe('expiring_soon');
+
+    const expiring = await adapter.listExpiringContracts(60);
+    expect(expiring.some(c => String(c._id) === String(created._id))).toBe(true);
+
+    const all = await adapter.listContracts();
+    expect(all).toHaveLength(1);
+  });
+});

--- a/backend/__tests__/purchasing-routes-receipts-contracts-wave781.test.js
+++ b/backend/__tests__/purchasing-routes-receipts-contracts-wave781.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * purchasing-routes-receipts-contracts-wave781.test.js — W781 drift guard.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PURCHASING = fs.readFileSync(
+  path.join(__dirname, '..', 'routes', 'purchasing.routes.js'),
+  'utf8'
+);
+
+describe('W781 — purchasing receipts + contracts routes', () => {
+  it('receipts and contracts delegate to adapter', () => {
+    expect(PURCHASING).toMatch(/adapter\.listReceipts/);
+    expect(PURCHASING).toMatch(/adapter\.createReceipt/);
+    expect(PURCHASING).toMatch(/adapter\.listContracts/);
+    expect(PURCHASING).toMatch(/adapter\.listExpiringContracts/);
+    expect(PURCHASING).toMatch(/adapter\.createContract/);
+  });
+
+  it('/contracts/expiring is registered before generic contract handlers', () => {
+    const expIdx = PURCHASING.indexOf("'/contracts/expiring'");
+    const receiptsIdx = PURCHASING.indexOf("'/receipts'");
+    expect(expIdx).toBeGreaterThan(-1);
+    expect(receiptsIdx).toBeGreaterThan(-1);
+  });
+});

--- a/backend/models/VendorSupplyContract.js
+++ b/backend/models/VendorSupplyContract.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * VendorSupplyContract — supplier framework contracts for /api/v1/purchasing/contracts.
+ * W781 — separate from HR EmploymentContract and generic Contract.model.
+ */
+
+const mongoose = require('mongoose');
+
+const vendorSupplyContractSchema = new mongoose.Schema(
+  {
+    contract_number: { type: String, unique: true, uppercase: true },
+    vendor_id: { type: mongoose.Schema.Types.ObjectId, ref: 'Vendor' },
+    vendor_name: { type: String, required: true, trim: true },
+    contract_type: {
+      type: String,
+      enum: ['annual', 'one_time', 'framework'],
+      default: 'annual',
+    },
+    category: { type: String, trim: true },
+    start_date: { type: Date, required: true },
+    end_date: { type: Date, required: true },
+    contract_value: { type: Number, default: 0, min: 0 },
+    status: {
+      type: String,
+      enum: ['draft', 'active', 'expired', 'terminated'],
+      default: 'active',
+    },
+    auto_renew: { type: Boolean, default: false },
+    branch_id: { type: mongoose.Schema.Types.ObjectId, ref: 'Branch' },
+    notes: { type: String },
+    is_deleted: { type: Boolean, default: false },
+  },
+  { timestamps: true }
+);
+
+vendorSupplyContractSchema.pre('save', async function () {
+  if (!this.contract_number) {
+    const year = new Date().getFullYear();
+    const count = await mongoose.model('VendorSupplyContract').countDocuments();
+    this.contract_number = `CNT-${year}-${String(count + 1).padStart(3, '0')}`;
+  }
+});
+
+vendorSupplyContractSchema.index({ vendor_id: 1, status: 1 });
+vendorSupplyContractSchema.index({ end_date: 1, status: 1 });
+vendorSupplyContractSchema.index({ is_deleted: 1 });
+
+module.exports =
+  mongoose.models.VendorSupplyContract ||
+  mongoose.model('VendorSupplyContract', vendorSupplyContractSchema);

--- a/backend/models/inventory/PurchaseReceipt.js
+++ b/backend/models/inventory/PurchaseReceipt.js
@@ -1,0 +1,83 @@
+'use strict';
+
+/**
+ * PurchaseReceipt — goods receipt note (GRN) for legacy /api/v1/purchasing/receipts.
+ * W781 — linked to InventoryModulePurchaseOrder when po_id provided.
+ */
+
+const mongoose = require('mongoose');
+
+const receiptItemSchema = new mongoose.Schema(
+  {
+    item_name: { type: String, required: true },
+    quantity_ordered: { type: Number, default: 0 },
+    quantity_received: { type: Number, default: 0 },
+    unit_cost: { type: Number, default: 0 },
+  },
+  { _id: true }
+);
+
+const purchaseReceiptSchema = new mongoose.Schema(
+  {
+    receipt_number: { type: String, unique: true },
+    purchase_order_id: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'InventoryModulePurchaseOrder',
+    },
+    po_number: { type: String },
+    vendor_name: { type: String },
+    warehouse_name: { type: String },
+    branch_id: { type: mongoose.Schema.Types.ObjectId, ref: 'Branch' },
+    receipt_date: { type: Date, default: Date.now },
+    items: [receiptItemSchema],
+    total_amount: { type: Number, default: 0 },
+    status: {
+      type: String,
+      enum: ['pending', 'partial', 'complete'],
+      default: 'pending',
+    },
+    received_by_name: { type: String },
+    quality_check: {
+      type: String,
+      enum: ['pending', 'passed', 'failed'],
+      default: 'pending',
+    },
+    notes: { type: String },
+    created_by: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    deleted_at: { type: Date, default: null },
+  },
+  { timestamps: true }
+);
+
+purchaseReceiptSchema.pre('save', async function () {
+  if (!this.receipt_number) {
+    const year = new Date().getFullYear();
+    const count = await mongoose.model('PurchaseReceipt').countDocuments();
+    this.receipt_number = `GRN-${year}-${String(count + 1).padStart(3, '0')}`;
+  }
+  const lines = this.items || [];
+  let received = 0;
+  let ordered = 0;
+  let total = 0;
+  lines.forEach(line => {
+    ordered += line.quantity_ordered || 0;
+    received += line.quantity_received || 0;
+    total += (line.quantity_received || 0) * (line.unit_cost || 0);
+  });
+  this.total_amount = total || this.total_amount;
+  if (!lines.length) {
+    this.status = this.status || 'pending';
+  } else if (received >= ordered && ordered > 0) {
+    this.status = 'complete';
+  } else if (received > 0) {
+    this.status = 'partial';
+  } else {
+    this.status = 'pending';
+  }
+});
+
+purchaseReceiptSchema.index({ branch_id: 1, receipt_date: -1 });
+purchaseReceiptSchema.index({ deleted_at: 1 });
+
+module.exports =
+  mongoose.models.PurchaseReceipt || mongoose.model('PurchaseReceipt', purchaseReceiptSchema);

--- a/backend/routes/purchasing.routes.js
+++ b/backend/routes/purchasing.routes.js
@@ -1,6 +1,6 @@
 /**
  * Purchasing Routes — /api/v1/purchasing/*
- * W773 — PR adapter; W780 — vendors (Vendor) + orders (InventoryModulePurchaseOrder).
+ * W773 — PR adapter; W780 — vendors/orders; W781 — receipts + vendor contracts.
  */
 'use strict';
 
@@ -350,6 +350,67 @@ router.delete(
       return res.status(404).json({ success: false, message: 'order_not_found' });
     }
     res.json({ success: true, data: { deleted: true, _id: doc._id } });
+  })
+);
+
+router.get(
+  '/receipts',
+  wrap(async (req, res) => {
+    const scope = branchFilter(req);
+    const data = await adapter.listReceipts({
+      ...req.query,
+      branchId: scope.branchId || req.query.branchId,
+    });
+    res.json({ success: true, data });
+  })
+);
+
+router.post(
+  '/receipts',
+  authorize('admin', 'manager', 'procurement_manager', 'warehouse_manager'),
+  wrap(async (req, res) => {
+    const { id } = actor(req);
+    const data = await adapter.createReceipt({ ...req.body, ...branchFilter(req) }, id);
+    res.status(201).json({ success: true, data });
+  })
+);
+
+router.get(
+  '/receipts/:id',
+  wrap(async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) return invalidId(res);
+    const data = await adapter.getReceipt(req.params.id);
+    res.json({ success: true, data });
+  })
+);
+
+router.get(
+  '/contracts/expiring',
+  wrap(async (req, res) => {
+    const days = req.query.days ? Number(req.query.days) : 60;
+    const data = await adapter.listExpiringContracts(days);
+    res.json({ success: true, data });
+  })
+);
+
+router.get(
+  '/contracts',
+  wrap(async (req, res) => {
+    const scope = branchFilter(req);
+    const data = await adapter.listContracts({
+      ...req.query,
+      branchId: scope.branchId || req.query.branchId,
+    });
+    res.json({ success: true, data });
+  })
+);
+
+router.post(
+  '/contracts',
+  authorize('admin', 'manager', 'procurement_manager'),
+  wrap(async (req, res) => {
+    const data = await adapter.createContract({ ...req.body, ...branchFilter(req) });
+    res.status(201).json({ success: true, data });
   })
 );
 

--- a/backend/services/purchasingAdapter.service.js
+++ b/backend/services/purchasingAdapter.service.js
@@ -4,6 +4,7 @@
  * Legacy /api/v1/purchasing/* adapter — delegates PR workflow to Phase-16 ops.
  * W773: purchase requests → purchaseRequest.service.
  * W780: vendors → Vendor model; orders → InventoryModulePurchaseOrder.
+ * W781: receipts → PurchaseReceipt; contracts → VendorSupplyContract.
  */
 
 function getVendorModel() {
@@ -411,6 +412,188 @@ async function receiveOrder(id, actorId) {
   return mapPoToLegacy(doc);
 }
 
+function getReceiptModel() {
+  return require('../models/inventory/PurchaseReceipt');
+}
+
+function getContractModel() {
+  return require('../models/VendorSupplyContract');
+}
+
+function mapReceiptToLegacy(doc) {
+  if (!doc) return doc;
+  const o = typeof doc.toObject === 'function' ? doc.toObject() : { ...doc };
+  const lines = o.items || [];
+  const ordered = lines.reduce((s, l) => s + (l.quantity_ordered || 0), 0);
+  const received = lines.reduce((s, l) => s + (l.quantity_received || 0), 0);
+  const d = o.receipt_date ? new Date(o.receipt_date) : new Date();
+  return {
+    ...o,
+    _id: o._id,
+    receiptNumber: o.receiptNumber || o.receipt_number,
+    purchaseOrder: o.purchaseOrder || o.po_number || '',
+    vendor: o.vendor || o.vendor_name || '',
+    warehouse: o.warehouse || o.warehouse_name || '',
+    branch: o.branch || (o.branch_id ? String(o.branch_id) : ''),
+    date: d.toISOString().slice(0, 10),
+    items: lines.length,
+    totalReceived: received,
+    totalAmount: o.totalAmount ?? o.total_amount ?? 0,
+    status: o.status,
+    receivedBy: o.receivedBy || o.received_by_name || '',
+    qualityCheck: o.qualityCheck || o.quality_check || 'pending',
+  };
+}
+
+function mapContractToLegacy(doc) {
+  if (!doc) return doc;
+  const o = typeof doc.toObject === 'function' ? doc.toObject() : { ...doc };
+  const end = new Date(o.end_date || o.endDate);
+  const now = Date.now();
+  const daysLeft = (end.getTime() - now) / 86400000;
+  let status = o.status === 'active' ? 'active' : o.status;
+  if (o.status === 'active') {
+    if (daysLeft <= 0) status = 'expired';
+    else if (daysLeft <= 60) status = 'expiring_soon';
+  }
+  const start = o.start_date ? new Date(o.start_date) : null;
+  return {
+    ...o,
+    _id: o._id,
+    contractNumber: o.contractNumber || o.contract_number,
+    vendor: o.vendor || o.vendor_name,
+    type: o.type || o.contract_type || 'annual',
+    startDate: start ? start.toISOString().slice(0, 10) : '',
+    endDate: end.toISOString().slice(0, 10),
+    value: o.value ?? o.contract_value ?? 0,
+    category: o.category || '',
+    autoRenew: o.autoRenew ?? o.auto_renew ?? false,
+    status,
+  };
+}
+
+async function listReceipts(query = {}) {
+  const Receipt = getReceiptModel();
+  const filter = { deleted_at: null };
+  if (query.branchId) filter.branch_id = query.branchId;
+  if (query.status) filter.status = query.status;
+  const rows = await Receipt.find(filter)
+    .sort({ receipt_date: -1 })
+    .limit(query.limit ? Number(query.limit) : 200)
+    .lean();
+  return rows.map(mapReceiptToLegacy);
+}
+
+async function getReceipt(id) {
+  const Receipt = getReceiptModel();
+  const doc = await Receipt.findOne({ _id: id, deleted_at: null });
+  if (!doc) {
+    const err = new Error('receipt_not_found');
+    err.status = 404;
+    throw err;
+  }
+  return mapReceiptToLegacy(doc);
+}
+
+async function createReceipt(body, actorId) {
+  const Receipt = getReceiptModel();
+  const Po = getPoModel();
+  const poId = body.purchaseOrderId || body.purchase_order_id;
+  let poNumber = body.purchaseOrder || body.po_number;
+  let vendorName = body.vendor || body.vendor_name;
+  if (poId && require('mongoose').Types.ObjectId.isValid(poId)) {
+    const po = await Po.findOne({ _id: poId, deleted_at: null }).lean();
+    if (po) {
+      poNumber = po.po_number || poNumber;
+      vendorName = vendorName || po.supplier_name;
+      if (!body.items || typeof body.items === 'number') {
+        body.items = (po.items || []).map(it => ({
+          item_name: it.item_name_ar,
+          quantity_ordered: it.quantity_ordered,
+          quantity_received:
+            body.status === 'complete' ? it.quantity_ordered || it.quantity_received : 0,
+          unit_cost: it.unit_cost,
+        }));
+      }
+    }
+  }
+  const rawItems = Array.isArray(body.items)
+    ? body.items
+    : typeof body.items === 'number'
+      ? Array.from({ length: body.items }, (_, i) => ({
+          item_name: `Line ${i + 1}`,
+          quantity_ordered: body.totalReceived || 1,
+          quantity_received: body.totalReceived || 0,
+          unit_cost: 0,
+        }))
+      : [];
+  const items = rawItems.map(it => ({
+    item_name: it.item_name || it.itemName || 'Item',
+    quantity_ordered: it.quantity_ordered ?? it.quantityOrdered ?? it.quantity ?? 1,
+    quantity_received:
+      it.quantity_received ?? it.quantityReceived ?? (body.status === 'complete' ? it.quantity : 0),
+    unit_cost: it.unit_cost ?? it.unitCost ?? 0,
+  }));
+  const doc = await Receipt.create({
+    purchase_order_id: poId || null,
+    po_number: poNumber,
+    vendor_name: vendorName,
+    warehouse_name: body.warehouse || body.warehouse_name,
+    branch_id: body.branchId || body.branch_id,
+    receipt_date: body.date || body.receipt_date,
+    items,
+    received_by_name: body.receivedBy || body.received_by_name,
+    quality_check: body.qualityCheck || body.quality_check || 'pending',
+    notes: body.notes,
+    created_by: actorId,
+  });
+  return mapReceiptToLegacy(doc);
+}
+
+async function listContracts(query = {}) {
+  const Contract = getContractModel();
+  const filter = { is_deleted: { $ne: true } };
+  if (query.branchId) filter.branch_id = query.branchId;
+  if (query.status) filter.status = query.status;
+  const rows = await Contract.find(filter)
+    .sort({ end_date: 1 })
+    .limit(query.limit ? Number(query.limit) : 200)
+    .lean();
+  return rows.map(mapContractToLegacy);
+}
+
+async function listExpiringContracts(daysAhead = 60) {
+  const Contract = getContractModel();
+  const now = new Date();
+  const horizon = new Date(now.getTime() + Number(daysAhead) * 86400000);
+  const rows = await Contract.find({
+    is_deleted: { $ne: true },
+    status: 'active',
+    end_date: { $gte: now, $lte: horizon },
+  })
+    .sort({ end_date: 1 })
+    .lean();
+  return rows.map(mapContractToLegacy);
+}
+
+async function createContract(body) {
+  const Contract = getContractModel();
+  const doc = await Contract.create({
+    vendor_id: body.vendorId || body.vendor_id,
+    vendor_name: body.vendor || body.vendor_name,
+    contract_type: body.type || body.contract_type || 'annual',
+    category: body.category,
+    start_date: body.startDate || body.start_date || new Date(),
+    end_date: body.endDate || body.end_date,
+    contract_value: body.value ?? body.contract_value ?? 0,
+    status: 'active',
+    auto_renew: body.autoRenew ?? body.auto_renew ?? false,
+    branch_id: body.branchId || body.branch_id,
+    notes: body.notes,
+  });
+  return mapContractToLegacy(doc);
+}
+
 async function getStats() {
   const Vendor = getVendorModel();
   const Po = getPoModel();
@@ -463,5 +646,11 @@ module.exports = {
   createOrder,
   approveOrder,
   receiveOrder,
+  listReceipts,
+  getReceipt,
+  createReceipt,
+  listContracts,
+  listExpiringContracts,
+  createContract,
   getStats,
 };

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -106,6 +106,8 @@ __tests__/stub-surface-cleanup-wave773.test.js
 __tests__/purchasing-adapter-behavioral-wave773.test.js
 __tests__/purchasing-vendor-order-wave780.test.js
 __tests__/purchasing-routes-real-data-wave780.test.js
+__tests__/purchasing-receipts-contracts-wave781.test.js
+__tests__/purchasing-routes-receipts-contracts-wave781.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js


### PR DESCRIPTION
## Summary
- Add PurchaseReceipt (GRN) and VendorSupplyContract models.
- Extend purchasingAdapter + /api/v1/purchasing routes for receipts and contracts (incl. /contracts/expiring).
- Closes branchWarehouseService mock fallbacks for purchaseReceiptService and vendorContractService.

## Test plan
- [ ] npx jest __tests__/purchasing-receipts-contracts-wave781.test.js
- [ ] CI sprint + Admin API Smoke
- [ ] Legacy branch warehouse UI: receipts + contracts tabs

Made with [Cursor](https://cursor.com)