### PR TITLE
fix(frontend): W782 legacy purchasing UI reads API envelopes

### DIFF
--- a/backend/services/purchasingAdapter.service.js
+++ b/backend/services/purchasingAdapter.service.js
@@ -107,6 +107,10 @@ function mapPrToLegacyRequest(doc) {
       (firstItem && firstItem.itemName) ||
       o.department ||
       'Purchase request',
+    branch: o.branch || o.department || '',
+    requestedBy: o.requestedBy || o.requester?.nameSnapshot || '',
+    priority: o.priority || 'normal',
+    estimatedValue: o.summary?.estimatedValue ?? o.estimatedValue ?? 0,
   };
 }
 

--- a/frontend/src/__tests__/services-branchWarehouseService.test.js
+++ b/frontend/src/__tests__/services-branchWarehouseService.test.js
@@ -50,6 +50,13 @@ describe('services/branchWarehouseService.js', () => {
     expect(source).toMatch(/purchaseRequestService/);
   });
 
+  test('unwraps purchasing API envelopes for legacy pages', () => {
+    expect(source).toMatch(/unwrapApiList/);
+    expect(source).toMatch(/purchasing\/requests.*unwrapApiList/s);
+    expect(source).toMatch(/purchasing\/receipts.*unwrapApiList/s);
+    expect(source).toMatch(/purchasing\/contracts.*unwrapApiList/s);
+  });
+
   test('makes API calls', () => {
     expect(source).toMatch(/(?:axios|api\.|fetch\(|\.get\(|\.post\(|\.put\(|\.delete\()/);
   });

--- a/frontend/src/pages/supply-chain/BranchPurchasing.js
+++ b/frontend/src/pages/supply-chain/BranchPurchasing.js
@@ -65,10 +65,30 @@ import {
 const prStatusConfig = {
   draft: { label: 'مسودة', color: 'default' },
   submitted: { label: 'مقدم', color: 'info' },
+  under_review: { label: 'قيد المراجعة', color: 'info' },
   approved: { label: 'معتمد', color: 'success' },
   rejected: { label: 'مرفوض', color: 'error' },
+  returned_for_clarification: { label: 'معاد للتوضيح', color: 'warning' },
+  converted_to_po: { label: 'تحوّل لأمر شراء', color: 'primary' },
+  cancelled: { label: 'ملغى', color: 'default' },
   ordered: { label: 'تم الطلب', color: 'primary' },
 };
+
+function computePrStats(rows) {
+  const list = Array.isArray(rows) ? rows : [];
+  return {
+    total: list.length,
+    draft: list.filter(r => r.status === 'draft').length,
+    submitted: list.filter(r => ['submitted', 'under_review'].includes(r.status)).length,
+    approved: list.filter(r => ['approved', 'converted_to_po'].includes(r.status)).length,
+    urgentPending: list.filter(
+      r =>
+        (r.priority === 'urgent' || r.isUrgent) &&
+        !['approved', 'rejected', 'cancelled', 'converted_to_po'].includes(r.status)
+    ).length,
+    totalEstimated: list.reduce((s, r) => s + (Number(r.estimatedValue) || 0), 0),
+  };
+}
 const priorityConfig = {
   urgent: { label: 'عاجل', color: 'error' },
   high: { label: 'عالي', color: 'warning' },
@@ -120,18 +140,18 @@ const BranchPurchasing = () => {
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
-      const [prData, rcData, ctData, brData, prStats] = await Promise.all([
+      const [prData, rcData, ctData, brData] = await Promise.all([
         purchaseRequestService.getAll(),
         purchaseReceiptService.getAll(),
         vendorContractService.getAll(),
         branchService.getAll(),
-        purchaseRequestService.getMockStats(),
       ]);
-      setRequests(prData || purchaseRequestService.getMockPRs());
+      const prRows = prData || purchaseRequestService.getMockPRs();
+      setRequests(prRows);
       setReceipts(rcData || purchaseReceiptService.getMockReceipts());
       setContracts(ctData || vendorContractService.getMockContracts());
       setBranches(brData || branchService.getMockBranches());
-      setStats(prStats || {});
+      setStats(computePrStats(prRows));
     } catch {
       setRequests(purchaseRequestService.getMockPRs());
       setReceipts(purchaseReceiptService.getMockReceipts());

--- a/frontend/src/pages/supply-chain/PurchasingManagement.js
+++ b/frontend/src/pages/supply-chain/PurchasingManagement.js
@@ -91,7 +91,7 @@ const PurchasingManagement = () => {
       ]);
       setVendors(Array.isArray(v?.data) ? v.data : purchasingService.getMockVendors());
       setOrders(Array.isArray(o?.data) ? o.data : purchasingService.getMockPOs());
-      setStats(s || purchasingService.getMockStats());
+      setStats(s?.data || s || purchasingService.getMockStats());
     } catch {
       setVendors(purchasingService.getMockVendors());
       setOrders(purchasingService.getMockPOs());

--- a/frontend/src/services/branchWarehouseService.js
+++ b/frontend/src/services/branchWarehouseService.js
@@ -17,6 +17,18 @@ const safe =
     }
   };
 
+/** Unwrap 66666 API envelopes `{ success, data }` for legacy React pages. */
+export function unwrapApiList(payload) {
+  if (Array.isArray(payload?.data)) return payload.data;
+  if (Array.isArray(payload)) return payload;
+  return null;
+}
+
+export function unwrapApiOne(payload) {
+  if (payload?.data != null && typeof payload.data === 'object') return payload.data;
+  return payload ?? null;
+}
+
 // ═══════════════════════════════════════════
 // 1. BRANCHES — الفروع
 // ═══════════════════════════════════════════
@@ -193,11 +205,11 @@ export const stockTakeService = {
 export const purchaseRequestService = {
   getAll: safe(async (params = {}) => {
     const r = await apiClient.get('/api/v1/purchasing/requests', { params });
-    return r.data;
+    return unwrapApiList(r.data);
   }),
   getById: safe(async id => {
     const r = await apiClient.get(`/api/v1/purchasing/requests/${id}`);
-    return r.data;
+    return unwrapApiOne(r.data);
   }),
   create: safe(async data => {
     const r = await apiClient.post('/api/v1/purchasing/requests', data);
@@ -230,15 +242,15 @@ export const purchaseRequestService = {
 export const purchaseReceiptService = {
   getAll: safe(async (params = {}) => {
     const r = await apiClient.get('/api/v1/purchasing/receipts', { params });
-    return r.data;
+    return unwrapApiList(r.data);
   }),
   create: safe(async data => {
     const r = await apiClient.post('/api/v1/purchasing/receipts', data);
-    return r.data;
+    return unwrapApiOne(r.data);
   }),
   getById: safe(async id => {
     const r = await apiClient.get(`/api/v1/purchasing/receipts/${id}`);
-    return r.data;
+    return unwrapApiOne(r.data);
   }),
 
   getMockReceipts: () => MOCK_RECEIPTS,
@@ -250,15 +262,15 @@ export const purchaseReceiptService = {
 export const vendorContractService = {
   getAll: safe(async (params = {}) => {
     const r = await apiClient.get('/api/v1/purchasing/contracts', { params });
-    return r.data;
+    return unwrapApiList(r.data);
   }),
   create: safe(async data => {
     const r = await apiClient.post('/api/v1/purchasing/contracts', data);
-    return r.data;
+    return unwrapApiOne(r.data);
   }),
   getExpiring: safe(async () => {
     const r = await apiClient.get('/api/v1/purchasing/contracts/expiring');
-    return r.data;
+    return unwrapApiList(r.data);
   }),
 
   getMockContracts: () => MOCK_CONTRACTS,


### PR DESCRIPTION
## Summary
- Unwrap { success, data } in branchWarehouseService for purchasing requests/receipts/contracts (W780/W781).
- BranchPurchasing: live PR stats + Phase-16 status labels.
- PurchasingManagement: fix stats envelope.
- Adapter: branch/priority/requestedBy on PR legacy mapper.

## Test plan
- [ ] /branch-purchasing and /purchasing with backend on :3001
- [ ] npx jest src/__tests__/services-branchWarehouseService.test.js

Made with [Cursor](https://cursor.com)