### PR TITLE
W789: PR itemId picker + convert-to-PO for branch purchasing

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -951,6 +951,9 @@ on:
       - 'backend/__tests__/purchasing-stats-legacy-wave787.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/branch-purchasing-orders-wave788.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/branch-purchasing-convert-wave789.test.js'
+      - 'backend/__tests__/purchasing-pr-item-convert-wave789.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1885,6 +1888,9 @@ on:
       - 'backend/__tests__/purchasing-stats-legacy-wave787.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/branch-purchasing-orders-wave788.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/branch-purchasing-convert-wave789.test.js'
+      - 'backend/__tests__/purchasing-pr-item-convert-wave789.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/branch-purchasing-convert-wave789.test.js
+++ b/backend/__tests__/branch-purchasing-convert-wave789.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * branch-purchasing-convert-wave789.test.js — W789 PR→PO convert + inventory picker drift guard.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SERVICE = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'frontend', 'src', 'services', 'branchWarehouseService.js'),
+  'utf8'
+);
+const PAGE = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    'frontend',
+    'src',
+    'pages',
+    'supply-chain',
+    'BranchPurchasing.js'
+  ),
+  'utf8'
+);
+
+describe('W789 — branch purchasing PR convert + item picker', () => {
+  it('purchaseRequestService exposes convertToPo + inventoryModuleItemService', () => {
+    expect(SERVICE).toMatch(/convertToPo.*convert-to-po/s);
+    expect(SERVICE).toMatch(/export const inventoryModuleItemService/);
+    expect(SERVICE).toMatch(/inventory-module\/items/);
+  });
+
+  it('BranchPurchasing wires convert action and inventory item select', () => {
+    expect(PAGE).toMatch(/handleConvertToPo/);
+    expect(PAGE).toMatch(/convertToPo/);
+    expect(PAGE).toMatch(/inventoryModuleItemService/);
+    expect(PAGE).toMatch(/صنف المخزون/);
+    expect(PAGE).toMatch(/تحويل لأمر شراء/);
+    expect(PAGE).toMatch(/under_review/);
+  });
+});

