### PR TITLE
W784: PO receive ↔ GRN bridge on legacy purchasing

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -941,6 +941,8 @@ on:
       - 'backend/__tests__/purchasing-routes-receipts-contracts-wave781.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/inventory-mount-alias-wave783.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-po-receipt-bridge-wave784.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1865,6 +1867,8 @@ on:
       - 'backend/__tests__/purchasing-routes-receipts-contracts-wave781.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/inventory-mount-alias-wave783.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-po-receipt-bridge-wave784.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/purchasing-po-receipt-bridge-wave784.test.js
+++ b/backend/__tests__/purchasing-po-receipt-bridge-wave784.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+/**
+ * purchasing-po-receipt-bridge-wave784.test.js — W784 PO receive ↔ GRN sync.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(30000);
+
+const mongoose = require('mongoose');
+const fs = require('fs');
+const path = require('path');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const adapter = require('../services/purchasingAdapter.service');
+
+let mongod;
+
+beforeAll(async () => {
+  const URI_FILE = path.join(__dirname, '..', '.test-mongo-uri');
+  let uri;
+  if (fs.existsSync(URI_FILE)) {
+    uri = fs.readFileSync(URI_FILE, 'utf-8').trim();
+  } else {
+    mongod = await MongoMemoryServer.create({ instance: { dbName: 'w784-purchasing' } });
+    uri = mongod.getUri();
+  }
+  await mongoose.connect(uri);
+  require('../models/inventory/PurchaseReceipt');
+  require('../models/inventory/PurchaseOrder');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+beforeEach(async () => {
+  const Receipt = require('../models/inventory/PurchaseReceipt');
+  const Po = require('../models/inventory/PurchaseOrder');
+  await Receipt.deleteMany({});
+  await Po.deleteMany({});
+});
+
+describe('W784 behavioral — PO receive creates linked GRN', () => {
+  it('receiveOrder auto-creates one PurchaseReceipt and is idempotent', async () => {
+    const actorId = new mongoose.Types.ObjectId();
+    const order = await adapter.createOrder(
+      {
+        vendor: 'مورد الربط',
+        items: [{ itemName: 'حبر', quantity: 5, unitCost: 10 }],
+      },
+      actorId
+    );
+    await adapter.approveOrder(order._id, actorId);
+
+    const received = await adapter.receiveOrder(order._id, actorId);
+    expect(received.status).toBe('received');
+
+    const Receipt = require('../models/inventory/PurchaseReceipt');
+    const grns = await Receipt.find({ purchase_order_id: order._id, deleted_at: null });
+    expect(grns).toHaveLength(1);
+    expect(grns[0].items[0].quantity_received).toBe(5);
+
+    const Po = require('../models/inventory/PurchaseOrder');
+    const poDoc = await Po.findById(order._id);
+    expect(poDoc.status).toBe('received');
+    expect(poDoc.items[0].quantity_received).toBe(5);
+
+    const again = await adapter.receiveOrder(order._id, actorId);
+    expect(again.status).toBe('received');
+    const grnsAfter = await Receipt.find({ purchase_order_id: order._id, deleted_at: null });
+    expect(grnsAfter).toHaveLength(1);
+  });
+});
+
+describe('W784 behavioral — manual GRN updates PO lines', () => {
+  it('createReceipt with purchaseOrderId sets partial then received', async () => {
+    const actorId = new mongoose.Types.ObjectId();
+    const order = await adapter.createOrder(
+      {
+        vendor: 'مورد جزئي',
+        items: [
+          { itemName: 'قلم', quantity: 10, unitCost: 2 },
+          { itemName: 'دفتر', quantity: 4, unitCost: 5 },
+        ],
+      },
+      actorId
+    );
+    await adapter.approveOrder(order._id, actorId);
+
+    await adapter.createReceipt(
+      {
+        purchaseOrderId: order._id,
+        vendor: 'مورد جزئي',
+        items: [
+          { itemName: 'قلم', quantity_ordered: 10, quantity_received: 10, unitCost: 2 },
+          { itemName: 'دفتر', quantity_ordered: 4, quantity_received: 2, unitCost: 5 },
+        ],
+      },
+      actorId
+    );
+
+    const Po = require('../models/inventory/PurchaseOrder');
+    const partial = await Po.findById(order._id);
+    expect(partial.status).toBe('partial');
+    expect(partial.items[0].quantity_received).toBe(10);
+    expect(partial.items[1].quantity_received).toBe(2);
+
+    await adapter.createReceipt(
+      {
+        purchaseOrderId: order._id,
+        vendor: 'مورد جزئي',
+        items: [{ itemName: 'دفتر', quantity_ordered: 4, quantity_received: 2, unitCost: 5 }],
+      },
+      actorId
+    );
+
+    const full = await Po.findById(order._id);
+    expect(full.status).toBe('received');
+    expect(full.items[1].quantity_received).toBe(4);
+  });
+});
+
+describe('W784 drift — adapter documents PO↔GRN bridge', () => {
+  it('receiveOrder creates PurchaseReceipt when none exists', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '..', 'services', 'purchasingAdapter.service.js'),
+      'utf8'
+    );
+    expect(src).toMatch(/W784/);
+    expect(src).toMatch(/applyReceiptLinesToPo/);
+    expect(src).toMatch(/existingGrn/);
+    expect(src).toMatch(/Receipt\.create\(/);
+  });
+});

--- a/backend/__tests__/purchasing-vendor-order-wave780.test.js
+++ b/backend/__tests__/purchasing-vendor-order-wave780.test.js
@@ -40,9 +40,11 @@ beforeEach(async () => {
   const Vendor = require('../models/Vendor');
   const Po = require('../models/inventory/PurchaseOrder');
   const PR = require('../models/operations/PurchaseRequest.model');
+  const Receipt = require('../models/inventory/PurchaseReceipt');
   await Vendor.deleteMany({});
   await Po.deleteMany({});
   await PR.deleteMany({});
+  await Receipt.deleteMany({});
 });
 
 describe('W780 behavioral — vendors', () => {

--- a/backend/services/purchasingAdapter.service.js
+++ b/backend/services/purchasingAdapter.service.js
@@ -5,6 +5,7 @@
  * W773: purchase requests → purchaseRequest.service.
  * W780: vendors → Vendor model; orders → InventoryModulePurchaseOrder.
  * W781: receipts → PurchaseReceipt; contracts → VendorSupplyContract.
+ * W784: PO receive ↔ GRN sync on InventoryModulePurchaseOrder.
  */
 
 function getVendorModel() {
@@ -397,23 +398,69 @@ async function approveOrder(id, actorId) {
   return mapPoToLegacy(doc);
 }
 
+async function applyReceiptLinesToPo(po, receiptLines, actorId) {
+  if (!po || !Array.isArray(po.items)) return po;
+  receiptLines.forEach((line, idx) => {
+    const poLine =
+      po.items.find(i => i.item_name_ar && line.item_name && i.item_name_ar === line.item_name) ||
+      po.items[idx];
+    if (!poLine) return;
+    const received = Number(line.quantity_received) || 0;
+    poLine.quantity_received = Math.min(
+      poLine.quantity_ordered || received,
+      (poLine.quantity_received || 0) + received
+    );
+  });
+  const allReceived = po.items.every(i => (i.quantity_received || 0) >= (i.quantity_ordered || 0));
+  po.status = allReceived ? 'received' : 'partial';
+  if (allReceived) po.actual_delivery_date = new Date();
+  if (actorId) po.updated_by = actorId;
+  await po.save();
+  return po;
+}
+
 async function receiveOrder(id, actorId) {
   const Po = getPoModel();
-  const doc = await Po.findOneAndUpdate(
-    { _id: id, deleted_at: null },
-    {
-      status: 'received',
-      actual_delivery_date: new Date(),
-      updated_by: actorId,
-    },
-    { new: true }
-  );
-  if (!doc) {
+  const Receipt = getReceiptModel();
+  const po = await Po.findOne({ _id: id, deleted_at: null });
+  if (!po) {
     const err = new Error('order_not_found');
     err.status = 404;
     throw err;
   }
-  return mapPoToLegacy(doc);
+
+  const existingGrn = await Receipt.findOne({ purchase_order_id: id, deleted_at: null });
+  if (existingGrn) {
+    return mapPoToLegacy(po);
+  }
+
+  const receiptLines = (po.items || []).map(it => ({
+    item_name: it.item_name_ar || 'Item',
+    quantity_ordered: it.quantity_ordered || 0,
+    quantity_received: it.quantity_ordered || 0,
+    unit_cost: it.unit_cost || 0,
+  }));
+
+  po.items.forEach(it => {
+    it.quantity_received = it.quantity_ordered || 0;
+  });
+  po.status = 'received';
+  po.actual_delivery_date = new Date();
+  po.updated_by = actorId;
+  await po.save();
+
+  await Receipt.create({
+    purchase_order_id: po._id,
+    po_number: po.po_number,
+    vendor_name: po.supplier_name,
+    branch_id: po.branch_id,
+    items: receiptLines,
+    received_by_name: null,
+    quality_check: 'passed',
+    created_by: actorId,
+  });
+
+  return mapPoToLegacy(po);
 }
 
 function getReceiptModel() {
@@ -551,6 +598,12 @@ async function createReceipt(body, actorId) {
     notes: body.notes,
     created_by: actorId,
   });
+
+  if (poId && require('mongoose').Types.ObjectId.isValid(poId)) {
+    const po = await Po.findOne({ _id: poId, deleted_at: null });
+    if (po) await applyReceiptLinesToPo(po, items, actorId);
+  }
+
   return mapReceiptToLegacy(doc);
 }
 

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -109,6 +109,7 @@ __tests__/purchasing-routes-real-data-wave780.test.js
 __tests__/purchasing-receipts-contracts-wave781.test.js
 __tests__/purchasing-routes-receipts-contracts-wave781.test.js
 __tests__/inventory-mount-alias-wave783.test.js
+__tests__/purchasing-po-receipt-bridge-wave784.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js


### PR DESCRIPTION
## Summary
- `receiveOrder` on `/api/v1/purchasing` now creates one linked `PurchaseReceipt` (GRN), updates PO line `quantity_received`, and is idempotent if a GRN already exists.
- `createReceipt` with `purchaseOrderId` syncs PO status to `partial` or `received` from receipt lines.
- Sprint test `purchasing-po-receipt-bridge-wave784.test.js` + W780 cleanup clears receipts between runs.

## Test plan
- [x] `npx jest __tests__/purchasing-po-receipt-bridge-wave784.test.js __tests__/purchasing-vendor-order-wave780.test.js`
- [ ] CI sprint + purchasing suites
- [ ] Manual: approve PO → receive → verify GRN in `/branch-purchasing` receipts tab