### PR TITLE
W785: list GRNs by purchase order + receipt stats

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -943,6 +943,8 @@ on:
       - 'backend/__tests__/inventory-mount-alias-wave783.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-po-receipt-bridge-wave784.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-order-receipts-wave785.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1869,6 +1871,8 @@ on:
       - 'backend/__tests__/inventory-mount-alias-wave783.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-po-receipt-bridge-wave784.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-order-receipts-wave785.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/purchasing-order-receipts-wave785.test.js
+++ b/backend/__tests__/purchasing-order-receipts-wave785.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * purchasing-order-receipts-wave785.test.js — W785 PO-linked GRN listing + stats.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(30000);
+
+const mongoose = require('mongoose');
+const fs = require('fs');
+const path = require('path');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const adapter = require('../services/purchasingAdapter.service');
+
+let mongod;
+
+beforeAll(async () => {
+  const URI_FILE = path.join(__dirname, '..', '.test-mongo-uri');
+  let uri;
+  if (fs.existsSync(URI_FILE)) {
+    uri = fs.readFileSync(URI_FILE, 'utf-8').trim();
+  } else {
+    mongod = await MongoMemoryServer.create({ instance: { dbName: 'w785-purchasing' } });
+    uri = mongod.getUri();
+  }
+  await mongoose.connect(uri);
+  require('../models/inventory/PurchaseReceipt');
+  require('../models/inventory/PurchaseOrder');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+beforeEach(async () => {
+  const Receipt = require('../models/inventory/PurchaseReceipt');
+  const Po = require('../models/inventory/PurchaseOrder');
+  await Receipt.deleteMany({});
+  await Po.deleteMany({});
+});
+
+describe('W785 behavioral — receipts by purchase order', () => {
+  it('listReceiptsForOrder returns GRNs after receiveOrder', async () => {
+    const actorId = new mongoose.Types.ObjectId();
+    const order = await adapter.createOrder(
+      { vendor: 'مورد', items: [{ itemName: 'صنف', quantity: 3, unitCost: 1 }] },
+      actorId
+    );
+    await adapter.approveOrder(order._id, actorId);
+    await adapter.receiveOrder(order._id, actorId);
+
+    const linked = await adapter.listReceiptsForOrder(order._id);
+    expect(linked).toHaveLength(1);
+    expect(String(linked[0].purchaseOrderId)).toBe(String(order._id));
+
+    const stats = await adapter.getStats();
+    expect(stats.totalReceipts).toBe(1);
+  });
+});
+
+describe('W785 drift — route and adapter surface', () => {
+  it('registers GET /orders/:id/receipts before /orders/:id', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '..', 'routes', 'purchasing.routes.js'),
+      'utf8'
+    );
+    const receiptsIdx = src.indexOf("'/orders/:id/receipts'");
+    const orderIdx = src.indexOf("'/orders/:id',");
+    expect(receiptsIdx).toBeGreaterThan(-1);
+    expect(orderIdx).toBeGreaterThan(receiptsIdx);
+    expect(src).toMatch(/listReceiptsForOrder/);
+  });
+});

--- a/backend/routes/purchasing.routes.js
+++ b/backend/routes/purchasing.routes.js
@@ -1,6 +1,6 @@
 /**
  * Purchasing Routes — /api/v1/purchasing/*
- * W773 — PR adapter; W780 — vendors/orders; W781 — receipts + vendor contracts.
+ * W773 — PR adapter; W780 — vendors/orders; W781 — receipts + vendor contracts; W785 — PO receipts.
  */
 'use strict';
 
@@ -293,6 +293,21 @@ router.patch(
       return res.status(404).json({ success: false, message: 'order_not_found' });
     }
     const data = await adapter.getOrder(req.params.id);
+    res.json({ success: true, data });
+  })
+);
+
+router.get(
+  '/orders/:id/receipts',
+  wrap(async (req, res) => {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'invalid_id' });
+    }
+    const scope = branchFilter(req);
+    const data = await adapter.listReceiptsForOrder(req.params.id, {
+      ...req.query,
+      branchId: scope.branchId || req.query.branchId,
+    });
     res.json({ success: true, data });
   })
 );