--- a/backend/__tests__/purchasing-pr-item-convert-wave789.test.js
+++ b/backend/__tests__/purchasing-pr-item-convert-wave789.test.js
@@ -1,0 +1,131 @@
+'use strict';
+
+/**
+ * purchasing-pr-item-convert-wave789.test.js — W789 PR itemId + convert-to-PO stock path.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(30000);
+
+const mongoose = require('mongoose');
+const fs = require('fs');
+const path = require('path');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const adapter = require('../services/purchasingAdapter.service');
+
+let mongod;
+
+beforeAll(async () => {
+  const URI_FILE = path.join(__dirname, '..', '.test-mongo-uri');
+  let uri;
+  if (fs.existsSync(URI_FILE)) {
+    uri = fs.readFileSync(URI_FILE, 'utf-8').trim();
+  } else {
+    mongod = await MongoMemoryServer.create({ instance: { dbName: 'w789-purchasing' } });
+    uri = mongod.getUri();
+  }
+  await mongoose.connect(uri);
+  require('../models/inventory/PurchaseOrder');
+  require('../models/inventory/InventoryItem');
+  require('../models/operations/PurchaseRequest.model');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+beforeEach(async () => {
+  const Po = require('../models/inventory/PurchaseOrder');
+  const PR = require('../models/operations/PurchaseRequest.model');
+  const Item = require('../models/inventory/InventoryItem');
+  await Po.deleteMany({});
+  await PR.deleteMany({});
+  await Item.deleteMany({});
+});
+
+describe('W789 behavioral — PR itemId normalization', () => {
+  it('maps legacy product/estimatedPrice and preserves itemId on create', async () => {
+    const itemId = new mongoose.Types.ObjectId();
+    const actorId = new mongoose.Types.ObjectId();
+    const created = await adapter.createRequest(
+      {
+        requiredDate: new Date(Date.now() + 86400000).toISOString(),
+        department: 'مستودع',
+        items: [
+          {
+            itemId,
+            product: 'قفازات طبية',
+            quantity: 5,
+            unit: 'علبة',
+            estimatedPrice: 25,
+          },
+        ],
+      },
+      actorId
+    );
+    expect(created._id).toBeTruthy();
+
+    const PR = require('../models/operations/PurchaseRequest.model');
+    const doc = await PR.findById(created._id).lean();
+    expect(doc.items[0].itemName).toBe('قفازات طبية');
+    expect(doc.items[0].estimatedUnitPrice).toBe(25);
+    expect(String(doc.items[0].itemId)).toBe(String(itemId));
+  });
+});
+
+describe('W789 behavioral — PR convert-to-PO carries item_id', () => {
+  it('submit → approve → convert preserves item_id on PO lines', async () => {
+    const Item = require('../models/inventory/InventoryItem');
+    const actorId = new mongoose.Types.ObjectId();
+    const inv = await Item.create({
+      name_ar: 'معقم يد',
+      item_code: 'INV-W789',
+      category: 'medical_supplies',
+      quantity_on_hand: 10,
+      minimum_stock: 2,
+      unit_of_measure: 'زجاجة',
+      unit_cost: 12,
+      created_by: actorId,
+    });
+
+    const pr = await adapter.createRequest(
+      {
+        requiredDate: new Date(Date.now() + 86400000).toISOString(),
+        items: [{ itemId: inv._id, product: 'معقم يد', quantity: 3, estimatedPrice: 12 }],
+      },
+      actorId
+    );
+    await adapter.submitRequest(pr._id, { actorId });
+    await adapter.approveRequest(pr._id, {
+      approverId: actorId,
+      approverName: 'Test Approver',
+      role: 'department_head',
+    });
+
+    const { order, request } = await adapter.convertRequestToPo(pr._id, { actorId });
+    expect(request.status).toBe('converted_to_po');
+    expect(order._id).toBeTruthy();
+
+    const Po = require('../models/inventory/PurchaseOrder');
+    const poDoc = await Po.findById(order._id).lean();
+    expect(poDoc.items).toHaveLength(1);
+    expect(String(poDoc.items[0].item_id)).toBe(String(inv._id));
+    expect(poDoc.items[0].item_name_ar).toBe('معقم يد');
+    expect(poDoc.items[0].quantity_ordered).toBe(3);
+  });
+});
+
+describe('W789 static — adapter normalizePrItem', () => {
+  it('exports normalizePrItem via createRequest legacy mapping (source guard)', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '..', 'services', 'purchasingAdapter.service.js'),
+      'utf8'
+    );
+    expect(src).toMatch(/function normalizePrItem/);
+    expect(src).toMatch(/it\.product/);
+    expect(src).toMatch(/it\.estimatedPrice/);
+    expect(src).toMatch(/W789/);
+  });
+});

--- a/backend/services/purchasingAdapter.service.js
+++ b/backend/services/purchasingAdapter.service.js
@@ -9,6 +9,7 @@
  * W785: list receipts by PO + dashboard receipt count.
  * W786: stock receipt when PO lines include item_id (InventoryModuleItem).
  * W787: legacy stats field aliases for PurchasingManagement.js tiles.
+ * W789: PR itemId normalization (legacy product/estimatedPrice → itemName/itemId).
  */
 
 const { applyStockReceiptForPoLines } = require('./purchasingStockReceive.lib');
@@ -118,6 +119,22 @@ function mapPrToLegacyRequest(doc) {
     priority: o.priority || 'normal',
     estimatedValue: o.summary?.estimatedValue ?? o.estimatedValue ?? 0,
   };
