### PR TITLE
W787: purchasing dashboard stats + receive PO in UI

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -947,6 +947,8 @@ on:
       - 'backend/__tests__/purchasing-order-receipts-wave785.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-receive-stock-wave786.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-stats-legacy-wave787.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1877,6 +1879,8 @@ on:
       - 'backend/__tests__/purchasing-order-receipts-wave785.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-receive-stock-wave786.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-stats-legacy-wave787.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/purchasing-stats-legacy-wave787.test.js
+++ b/backend/__tests__/purchasing-stats-legacy-wave787.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * purchasing-stats-legacy-wave787.test.js — W787 stats aliases for legacy UI.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(30000);
+
+const mongoose = require('mongoose');
+const fs = require('fs');
+const path = require('path');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const adapter = require('../services/purchasingAdapter.service');
+
+let mongod;
+
+beforeAll(async () => {
+  const URI_FILE = path.join(__dirname, '..', '.test-mongo-uri');
+  let uri;
+  if (fs.existsSync(URI_FILE)) {
+    uri = fs.readFileSync(URI_FILE, 'utf-8').trim();
+  } else {
+    mongod = await MongoMemoryServer.create({ instance: { dbName: 'w787-purchasing-stats' } });
+    uri = mongod.getUri();
+  }
+  await mongoose.connect(uri);
+  require('../models/Vendor');
+  require('../models/inventory/PurchaseOrder');
+  require('../models/inventory/PurchaseReceipt');
+  require('../models/operations/PurchaseRequest.model');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+beforeEach(async () => {
+  const Vendor = require('../models/Vendor');
+  const Po = require('../models/inventory/PurchaseOrder');
+  const Receipt = require('../models/inventory/PurchaseReceipt');
+  const PR = require('../models/operations/PurchaseRequest.model');
+  await Vendor.deleteMany({});
+  await Po.deleteMany({});
+  await Receipt.deleteMany({});
+  await PR.deleteMany({});
+});
+
+describe('W787 behavioral — getStats legacy UI fields', () => {
+  it('returns tiles used by PurchasingManagement.js', async () => {
+    const actorId = new mongoose.Types.ObjectId();
+    await adapter.createVendor({ name: 'مورد', email: 'a@b.c', phone: '05', city: 'الرياض' });
+    const order = await adapter.createOrder(
+      { vendor: 'مورد', items: [{ itemName: 'بند', quantity: 2, unitCost: 50 }] },
+      actorId
+    );
+    await adapter.approveOrder(order._id, actorId);
+    await adapter.receiveOrder(order._id, actorId);
+
+    const stats = await adapter.getStats();
+    expect(stats.totalOrders).toBeGreaterThanOrEqual(1);
+    expect(stats.totalAmount).toBe(stats.totalSpend);
+    expect(stats.vendors).toBe(stats.totalVendors);
+    expect(stats.delivered).toBeGreaterThanOrEqual(1);
+    expect(stats.totalReceipts).toBeGreaterThanOrEqual(1);
+    expect(typeof stats.avgDeliveryDays).toBe('number');
+  });
+});
+
+describe('W787 drift — legacy stats documented in adapter', () => {
+  it('getStats maps totalAmount and vendors aliases', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '..', 'services', 'purchasingAdapter.service.js'),
+      'utf8'
+    );
+    expect(src).toMatch(/W787/);
+    expect(src).toMatch(/totalAmount: totalSpend/);
+    expect(src).toMatch(/vendors: totalVendors/);
+  });
+});

--- a/backend/services/purchasingAdapter.service.js
+++ b/backend/services/purchasingAdapter.service.js
@@ -8,6 +8,7 @@
  * W784: PO receive ↔ GRN sync on InventoryModulePurchaseOrder.
  * W785: list receipts by PO + dashboard receipt count.
  * W786: stock receipt when PO lines include item_id (InventoryModuleItem).
+ * W787: legacy stats field aliases for PurchasingManagement.js tiles.
  */
 
 const { applyStockReceiptForPoLines } = require('./purchasingStockReceive.lib');
@@ -706,19 +707,57 @@ async function getStats() {
     'returned_for_clarification',
   ]);
   const pendingRequests = rows.filter(r => pendingStatuses.has(r.status)).length;
