### PR TITLE
W786: inventory stock on purchasing PO receive

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -945,6 +945,8 @@ on:
       - 'backend/__tests__/purchasing-po-receipt-bridge-wave784.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-order-receipts-wave785.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-receive-stock-wave786.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1873,6 +1875,8 @@ on:
       - 'backend/__tests__/purchasing-po-receipt-bridge-wave784.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-order-receipts-wave785.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-receive-stock-wave786.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/purchasing-receive-stock-wave786.test.js
+++ b/backend/__tests__/purchasing-receive-stock-wave786.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+/**
+ * purchasing-receive-stock-wave786.test.js — W786 PO receive bumps InventoryModuleItem stock.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(30000);
+
+const mongoose = require('mongoose');
+const fs = require('fs');
+const path = require('path');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const adapter = require('../services/purchasingAdapter.service');
+
+let mongod;
+
+beforeAll(async () => {
+  const URI_FILE = path.join(__dirname, '..', '.test-mongo-uri');
+  let uri;
+  if (fs.existsSync(URI_FILE)) {
+    uri = fs.readFileSync(URI_FILE, 'utf-8').trim();
+  } else {
+    mongod = await MongoMemoryServer.create({ instance: { dbName: 'w786-purchasing-stock' } });
+    uri = mongod.getUri();
+  }
+  await mongoose.connect(uri);
+  require('../models/inventory/InventoryItem');
+  require('../models/inventory/InventoryTransaction');
+  require('../models/inventory/PurchaseReceipt');
+  require('../models/inventory/PurchaseOrder');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+beforeEach(async () => {
+  const Item = require('../models/inventory/InventoryItem');
+  const Txn = require('../models/inventory/InventoryTransaction');
+  const Receipt = require('../models/inventory/PurchaseReceipt');
+  const Po = require('../models/inventory/PurchaseOrder');
+  await Item.deleteMany({});
+  await Txn.deleteMany({});
+  await Receipt.deleteMany({});
+  await Po.deleteMany({});
+});
+
+describe('W786 behavioral — receiveOrder updates stock', () => {
+  it('increments quantity_on_hand and writes receipt transaction', async () => {
+    const actorId = new mongoose.Types.ObjectId();
+    const Item = require('../models/inventory/InventoryItem');
+    const inv = await Item.create({
+      name_ar: 'قفازات',
+      category: 'medical_supplies',
+      quantity_on_hand: 10,
+      quantity_available: 10,
+      created_by: actorId,
+    });
+
+    const order = await adapter.createOrder(
+      {
+        vendor: 'مورد طبي',
+        items: [{ itemId: inv._id, itemName: 'قفازات', quantity: 5, unitCost: 2 }],
+      },
+      actorId
+    );
+    await adapter.approveOrder(order._id, actorId);
+    await adapter.receiveOrder(order._id, actorId);
+
+    const updated = await Item.findById(inv._id);
+    expect(updated.quantity_on_hand).toBe(15);
+    expect(updated.quantity_available).toBe(15);
+
+    const Txn = require('../models/inventory/InventoryTransaction');
+    const txns = await Txn.find({ item_id: inv._id, transaction_type: 'receipt' });
+    expect(txns).toHaveLength(1);
+    expect(txns[0].quantity).toBe(5);
+    expect(String(txns[0].reference_id)).toBe(String(order._id));
+  });
+});
+
+describe('W786 drift — stock lib wired in adapter', () => {
+  it('receiveOrder imports purchasingStockReceive.lib', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '..', 'services', 'purchasingAdapter.service.js'),
+      'utf8'
+    );
+    expect(src).toMatch(/W786/);
+    expect(src).toMatch(/purchasingStockReceive\.lib/);
+    expect(src).toMatch(/applyStockReceiptForPoLines/);
+  });
+});

--- a/backend/models/inventory/InventoryItem.js
+++ b/backend/models/inventory/InventoryItem.js
@@ -81,7 +81,7 @@ const inventoryItemSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-inventoryItemSchema.pre('save', async function (next) {
+inventoryItemSchema.pre('save', async function () {
   if (!this.item_code) {
     const year = new Date().getFullYear();
     // Query the scoped model name so the counter is stable per-collection.
@@ -90,7 +90,6 @@ inventoryItemSchema.pre('save', async function (next) {
   }
   // حساب الكمية المتاحة
   this.quantity_available = Math.max(0, this.quantity_on_hand - this.quantity_reserved);
-  next();
 });
 
 inventoryItemSchema.index({ category: 1, is_active: 1 });
@@ -103,5 +102,4 @@ inventoryItemSchema.index({ deleted_at: 1 });
 // canonical models/InventoryItem.js (used by inventory-enhanced.routes.js).
 // Default export unchanged.
 module.exports =
-  mongoose.models.InventoryModuleItem ||
-  mongoose.model('InventoryModuleItem', inventoryItemSchema);
+  mongoose.models.InventoryModuleItem || mongoose.model('InventoryModuleItem', inventoryItemSchema);

--- a/backend/models/inventory/InventoryTransaction.js
+++ b/backend/models/inventory/InventoryTransaction.js
@@ -62,7 +62,7 @@ const inventoryTransactionSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-inventoryTransactionSchema.pre('save', async function (next) {
+inventoryTransactionSchema.pre('save', async function () {
   if (!this.transaction_number) {
     const year = new Date().getFullYear();
     // Query the scoped model name so the counter is stable per-collection.
@@ -70,7 +70,6 @@ inventoryTransactionSchema.pre('save', async function (next) {
     this.transaction_number = `TXN-${year}-${String(count + 1).padStart(7, '0')}`;
   }
   this.total_cost = this.quantity * (this.unit_cost || 0);
-  next();
 });
 
 inventoryTransactionSchema.index({ item_id: 1, transaction_date: -1 });

--- a/backend/services/purchasingAdapter.service.js
+++ b/backend/services/purchasingAdapter.service.js
@@ -7,7 +7,10 @@
  * W781: receipts → PurchaseReceipt; contracts → VendorSupplyContract.
  * W784: PO receive ↔ GRN sync on InventoryModulePurchaseOrder.
  * W785: list receipts by PO + dashboard receipt count.
+ * W786: stock receipt when PO lines include item_id (InventoryModuleItem).
  */
