### PR TITLE
fix(backend): W783 alias /api/v1/inventory to inventory-enhanced

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -939,6 +939,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-receipts-contracts-wave781.test.js'
       - 'backend/__tests__/purchasing-routes-receipts-contracts-wave781.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/inventory-mount-alias-wave783.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1861,6 +1863,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-receipts-contracts-wave781.test.js'
       - 'backend/__tests__/purchasing-routes-receipts-contracts-wave781.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/inventory-mount-alias-wave783.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/inventory-mount-alias-wave783.test.js
+++ b/backend/__tests__/inventory-mount-alias-wave783.test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/**
+ * inventory-mount-alias-wave783.test.js — W783 drift guard.
+ * web-admin calls /api/v1/inventory/* (see apps/web-admin/src/lib/api.ts INV_BASE).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const FEATURES = fs.readFileSync(
+  path.join(__dirname, '..', 'routes', 'registries', 'features.registry.js'),
+  'utf8'
+);
+
+describe('W783 — inventory API alias for web-admin', () => {
+  it('features.registry mounts inventory-enhanced at /inventory (dual mount)', () => {
+    expect(FEATURES).toMatch(/dualMount\(app,\s*'inventory',\s*inventoryEnhancedRoutes\)/);
+  });
+
+  it('inventory-enhanced mount preserved for backward compatibility', () => {
+    expect(FEATURES).toMatch(/dualMount\(app,\s*'inventory-enhanced',\s*inventoryEnhancedRoutes\)/);
+  });
+});

--- a/backend/routes/registries/features.registry.js
+++ b/backend/routes/registries/features.registry.js
@@ -303,6 +303,8 @@ module.exports = function registerFeatureRoutes(
   dualMount(app, 'communication/notifications', notificationEnhancedRoutes);
   dualMount(app, 'branches-enhanced', branchEnhancedRoutes);
   dualMount(app, 'inventory-enhanced', inventoryEnhancedRoutes);
+  // W783 — web-admin INV_BASE is /api/v1/inventory (not inventory-enhanced).
+  dualMount(app, 'inventory', inventoryEnhancedRoutes);
   dualMount(app, 'quality-enhanced', qualityEnhancedRoutes);
   logger.info(
     '✅ prompt_08 Enhanced Modules mounted: communication/notifications (SMS/WhatsApp/FCM/templates/escalations/broadcasts), documents-enhanced (AES-256/versioning/e-signatures/OCR/sharing/retention), branches-enhanced (settings/rooms/services/transfers/comparison), inventory-enhanced (receive/issue/transfer/PO/assets-depreciation/stock-counts), quality-enhanced (CBAHI/incidents-RCA/complaints/NPS/audits/PDCA/risks — 200+ endpoints)'

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -108,6 +108,7 @@ __tests__/purchasing-vendor-order-wave780.test.js
 __tests__/purchasing-routes-real-data-wave780.test.js
 __tests__/purchasing-receipts-contracts-wave781.test.js
 __tests__/purchasing-routes-receipts-contracts-wave781.test.js
+__tests__/inventory-mount-alias-wave783.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js


### PR DESCRIPTION
## Summary
- web-admin \INV_BASE\ is \/api/v1/inventory\ but backend only mounted \inventory-enhanced\.
- Add \dualMount(app, 'inventory', inventoryEnhancedRoutes)\ (keeps legacy path).

## Test plan
- [ ] GET /api/v1/inventory/purchase-orders with auth
- [ ] web-admin /inventory/purchase-orders loads
- [ ] __tests__/inventory-mount-alias-wave783.test.js