-  const [totalVendors, activeOrders, totalReceipts, spendAgg] = await Promise.all([
+  const [
+    totalVendors,
+    activeOrders,
+    totalReceipts,
+    totalOrders,
+    delivered,
+    pendingApproval,
+    spendAgg,
+  ] = await Promise.all([
     Vendor.countDocuments({ isDeleted: { $ne: true }, status: 'active' }),
     Po.countDocuments({
       deleted_at: null,
       status: { $in: ['approved', 'sent', 'partial', 'received', 'closed'] },
     }),
     Receipt.countDocuments({ deleted_at: null }),
+    Po.countDocuments({ deleted_at: null }),
+    Po.countDocuments({ deleted_at: null, status: { $in: ['received', 'closed'] } }),
+    Po.countDocuments({
+      deleted_at: null,
+      status: { $in: ['draft', 'pending_approval'] },
+    }),
     Po.aggregate([
-      { $match: { deleted_at: null, status: { $in: ['received', 'closed', 'approved', 'sent'] } } },
+      {
+        $match: {
+          deleted_at: null,
+          status: { $in: ['received', 'closed', 'approved', 'sent', 'partial'] },
+        },
+      },
       { $group: { _id: null, total: { $sum: '$total_amount' } } },
     ]),
   ]);
   const totalSpend = spendAgg[0]?.total || 0;
+
+  const deliveredPos = await Po.find({
+    deleted_at: null,
+    status: { $in: ['received', 'closed'] },
+    actual_delivery_date: { $ne: null },
+    order_date: { $ne: null },
+  })
+    .select('order_date actual_delivery_date')
+    .lean();
+  let avgDeliveryDays = 0;
+  if (deliveredPos.length) {
+    const sumDays = deliveredPos.reduce((acc, p) => {
+      const days =
+        (new Date(p.actual_delivery_date).getTime() - new Date(p.order_date).getTime()) / 86400000;
+      return acc + Math.max(0, days);
+    }, 0);
+    avgDeliveryDays = Math.round(sumDays / deliveredPos.length);
+  }
+
   return {
     totalVendors,
     activeOrders,
@@ -727,6 +766,12 @@ async function getStats() {
     totalSpend,
     monthlyBudget: 0,
     savingsAchieved: 0,
+    totalOrders,
+    totalAmount: totalSpend,
+    pendingApproval,
+    delivered,
+    vendors: totalVendors,
+    avgDeliveryDays,
   };
 }
 

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -112,6 +112,7 @@ __tests__/inventory-mount-alias-wave783.test.js
 __tests__/purchasing-po-receipt-bridge-wave784.test.js
 __tests__/purchasing-order-receipts-wave785.test.js
 __tests__/purchasing-receive-stock-wave786.test.js
+__tests__/purchasing-stats-legacy-wave787.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js

--- a/frontend/src/pages/supply-chain/PurchasingManagement.js
+++ b/frontend/src/pages/supply-chain/PurchasingManagement.js
@@ -40,6 +40,7 @@ import {
   Description as POIcon,
   Visibility as ViewIcon,
   Check as ApproveIcon,
+  LocalShipping as ReceiveIcon,
 } from '@mui/icons-material';
 import { purchasingService } from 'services/operationsService';
 import { gradients, brandColors, statusColors, surfaceColors, neutralColors } from 'theme/palette';
@@ -126,6 +127,16 @@ const PurchasingManagement = () => {
     }
   };
 
+  const handleReceivePO = async id => {
+    try {
+      await purchasingService.receivePO(id);
+      showSnackbar('تم تسجيل استلام أمر الشراء', 'success');
+      loadData();
+    } catch {
+      showSnackbar('فشل في تسجيل الاستلام', 'error');
+    }
+  };
+
   return (
     <Container maxWidth="xl" sx={{ py: 3 }}>
       {/* Header */}
@@ -178,14 +189,19 @@ const PurchasingManagement = () => {
               color: statusColors.warning,
             },
             { label: 'تم التسليم', value: stats.delivered, color: statusColors.info },
+            {
+              label: 'سجلات الاستلام',
+              value: stats.totalReceipts ?? 0,
+              color: statusColors.info,
+            },
             { label: 'الموردين', value: stats.vendors, color: brandColors.primary },
             {
               label: 'متوسط التسليم',
-              value: `${stats.avgDeliveryDays} أيام`,
+              value: `${stats.avgDeliveryDays ?? 0} أيام`,
               color: neutralColors.textSecondary,
             },
           ].map((s, i) => (
-            <Grid item xs={2} key={i}>
+            <Grid item xs={6} sm={4} md={3} lg={2} key={i}>
               <Card
                 sx={{
                   borderRadius: 2.5,
@@ -318,6 +334,17 @@ const PurchasingManagement = () => {
                               onClick={() => handleApprovePO(po._id)}
                             >
                               <ApproveIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        )}
+                        {(po.status === 'approved' || po.status === 'ordered') && (
+                          <Tooltip title="تسجيل الاستلام">
+                            <IconButton
+                              size="small"
+                              color="primary"
+                              onClick={() => handleReceivePO(po._id)}
+                            >
+                              <ReceiveIcon fontSize="small" />
                             </IconButton>
                           </Tooltip>
                         )}


### PR DESCRIPTION
## Summary
- getStats returns legacy field names (totalOrders, totalAmount, delivered, vendors, avgDeliveryDays) plus totalReceipts.
- PurchasingManagement: GRN stat tile, receive button for approved/ordered POs via PATCH /orders/:id/receive.

## Test plan
- [x] purchasing-stats-legacy-wave787
- [x] frontend eslint pre-push
- [ ] CI

Made with [Cursor](https://cursor.com)