+
+const { applyStockReceiptForPoLines } = require('./purchasingStockReceive.lib');
 
 function getVendorModel() {
   return require('../models/Vendor');
@@ -351,6 +354,7 @@ async function getOrder(id) {
 async function createOrder(body, actorId) {
   const Po = getPoModel();
   const items = (body.items || []).map(it => ({
+    item_id: it.itemId || it.item_id,
     item_name_ar: it.itemName || it.item_name_ar || it.name || 'Item',
     item_code: it.itemCode || it.item_code,
     quantity_ordered: it.quantity || it.quantity_ordered || 1,
@@ -401,22 +405,32 @@ async function approveOrder(id, actorId) {
 
 async function applyReceiptLinesToPo(po, receiptLines, actorId) {
   if (!po || !Array.isArray(po.items)) return po;
+  const stockDeltas = [];
   receiptLines.forEach((line, idx) => {
     const poLine =
       po.items.find(i => i.item_name_ar && line.item_name && i.item_name_ar === line.item_name) ||
       po.items[idx];
     if (!poLine) return;
+    const before = poLine.quantity_received || 0;
     const received = Number(line.quantity_received) || 0;
-    poLine.quantity_received = Math.min(
-      poLine.quantity_ordered || received,
-      (poLine.quantity_received || 0) + received
-    );
+    poLine.quantity_received = Math.min(poLine.quantity_ordered || received, before + received);
+    const delta = (poLine.quantity_received || 0) - before;
+    if (poLine.item_id && delta > 0) {
+      stockDeltas.push({
+        item_id: poLine.item_id,
+        quantity_delta: delta,
+        unit_cost: poLine.unit_cost || 0,
+      });
+    }
   });
   const allReceived = po.items.every(i => (i.quantity_received || 0) >= (i.quantity_ordered || 0));
   po.status = allReceived ? 'received' : 'partial';
   if (allReceived) po.actual_delivery_date = new Date();
   if (actorId) po.updated_by = actorId;
   await po.save();
+  if (stockDeltas.length) {
+    await applyStockReceiptForPoLines({ po, deltas: stockDeltas, actorId });
+  }
   return po;
 }
 
@@ -442,13 +456,27 @@ async function receiveOrder(id, actorId) {
     unit_cost: it.unit_cost || 0,
   }));
 
+  const stockDeltas = [];
   po.items.forEach(it => {
-    it.quantity_received = it.quantity_ordered || 0;
+    const prev = it.quantity_received || 0;
+    const next = it.quantity_ordered || 0;
+    if (it.item_id && next > prev) {
+      stockDeltas.push({
+        item_id: it.item_id,
+        quantity_delta: next - prev,
+        unit_cost: it.unit_cost || 0,
+      });
+    }
+    it.quantity_received = next;
   });
   po.status = 'received';
   po.actual_delivery_date = new Date();
   po.updated_by = actorId;
   await po.save();
+
+  if (stockDeltas.length) {
+    await applyStockReceiptForPoLines({ po, deltas: stockDeltas, actorId });
+  }
 
   await Receipt.create({
     purchase_order_id: po._id,

--- a/backend/services/purchasingStockReceive.lib.js
+++ b/backend/services/purchasingStockReceive.lib.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * W786 — inventory-module stock receipt when PO lines carry item_id.
+ * Mirrors inventory-module.routes.js POST purchase-orders/:id/receive.
+ */
+
+function getInventoryItemModel() {
+  return require('../models/inventory/InventoryItem');
+}
+
+function getInventoryTransactionModel() {
+  return require('../models/inventory/InventoryTransaction');
+}
+
+/**
+ * @param {{ po: object, deltas: Array<{ item_id: unknown, quantity_delta: number, unit_cost?: number }>, actorId: unknown }} opts
+ */
+async function applyStockReceiptForPoLines({ po, deltas, actorId }) {
+  if (!po || !Array.isArray(deltas) || !deltas.length) return;
+
+  const InventoryItem = getInventoryItemModel();
+  const InventoryTransaction = getInventoryTransactionModel();
+
+  for (const line of deltas) {
+    if (!line.item_id || !(line.quantity_delta > 0)) continue;
+
+    const item = await InventoryItem.findById(line.item_id);
+    if (!item) continue;
+
+    const qtyBefore = item.quantity_on_hand || 0;
+    const delta = Number(line.quantity_delta);
+    const qtyAfter = qtyBefore + delta;
+    const qtyAvailable = Math.max(0, qtyAfter - (item.quantity_reserved || 0));
+    await InventoryItem.updateOne(
+      { _id: line.item_id },
+      { $set: { quantity_on_hand: qtyAfter, quantity_available: qtyAvailable } }
+    );
+
+    await InventoryTransaction.create({
+      item_id: line.item_id,
+      transaction_type: 'receipt',
+      quantity: delta,
+      unit_cost: line.unit_cost || 0,
+      quantity_before: qtyBefore,
+      quantity_after: qtyAfter,
+      reference_type: 'PurchaseOrder',
+      reference_id: po._id,
+      reference_number: po.po_number,
+      branch_id: po.branch_id,
+      created_by: actorId,
+    });
+  }
+}
+
+module.exports = { applyStockReceiptForPoLines };

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -111,6 +111,7 @@ __tests__/purchasing-routes-receipts-contracts-wave781.test.js
 __tests__/inventory-mount-alias-wave783.test.js
 __tests__/purchasing-po-receipt-bridge-wave784.test.js
 __tests__/purchasing-order-receipts-wave785.test.js
+__tests__/purchasing-receive-stock-wave786.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js


### PR DESCRIPTION
## Summary
- When legacy purchasing PO lines include item_id, receiveOrder and partial GRN sync bump InventoryModuleItem stock and log InventoryModuleTransaction (purchasingStockReceive.lib).
- createOrder accepts itemId on line items.
- Fix async pre-save hooks on InventoryModuleItem and InventoryModuleTransaction (next is not a function).

## Test plan
- [x] purchasing-receive-stock-wave786
- [ ] CI sprint

Made with [Cursor](https://cursor.com)