+}
+
+/** Map BranchPurchasing.js line shape + API aliases → canonical PR item. */
+function normalizePrItem(it) {
+  const rawId = it.itemId || it.item_id || it.inventoryItemId;
+  const row = {
+    itemName: it.itemName || it.product || it.name || it.description || 'Item',
+    itemCode: it.itemCode || it.item_code,
+    quantity: it.quantity ?? 1,
+    unit: it.unit || 'ea',
+    estimatedUnitPrice:
+      it.estimatedUnitPrice ?? it.estimatedUnitCost ?? it.estimatedPrice ?? it.unitCost ?? 0,
+    notes: it.notes,
+  };
+  if (rawId) row.itemId = rawId;
+  return row;
 }
 
 async function listVendors(query = {}) {
@@ -243,14 +260,7 @@ async function updateRequest(id, body, actorId) {
   if (body.title != null) pr.justification = body.title;
   if (body.purchaseMethod != null) pr.purchaseMethod = body.purchaseMethod;
   if (Array.isArray(body.items) && body.items.length) {
-    pr.items = body.items.map(it => ({
-      itemName: it.itemName || it.name || 'Item',
-      itemCode: it.itemCode,
-      quantity: it.quantity ?? 1,
-      unit: it.unit || 'ea',
-      estimatedUnitPrice: it.estimatedUnitPrice ?? it.estimatedUnitCost ?? it.unitCost ?? 0,
-      notes: it.notes,
-    }));
+    pr.items = body.items.map(normalizePrItem);
   }
   if (actorId) pr.updatedBy = actorId;
   await pr.save();
@@ -264,15 +274,16 @@ async function createRequest(body, actorId) {
     body.deliveryDate ||
     new Date(Date.now() + 7 * 86400000).toISOString();
   const items = Array.isArray(body.items)
-    ? body.items
+    ? body.items.map(normalizePrItem)
     : [
-        {
+        normalizePrItem({
           itemName: body.itemName || body.description || body.title || 'Requested item',
+          itemId: body.itemId || body.item_id,
           quantity: body.quantity || 1,
           unit: body.unit || 'ea',
           estimatedUnitPrice:
             body.estimatedUnitPrice ?? body.estimatedUnitCost ?? body.unitCost ?? 0,
-        },
+        }),
       ];
   const draft = await getPrService().createDraft(
     {

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -114,6 +114,8 @@ __tests__/purchasing-order-receipts-wave785.test.js
 __tests__/purchasing-receive-stock-wave786.test.js
 __tests__/purchasing-stats-legacy-wave787.test.js
 __tests__/branch-purchasing-orders-wave788.test.js
+__tests__/branch-purchasing-convert-wave789.test.js
+__tests__/purchasing-pr-item-convert-wave789.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js

--- a/frontend/src/__tests__/services-branchWarehouseService.test.js
+++ b/frontend/src/__tests__/services-branchWarehouseService.test.js
@@ -58,6 +58,9 @@ describe('services/branchWarehouseService.js', () => {
     expect(source).toMatch(/purchaseOrderService/);
     expect(source).toMatch(/purchasing\/orders.*unwrapApiList/s);
     expect(source).toMatch(/orders\/\$\{id\}\/receipts/);
+    expect(source).toMatch(/convert-to-po/);
+    expect(source).toMatch(/inventoryModuleItemService/);
+    expect(source).toMatch(/inventory-module\/items/);
   });
 
   test('makes API calls', () => {

--- a/frontend/src/pages/supply-chain/BranchPurchasing.js
+++ b/frontend/src/pages/supply-chain/BranchPurchasing.js
@@ -62,6 +62,7 @@ import {
   purchaseReceiptService,
   vendorContractService,
   branchService,
+  inventoryModuleItemService,
 } from 'services/branchWarehouseService';
 
 const prStatusConfig = {
@@ -128,6 +129,7 @@ const BranchPurchasing = () => {
   const [receipts, setReceipts] = useState([]);
   const [contracts, setContracts] = useState([]);
   const [branches, setBranches] = useState([]);
+  const [inventoryItems, setInventoryItems] = useState([]);
   const [stats, setStats] = useState({});
   const [loading, setLoading] = useState(true);
 
@@ -147,19 +149,28 @@ const BranchPurchasing = () => {
     priority: 'medium',
     notes: '',
     items: [
-      { product: '', description: '', quantity: 1, unit: 'حبة', estimatedPrice: 0, notes: '' },
+      {
+        itemId: '',
+        product: '',
+        description: '',
+        quantity: 1,
+        unit: 'حبة',
+        estimatedPrice: 0,
+        notes: '',
+      },
     ],
   });
 
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
-      const [prData, poData, rcData, ctData, brData] = await Promise.all([
+      const [prData, poData, rcData, ctData, brData, invItems] = await Promise.all([
         purchaseRequestService.getAll(),
         purchaseOrderService.getAll(),
         purchaseReceiptService.getAll(),
         vendorContractService.getAll(),
         branchService.getAll(),
+        inventoryModuleItemService.getAll().catch(() => []),
       ]);
       const prRows = prData || purchaseRequestService.getMockPRs();
       setRequests(prRows);
@@ -167,6 +178,7 @@ const BranchPurchasing = () => {
       setReceipts(rcData || purchaseReceiptService.getMockReceipts());
       setContracts(ctData || vendorContractService.getMockContracts());
       setBranches(brData || branchService.getMockBranches());
+      setInventoryItems(Array.isArray(invItems) ? invItems : []);
       setStats(computePrStats(prRows));
     } catch {
       setRequests(purchaseRequestService.getMockPRs());
@@ -272,6 +284,22 @@ const BranchPurchasing = () => {
     }
   };
 
+  const handleConvertToPo = async id => {
+    try {
+      const result = await purchaseRequestService.convertToPo(id);
+      showSnackbar(
+        result?.order?.orderNumber
+          ? `تم إنشاء أمر الشراء ${result.order.orderNumber}`
+          : 'تم تحويل الطلب إلى أمر شراء',
+        'success'
+      );
+      setTabValue(1);
+      loadData();
+    } catch {
+      showSnackbar('فشل تحويل الطلب إلى أمر شراء', 'error');
+    }
+  };
+
   const handleApprovePO = async id => {
     try {
       await purchaseOrderService.approve(id);
@@ -311,7 +339,15 @@ const BranchPurchasing = () => {
       priority: 'medium',
       notes: '',
       items: [
-        { product: '', description: '', quantity: 1, unit: 'حبة', estimatedPrice: 0, notes: '' },
+        {
+          itemId: '',
+          product: '',
+          description: '',
+          quantity: 1,
+          unit: 'حبة',
+          estimatedPrice: 0,
+          notes: '',
+        },
       ],
     });
   const addItem = () =>
@@ -319,7 +355,15 @@ const BranchPurchasing = () => {
       ...prForm,
       items: [
         ...prForm.items,
-        { product: '', description: '', quantity: 1, unit: 'حبة', estimatedPrice: 0, notes: '' },
+        {
+          itemId: '',
+          product: '',
+          description: '',
+          quantity: 1,
+          unit: 'حبة',
+          estimatedPrice: 0,
+          notes: '',
+        },
       ],
     });
   const removeItem = idx =>
@@ -327,6 +371,15 @@ const BranchPurchasing = () => {
   const updateItem = (idx, field, val) => {
     const items = [...prForm.items];
     items[idx] = { ...items[idx], [field]: val };
+    if (field === 'itemId' && val) {
+      const inv = inventoryItems.find(it => String(it._id) === String(val));
+      if (inv) {
+        items[idx].product = inv.name_ar || inv.name_en || items[idx].product;
+        items[idx].description = inv.description || items[idx].description;
+        items[idx].unit = inv.unit_of_measure || items[idx].unit;
+        if (inv.unit_cost != null) items[idx].estimatedPrice = inv.unit_cost;
+      }
+    }
     setPrForm({ ...prForm, items });
   };
 
@@ -605,7 +658,7 @@ const BranchPurchasing = () => {
                           </IconButton>
                         </Tooltip>
                       )}
-                      {pr.status === 'submitted' && (
+                      {['submitted', 'under_review'].includes(pr.status) && (
                         <>
                           <Tooltip title="اعتماد">
                             <IconButton
@@ -626,6 +679,17 @@ const BranchPurchasing = () => {
                             </IconButton>
                           </Tooltip>
                         </>
+                      )}
+                      {pr.status === 'approved' && (
+                        <Tooltip title="تحويل لأمر شراء">
+                          <IconButton
+                            size="small"
+                            color="primary"
+                            onClick={() => handleConvertToPo(pr._id)}
+                          >
+                            <PurchaseIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
                       )}
                     </Box>
                   </TableCell>
@@ -903,43 +967,67 @@ const BranchPurchasing = () => {
 
             {prForm.items.map((item, idx) => (
               <React.Fragment key={idx}>
-                <Grid item xs={3}>
+                <Grid item xs={12} sm={4}>
+                  <FormControl fullWidth size="small">
+                    <InputLabel>صنف المخزون (اختياري)</InputLabel>
+                    <Select
+                      value={item.itemId || ''}
+                      onChange={e => updateItem(idx, 'itemId', e.target.value)}
+                      label="صنف المخزون (اختياري)"
+                    >
+                      <MenuItem value="">
+                        <em>بدون ربط</em>
+                      </MenuItem>
+                      {inventoryItems.map(inv => (
+                        <MenuItem key={inv._id} value={inv._id}>
+                          {inv.name_ar || inv.name_en || inv.item_code}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                </Grid>
+                <Grid item xs={12} sm={4}>
                   <TextField
                     fullWidth
+                    size="small"
                     label={`الصنف ${idx + 1}`}
                     value={item.product}
                     onChange={e => updateItem(idx, 'product', e.target.value)}
                   />
                 </Grid>
-                <Grid item xs={3}>
+                <Grid item xs={12} sm={4}>
                   <TextField
                     fullWidth
+                    size="small"
                     label="الوصف"
                     value={item.description}
                     onChange={e => updateItem(idx, 'description', e.target.value)}
                   />
                 </Grid>
-                <Grid item xs={2}>
+                <Grid item xs={4} sm={2}>
                   <TextField
                     fullWidth
+                    size="small"
                     type="number"
                     label="الكمية"
                     value={item.quantity}
                     onChange={e => updateItem(idx, 'quantity', Number(e.target.value))}
                   />
                 </Grid>
-                <Grid item xs={2}>
+                <Grid item xs={4} sm={2}>
                   <TextField
                     fullWidth
+                    size="small"
                     type="number"
                     label="السعر التقديري"
                     value={item.estimatedPrice}
                     onChange={e => updateItem(idx, 'estimatedPrice', Number(e.target.value))}
                   />
                 </Grid>
-                <Grid item xs={2} display="flex" alignItems="center" gap={0.5}>
+                <Grid item xs={4} sm={2} display="flex" alignItems="center" gap={0.5}>
                   <TextField
                     fullWidth
+                    size="small"
                     label="الوحدة"
                     value={item.unit}
                     onChange={e => updateItem(idx, 'unit', e.target.value)}

--- a/frontend/src/services/branchWarehouseService.js
+++ b/frontend/src/services/branchWarehouseService.js
@@ -231,9 +231,25 @@ export const purchaseRequestService = {
     const r = await apiClient.post(`/api/v1/purchasing/requests/${id}/reject`, data);
     return r.data;
   }),
+  convertToPo: safe(async (id, data = {}) => {
+    const r = await apiClient.post(`/api/v1/purchasing/requests/${id}/convert-to-po`, data);
+    return unwrapApiOne(r.data);
+  }),
 
   getMockPRs: () => MOCK_PURCHASE_REQUESTS,
   getMockStats: () => MOCK_PR_STATS,
+};
+
+// ═══════════════════════════════════════════
+// 7a. INVENTORY MODULE ITEMS — أصناف المخزون (W789 picker)
+// ═══════════════════════════════════════════
+export const inventoryModuleItemService = {
+  getAll: safe(async (params = {}) => {
+    const r = await apiClient.get('/api/v1/inventory-module/items', {
+      params: { limit: 100, ...params },
+    });
+    return r.data?.items || [];
+  }),
 };
 
 // ═══════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Normalize legacy PR line fields (product/estimatedPrice) to itemName/itemId in purchasingAdapter
- Add inventoryModuleItemService + convertToPo to branchWarehouseService
- BranchPurchasing: inventory item picker, convert-to-PO button on approved PRs, under_review approval support

## Test plan
- [x] npx jest __tests__/purchasing-pr-item-convert-wave789.test.js __tests__/branch-purchasing-convert-wave789.test.js
- [x] frontend services-branchWarehouseService.test.js
- [ ] Manual: PR with inventory item -> approve -> convert -> receive -> verify stock bump (W786 path)


Made with [Cursor](https://cursor.com)