--- a/backend/services/purchasingAdapter.service.js
+++ b/backend/services/purchasingAdapter.service.js
@@ -6,6 +6,7 @@
  * W780: vendors → Vendor model; orders → InventoryModulePurchaseOrder.
  * W781: receipts → PurchaseReceipt; contracts → VendorSupplyContract.
  * W784: PO receive ↔ GRN sync on InventoryModulePurchaseOrder.
+ * W785: list receipts by PO + dashboard receipt count.
  */
 
 function getVendorModel() {
@@ -483,6 +484,7 @@ function mapReceiptToLegacy(doc) {
     _id: o._id,
     receiptNumber: o.receiptNumber || o.receipt_number,
     purchaseOrder: o.purchaseOrder || o.po_number || '',
+    purchaseOrderId: o.purchaseOrderId || o.purchase_order_id || null,
     vendor: o.vendor || o.vendor_name || '',
     warehouse: o.warehouse || o.warehouse_name || '',
     branch: o.branch || (o.branch_id ? String(o.branch_id) : ''),
@@ -528,6 +530,10 @@ async function listReceipts(query = {}) {
   const filter = { deleted_at: null };
   if (query.branchId) filter.branch_id = query.branchId;
   if (query.status) filter.status = query.status;
+  const poId = query.purchaseOrderId || query.purchase_order_id;
+  if (poId && require('mongoose').Types.ObjectId.isValid(poId)) {
+    filter.purchase_order_id = poId;
+  }
   const rows = await Receipt.find(filter)
     .sort({ receipt_date: -1 })
     .limit(query.limit ? Number(query.limit) : 200)
@@ -651,9 +657,19 @@ async function createContract(body) {
   return mapContractToLegacy(doc);
 }
 
+async function listReceiptsForOrder(orderId, query = {}) {
+  if (!require('mongoose').Types.ObjectId.isValid(orderId)) {
+    const err = new Error('invalid_order_id');
+    err.status = 400;
+    throw err;
+  }
+  return listReceipts({ ...query, purchaseOrderId: orderId });
+}
+
 async function getStats() {
   const Vendor = getVendorModel();
   const Po = getPoModel();
+  const Receipt = getReceiptModel();
   const rows = await listRequests({ limit: 500 });
   const pendingStatuses = new Set([
     'draft',
@@ -662,12 +678,13 @@ async function getStats() {
     'returned_for_clarification',
   ]);
   const pendingRequests = rows.filter(r => pendingStatuses.has(r.status)).length;
-  const [totalVendors, activeOrders, spendAgg] = await Promise.all([
+  const [totalVendors, activeOrders, totalReceipts, spendAgg] = await Promise.all([
     Vendor.countDocuments({ isDeleted: { $ne: true }, status: 'active' }),
     Po.countDocuments({
       deleted_at: null,
       status: { $in: ['approved', 'sent', 'partial', 'received', 'closed'] },
     }),
+    Receipt.countDocuments({ deleted_at: null }),
     Po.aggregate([
       { $match: { deleted_at: null, status: { $in: ['received', 'closed', 'approved', 'sent'] } } },
       { $group: { _id: null, total: { $sum: '$total_amount' } } },
@@ -677,6 +694,7 @@ async function getStats() {
   return {
     totalVendors,
     activeOrders,
+    totalReceipts,
     pendingRequests,
     totalSpend,
     monthlyBudget: 0,
@@ -704,6 +722,7 @@ module.exports = {
   approveOrder,
   receiveOrder,
   listReceipts,
+  listReceiptsForOrder,
   getReceipt,
   createReceipt,
   listContracts,

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -110,6 +110,7 @@ __tests__/purchasing-receipts-contracts-wave781.test.js
 __tests__/purchasing-routes-receipts-contracts-wave781.test.js
 __tests__/inventory-mount-alias-wave783.test.js
 __tests__/purchasing-po-receipt-bridge-wave784.test.js
+__tests__/purchasing-order-receipts-wave785.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js


### PR DESCRIPTION
## Summary
- Merged follow-up to W784: GET /api/v1/purchasing/orders/:id/receipts lists linked GRNs.
- listReceipts accepts purchaseOrderId; legacy payloads include purchaseOrderId.
- getStats adds totalReceipts for purchasing dashboard.

## Test plan
- [x] jest purchasing-order-receipts-wave785 + po-receipt-bridge-wave784
- [ ] CI sprint

Made with [Cursor](https://cursor.com)