### PR TITLE
W788: BranchPurchasing purchase orders + linked GRNs

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -949,6 +949,8 @@ on:
       - 'backend/__tests__/purchasing-receive-stock-wave786.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-stats-legacy-wave787.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/branch-purchasing-orders-wave788.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1881,6 +1883,8 @@ on:
       - 'backend/__tests__/purchasing-receive-stock-wave786.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-stats-legacy-wave787.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/branch-purchasing-orders-wave788.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/branch-purchasing-orders-wave788.test.js
+++ b/backend/__tests__/branch-purchasing-orders-wave788.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * branch-purchasing-orders-wave788.test.js — W788 BranchPurchasing PO tab drift guard.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SERVICE = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'frontend', 'src', 'services', 'branchWarehouseService.js'),
+  'utf8'
+);
+const PAGE = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    'frontend',
+    'src',
+    'pages',
+    'supply-chain',
+    'BranchPurchasing.js'
+  ),
+  'utf8'
+);
+
+describe('W788 — branch purchasing purchase orders', () => {
+  it('purchaseOrderService wraps orders + receipts endpoints', () => {
+    expect(SERVICE).toMatch(/export const purchaseOrderService/);
+    expect(SERVICE).toMatch(/purchasing\/orders.*unwrapApiList/s);
+    expect(SERVICE).toMatch(/orders\/\$\{id\}\/receipts/);
+    expect(SERVICE).toMatch(/patch\(`\/api\/v1\/purchasing\/orders\/\$\{id\}\/receive`/);
+  });
+
+  it('BranchPurchasing renders PO tab with receive and GRN dialog', () => {
+    expect(PAGE).toMatch(/أوامر الشراء/);
+    expect(PAGE).toMatch(/purchaseOrderService/);
+    expect(PAGE).toMatch(/handleReceivePO/);
+    expect(PAGE).toMatch(/handleViewPoGrns/);
+    expect(PAGE).toMatch(/poGrnDialogOpen/);
+  });
+});

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -113,6 +113,7 @@ __tests__/purchasing-po-receipt-bridge-wave784.test.js
 __tests__/purchasing-order-receipts-wave785.test.js
 __tests__/purchasing-receive-stock-wave786.test.js
 __tests__/purchasing-stats-legacy-wave787.test.js
+__tests__/branch-purchasing-orders-wave788.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js

--- a/frontend/src/__tests__/services-branchWarehouseService.test.js
+++ b/frontend/src/__tests__/services-branchWarehouseService.test.js
@@ -55,6 +55,9 @@ describe('services/branchWarehouseService.js', () => {
     expect(source).toMatch(/purchasing\/requests.*unwrapApiList/s);
     expect(source).toMatch(/purchasing\/receipts.*unwrapApiList/s);
     expect(source).toMatch(/purchasing\/contracts.*unwrapApiList/s);
+    expect(source).toMatch(/purchaseOrderService/);
+    expect(source).toMatch(/purchasing\/orders.*unwrapApiList/s);
+    expect(source).toMatch(/orders\/\$\{id\}\/receipts/);
   });
 
   test('makes API calls', () => {

--- a/frontend/src/pages/supply-chain/BranchPurchasing.js
+++ b/frontend/src/pages/supply-chain/BranchPurchasing.js
@@ -52,11 +52,13 @@ import {
   Edit as EditIcon,
   PriorityHigh as UrgentIcon,
   Schedule as PendingIcon,
+  LocalShipping as ReceiveIcon,
 } from '@mui/icons-material';
 import { useSnackbar } from 'contexts/SnackbarContext';
 import { gradients, surfaceColors } from 'theme/palette';
 import {
   purchaseRequestService,
+  purchaseOrderService,
   purchaseReceiptService,
   vendorContractService,
   branchService,
@@ -95,6 +97,14 @@ const priorityConfig = {
   medium: { label: 'متوسط', color: 'info' },
   low: { label: 'منخفض', color: 'default' },
 };
+const poStatusConfig = {
+  draft: { label: 'مسودة', color: 'default' },
+  pending: { label: 'بانتظار الموافقة', color: 'warning' },
+  approved: { label: 'معتمد', color: 'info' },
+  ordered: { label: 'تم الطلب', color: 'primary' },
+  received: { label: 'مستلم', color: 'success' },
+  cancelled: { label: 'ملغي', color: 'error' },
+};
 const receiptStatusConfig = {
   complete: { label: 'مكتمل', color: 'success' },
   partial: { label: 'جزئي', color: 'warning' },
@@ -114,6 +124,7 @@ const BranchPurchasing = () => {
   const [statusFilter, setStatusFilter] = useState('all');
 
   const [requests, setRequests] = useState([]);
+  const [orders, setOrders] = useState([]);
   const [receipts, setReceipts] = useState([]);
   const [contracts, setContracts] = useState([]);
   const [branches, setBranches] = useState([]);
@@ -125,6 +136,9 @@ const BranchPurchasing = () => {
   const [editingPR, setEditingPR] = useState(null);
   const [detailDialogOpen, setDetailDialogOpen] = useState(false);
   const [selectedPR, setSelectedPR] = useState(null);
+  const [poGrnDialogOpen, setPoGrnDialogOpen] = useState(false);
+  const [selectedPO, setSelectedPO] = useState(null);
+  const [poGrns, setPoGrns] = useState([]);
 
   const [prForm, setPrForm] = useState({
     branch: '',
@@ -140,20 +154,23 @@ const BranchPurchasing = () => {
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
-      const [prData, rcData, ctData, brData] = await Promise.all([
+      const [prData, poData, rcData, ctData, brData] = await Promise.all([
         purchaseRequestService.getAll(),
+        purchaseOrderService.getAll(),
         purchaseReceiptService.getAll(),
         vendorContractService.getAll(),
         branchService.getAll(),
       ]);
       const prRows = prData || purchaseRequestService.getMockPRs();
       setRequests(prRows);
+      setOrders(poData || purchaseOrderService.getMockOrders());
       setReceipts(rcData || purchaseReceiptService.getMockReceipts());
       setContracts(ctData || vendorContractService.getMockContracts());
       setBranches(brData || branchService.getMockBranches());
       setStats(computePrStats(prRows));
     } catch {
       setRequests(purchaseRequestService.getMockPRs());
+      setOrders(purchaseOrderService.getMockOrders());
       setReceipts(purchaseReceiptService.getMockReceipts());
       setContracts(vendorContractService.getMockContracts());
       setBranches(branchService.getMockBranches());
@@ -178,6 +195,16 @@ const BranchPurchasing = () => {
     const matchBranch = branchFilter === 'all' || pr.branch === branchFilter;
     const matchStatus = statusFilter === 'all' || pr.status === statusFilter;
     return matchSearch && matchBranch && matchStatus;
+  });
+
+  const filteredOrders = orders.filter(po => {
+    const s = search.toLowerCase();
+    const matchSearch =
+      po.orderNumber?.toLowerCase().includes(s) ||
+      po.vendor?.toLowerCase().includes(s) ||
+      po.department?.toLowerCase().includes(s);
+    const matchStatus = statusFilter === 'all' || po.status === statusFilter;
+    return matchSearch && matchStatus;
   });
 
   const filteredReceipts = receipts.filter(rc => {
@@ -242,6 +269,37 @@ const BranchPurchasing = () => {
       loadData();
     } catch {
       showSnackbar('خطأ', 'error');
+    }
+  };
+
+  const handleApprovePO = async id => {
+    try {
+      await purchaseOrderService.approve(id);
+      showSnackbar('تم اعتماد أمر الشراء', 'success');
+      loadData();
+    } catch {
+      showSnackbar('فشل في اعتماد أمر الشراء', 'error');
+    }
+  };
+
+  const handleReceivePO = async id => {
+    try {
+      await purchaseOrderService.receive(id);
+      showSnackbar('تم تسجيل الاستلام وإنشاء سند GRN', 'success');
+      loadData();
+    } catch {
+      showSnackbar('فشل في تسجيل الاستلام', 'error');
+    }
+  };
+
+  const handleViewPoGrns = async po => {
+    try {
+      setSelectedPO(po);
+      const rows = await purchaseOrderService.getReceipts(po._id);
+      setPoGrns(rows?.length ? rows : []);
+      setPoGrnDialogOpen(true);
+    } catch {
+      showSnackbar('تعذر تحميل سندات الاستلام', 'error');
     }
   };
 
@@ -401,6 +459,7 @@ const BranchPurchasing = () => {
             }}
           >
             <Tab label="طلبات الشراء" icon={<RequestIcon />} iconPosition="start" />
+            <Tab label="أوامر الشراء" icon={<PurchaseIcon />} iconPosition="start" />
             <Tab label="سندات الاستلام" icon={<ReceiptIcon />} iconPosition="start" />
             <Tab label="العقود" icon={<ContractIcon />} iconPosition="start" />
           </Tabs>
@@ -420,7 +479,7 @@ const BranchPurchasing = () => {
             }}
             sx={{ minWidth: 220 }}
           />
-          {tabValue < 2 && (
+          {(tabValue === 0 || tabValue === 2) && (
             <FormControl size="small" sx={{ minWidth: 160 }}>
               <InputLabel>الفرع</InputLabel>
               <Select
@@ -447,6 +506,23 @@ const BranchPurchasing = () => {
               >
                 <MenuItem value="all">الكل</MenuItem>
                 {Object.entries(prStatusConfig).map(([k, v]) => (
+                  <MenuItem key={k} value={k}>
+                    {v.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+          {tabValue === 1 && (
+            <FormControl size="small" sx={{ minWidth: 140 }}>
+              <InputLabel>الحالة</InputLabel>
+              <Select
+                value={statusFilter}
+                onChange={e => setStatusFilter(e.target.value)}
+                label="الحالة"
+              >
+                <MenuItem value="all">الكل</MenuItem>
+                {Object.entries(poStatusConfig).map(([k, v]) => (
                   <MenuItem key={k} value={k}>
                     {v.label}
                   </MenuItem>
@@ -565,8 +641,87 @@ const BranchPurchasing = () => {
         </TableContainer>
       )}
 
-      {/* ═══ TAB 1: PURCHASE RECEIPTS ═══ */}
+      {/* ═══ TAB 1: PURCHASE ORDERS ═══ */}
       {tabValue === 1 && (
+        <TableContainer component={Paper} sx={{ borderRadius: 2 }}>
+          <Table>
+            <TableHead>
+              <TableRow sx={{ bgcolor: surfaceColors?.background || '#fafafa' }}>
+                <TableCell sx={{ fontWeight: 'bold' }}>رقم الأمر</TableCell>
+                <TableCell sx={{ fontWeight: 'bold' }}>المورد</TableCell>
+                <TableCell sx={{ fontWeight: 'bold' }}>التاريخ</TableCell>
+                <TableCell sx={{ fontWeight: 'bold' }}>التسليم</TableCell>
+                <TableCell sx={{ fontWeight: 'bold' }}>الأصناف</TableCell>
+                <TableCell sx={{ fontWeight: 'bold' }}>المبلغ</TableCell>
+                <TableCell sx={{ fontWeight: 'bold' }}>الحالة</TableCell>
+                <TableCell sx={{ fontWeight: 'bold' }}>إجراءات</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {filteredOrders.map(po => (
+                <TableRow key={po._id} hover>
+                  <TableCell>
+                    <Typography variant="body2" fontWeight="bold" color="primary">
+                      {po.orderNumber}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>{po.vendor}</TableCell>
+                  <TableCell>{po.date}</TableCell>
+                  <TableCell>{po.deliveryDate}</TableCell>
+                  <TableCell>{po.items}</TableCell>
+                  <TableCell>{po.totalAmount?.toLocaleString()} ر.س</TableCell>
+                  <TableCell>
+                    <Chip
+                      label={poStatusConfig[po.status]?.label || po.status}
+                      color={poStatusConfig[po.status]?.color || 'default'}
+                      size="small"
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Box display="flex" gap={0.5}>
+                      <Tooltip title="سندات الاستلام">
+                        <IconButton size="small" onClick={() => handleViewPoGrns(po)}>
+                          <ReceiptIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                      {(po.status === 'pending' || po.status === 'draft') && (
+                        <Tooltip title="اعتماد">
+                          <IconButton
+                            size="small"
+                            color="success"
+                            onClick={() => handleApprovePO(po._id)}
+                          >
+                            <ApproveIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                      {(po.status === 'approved' || po.status === 'ordered') && (
+                        <Tooltip title="تسجيل الاستلام">
+                          <IconButton
+                            size="small"
+                            color="primary"
+                            onClick={() => handleReceivePO(po._id)}
+                          >
+                            <ReceiveIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                    </Box>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          {filteredOrders.length === 0 && !loading && (
+            <Box p={4} textAlign="center">
+              <Typography color="text.secondary">لا توجد أوامر شراء</Typography>
+            </Box>
+          )}
+        </TableContainer>
+      )}
+
+      {/* ═══ TAB 2: PURCHASE RECEIPTS ═══ */}
+      {tabValue === 2 && (
         <TableContainer component={Paper} sx={{ borderRadius: 2 }}>
           <Table>
             <TableHead>
@@ -624,8 +779,8 @@ const BranchPurchasing = () => {
         </TableContainer>
       )}
 
-      {/* ═══ TAB 2: CONTRACTS ═══ */}
-      {tabValue === 2 && (
+      {/* ═══ TAB 3: CONTRACTS ═══ */}
+      {tabValue === 3 && (
         <TableContainer component={Paper} sx={{ borderRadius: 2 }}>
           <Table>
             <TableHead>
@@ -943,6 +1098,53 @@ const BranchPurchasing = () => {
               اعتماد
             </Button>
           )}
+        </DialogActions>
+      </Dialog>
+
+      {/* ═══ PO GRN DIALOG (W788) ═══ */}
+      <Dialog
+        open={poGrnDialogOpen}
+        onClose={() => setPoGrnDialogOpen(false)}
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle>سندات الاستلام — {selectedPO?.orderNumber}</DialogTitle>
+        <DialogContent>
+          {poGrns.length === 0 ? (
+            <Typography color="text.secondary" sx={{ py: 2 }}>
+              لا توجد سندات استلام مرتبطة بهذا الأمر بعد.
+            </Typography>
+          ) : (
+            <Table size="small" sx={{ mt: 1 }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>رقم السند</TableCell>
+                  <TableCell>التاريخ</TableCell>
+                  <TableCell>المستلم</TableCell>
+                  <TableCell>الحالة</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {poGrns.map(grn => (
+                  <TableRow key={grn._id}>
+                    <TableCell>{grn.receiptNumber}</TableCell>
+                    <TableCell>{grn.date}</TableCell>
+                    <TableCell>{grn.totalReceived ?? grn.items}</TableCell>
+                    <TableCell>
+                      <Chip
+                        size="small"
+                        label={receiptStatusConfig[grn.status]?.label || grn.status}
+                        color={receiptStatusConfig[grn.status]?.color || 'default'}
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPoGrnDialogOpen(false)}>إغلاق</Button>
         </DialogActions>
       </Dialog>
     </Box>

--- a/frontend/src/services/branchWarehouseService.js
+++ b/frontend/src/services/branchWarehouseService.js
@@ -237,6 +237,34 @@ export const purchaseRequestService = {
 };
 
 // ═══════════════════════════════════════════
+// 7b. PURCHASE ORDERS — أوامر الشراء (W788)
+// ═══════════════════════════════════════════
+export const purchaseOrderService = {
+  getAll: safe(async (params = {}) => {
+    const r = await apiClient.get('/api/v1/purchasing/orders', { params });
+    return unwrapApiList(r.data);
+  }),
+  getById: safe(async id => {
+    const r = await apiClient.get(`/api/v1/purchasing/orders/${id}`);
+    return unwrapApiOne(r.data);
+  }),
+  getReceipts: safe(async id => {
+    const r = await apiClient.get(`/api/v1/purchasing/orders/${id}/receipts`);
+    return unwrapApiList(r.data);
+  }),
+  approve: safe(async id => {
+    const r = await apiClient.patch(`/api/v1/purchasing/orders/${id}/approve`);
+    return unwrapApiOne(r.data);
+  }),
+  receive: safe(async id => {
+    const r = await apiClient.patch(`/api/v1/purchasing/orders/${id}/receive`);
+    return unwrapApiOne(r.data);
+  }),
+
+  getMockOrders: () => MOCK_PURCHASE_ORDERS,
+};
+
+// ═══════════════════════════════════════════
 // 7. PURCHASE RECEIPTS — استلام المشتريات
 // ═══════════════════════════════════════════
 export const purchaseReceiptService = {
@@ -878,6 +906,31 @@ const MOCK_PR_STATS = {
   urgentPending: 4,
 };
 
+const MOCK_PURCHASE_ORDERS = [
+  {
+    _id: 'po-m1',
+    orderNumber: 'PO-2026-000101',
+    vendor: 'مورد المستلزمات الطبية',
+    date: '2026-05-28',
+    deliveryDate: '2026-06-05',
+    items: 3,
+    totalAmount: 12500,
+    status: 'approved',
+    department: 'المستودع',
+  },
+  {
+    _id: 'po-m2',
+    orderNumber: 'PO-2026-000102',
+    vendor: 'شركة الأثاث المكتبي',
+    date: '2026-05-20',
+    deliveryDate: '2026-05-30',
+    items: 2,
+    totalAmount: 8900,
+    status: 'received',
+    department: 'الإدارة',
+  },
+];
+
 const MOCK_RECEIPTS = [
   {
     _id: 'rc1',
@@ -972,6 +1025,7 @@ export default {
   stockMovementService,
   stockTakeService,
   purchaseRequestService,
+  purchaseOrderService,
   purchaseReceiptService,
   vendorContractService,
 };


### PR DESCRIPTION
## Summary
- purchaseOrderService in branchWarehouseService (list, approve, receive, getReceipts).
- /branch-purchasing: new tab orامر الشراء with approve/receive actions and GRN dialog via GET /orders/:id/receipts.

## Test plan
- [x] branch-purchasing-orders-wave788 + services-branchWarehouseService
- [x] frontend eslint pre-push
- [ ] CI

Made with [Cursor](https://cursor.com)