### PR TITLE
W790: PO/GRN line items summary for branch purchasing

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -954,6 +954,9 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/branch-purchasing-convert-wave789.test.js'
       - 'backend/__tests__/purchasing-pr-item-convert-wave789.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-po-line-items-wave790.test.js'
+      - 'backend/__tests__/branch-purchasing-line-items-wave790.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1891,6 +1894,9 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/branch-purchasing-convert-wave789.test.js'
       - 'backend/__tests__/purchasing-pr-item-convert-wave789.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-po-line-items-wave790.test.js'
+      - 'backend/__tests__/branch-purchasing-line-items-wave790.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/branch-purchasing-line-items-wave790.test.js
+++ b/backend/__tests__/branch-purchasing-line-items-wave790.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/**
+ * branch-purchasing-line-items-wave790.test.js — W790 PO/GRN line-item UI drift guard.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PAGE = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    'frontend',
+    'src',
+    'pages',
+    'supply-chain',
+    'BranchPurchasing.js'
+  ),
+  'utf8'
+);
+
+describe('W790 — branch purchasing line items UI', () => {
+  it('renders itemsSummary cells and PO detail dialog with line items', () => {
+    expect(PAGE).toMatch(/renderItemsCell/);
+    expect(PAGE).toMatch(/itemsSummary/);
+    expect(PAGE).toMatch(/LineItemsTable/);
+    expect(PAGE).toMatch(/handleViewPoDetail/);
+    expect(PAGE).toMatch(/poDetailDialogOpen/);
+    expect(PAGE).toMatch(/linkedItemCount/);
+    expect(PAGE).toMatch(/purchaseOrderService\.getById/);
+  });
+});

--- a/backend/__tests__/purchasing-po-line-items-wave790.test.js
+++ b/backend/__tests__/purchasing-po-line-items-wave790.test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+/**
+ * purchasing-po-line-items-wave790.test.js — W790 lineItems + itemsSummary on PO/GRN/PR payloads.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(30000);
+
+const mongoose = require('mongoose');
+const fs = require('fs');
+const path = require('path');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const adapter = require('../services/purchasingAdapter.service');
+
+let mongod;
+
+beforeAll(async () => {
+  const URI_FILE = path.join(__dirname, '..', '.test-mongo-uri');
+  let uri;
+  if (fs.existsSync(URI_FILE)) {
+    uri = fs.readFileSync(URI_FILE, 'utf-8').trim();
+  } else {
+    mongod = await MongoMemoryServer.create({ instance: { dbName: 'w790-purchasing-lines' } });
+    uri = mongod.getUri();
+  }
+  await mongoose.connect(uri);
+  require('../models/inventory/PurchaseOrder');
+  require('../models/inventory/PurchaseReceipt');
+  require('../models/inventory/InventoryItem');
+  require('../models/operations/PurchaseRequest.model');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+beforeEach(async () => {
+  const Po = require('../models/inventory/PurchaseOrder');
+  const Receipt = require('../models/inventory/PurchaseReceipt');
+  const PR = require('../models/operations/PurchaseRequest.model');
+  await Po.deleteMany({});
+  await Receipt.deleteMany({});
+  await PR.deleteMany({});
+});
+
+describe('W790 behavioral — PO lineItems + itemsSummary', () => {
+  it('createOrder exposes lineItems, itemsSummary, linkedItemCount', async () => {
+    const Item = require('../models/inventory/InventoryItem');
+    const actorId = new mongoose.Types.ObjectId();
+    const inv = await Item.create({
+      name_ar: 'قفازات طبية',
+      category: 'medical_supplies',
+      quantity_on_hand: 5,
+      created_by: actorId,
+    });
+
+    const order = await adapter.createOrder(
+      {
+        vendor: 'مورد',
+        items: [{ itemId: inv._id, itemName: 'قفازات طبية', quantity: 4, unitCost: 12 }],
+      },
+      actorId
+    );
+
+    expect(order.items).toBe(1);
+    expect(order.itemsCount).toBe(1);
+    expect(order.lineItems).toHaveLength(1);
+    expect(String(order.lineItems[0].itemId)).toBe(String(inv._id));
+    expect(order.itemsSummary).toMatch(/قفازات طبية/);
+    expect(order.linkedItemCount).toBe(1);
+  });
+
+  it('receiveOrder GRN includes lineItems + itemsSummary', async () => {
+    const actorId = new mongoose.Types.ObjectId();
+    const order = await adapter.createOrder(
+      {
+        vendor: 'مورد',
+        items: [{ itemName: 'معقم', quantity: 2, unitCost: 8 }],
+      },
+      actorId
+    );
+    await adapter.approveOrder(order._id, actorId);
+    await adapter.receiveOrder(order._id, actorId);
+
+    const grns = await adapter.listReceiptsForOrder(order._id);
+    expect(grns).toHaveLength(1);
+    expect(grns[0].lineItems).toHaveLength(1);
+    expect(grns[0].lineItems[0].itemName).toMatch(/معقم/);
+    expect(grns[0].itemsSummary).toMatch(/معقم/);
+    expect(grns[0].itemsCount).toBe(1);
+  });
+});
+
+describe('W790 behavioral — PR lineItems', () => {
+  it('createRequest maps lineItems and itemsSummary', async () => {
+    const itemId = new mongoose.Types.ObjectId();
+    const actorId = new mongoose.Types.ObjectId();
+    const pr = await adapter.createRequest(
+      {
+        requiredDate: new Date(Date.now() + 86400000).toISOString(),
+        items: [{ itemId, product: 'شريط لاصق', quantity: 10, estimatedPrice: 3 }],
+      },
+      actorId
+    );
+    expect(pr.itemsCount).toBe(1);
+    expect(pr.lineItems[0].itemName).toBe('شريط لاصق');
+    expect(String(pr.lineItems[0].itemId)).toBe(String(itemId));
+    expect(pr.itemsSummary).toMatch(/شريط لاصق/);
+  });
+});
+
+describe('W790 drift — adapter documents W790 fields', () => {
+  it('mapPoToLegacy adds lineItems and itemsSummary', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '..', 'services', 'purchasingAdapter.service.js'),
+      'utf8'
+    );
+    expect(src).toMatch(/W790/);
+    expect(src).toMatch(/lineItems/);
+    expect(src).toMatch(/itemsSummary/);
+    expect(src).toMatch(/linkedItemCount/);
+  });
+});

--- a/backend/services/purchasingAdapter.service.js
+++ b/backend/services/purchasingAdapter.service.js
@@ -10,6 +10,7 @@
  * W786: stock receipt when PO lines include item_id (InventoryModuleItem).
  * W787: legacy stats field aliases for PurchasingManagement.js tiles.
  * W789: PR itemId normalization (legacy product/estimatedPrice → itemName/itemId).
+ * W790: lineItems + itemsSummary on PO/GRN/PR legacy payloads for branch UI.
  */
 
 const { applyStockReceiptForPoLines } = require('./purchasingStockReceive.lib');
@@ -80,11 +81,47 @@ function mapVendorToLegacy(doc) {
   };
 }
 
+function mapPoLineToLegacy(it) {
+  if (!it) return null;
+  const rawId = it.item_id || it.itemId;
+  return {
+    itemId: rawId || null,
+    itemName: it.item_name_ar || it.itemName || it.item_name || 'Item',
+    itemCode: it.item_code || it.itemCode,
+    quantity: it.quantity_ordered ?? it.quantity ?? 0,
+    quantityReceived: it.quantity_received ?? 0,
+    unitCost: it.unit_cost ?? it.unitCost ?? 0,
+    totalCost: it.total_cost ?? it.totalCost ?? 0,
+    unit: it.unit_of_measure || it.unit || 'ea',
+  };
+}
+
+function mapReceiptLineToLegacy(it) {
+  if (!it) return null;
+  return {
+    itemName: it.item_name || it.itemName || 'Item',
+    quantityOrdered: it.quantity_ordered ?? 0,
+    quantityReceived: it.quantity_received ?? 0,
+    unitCost: it.unit_cost ?? 0,
+  };
+}
+
+function buildItemsSummary(lines, mapFn, { max = 2, qtyKey = 'quantity' } = {}) {
+  if (!Array.isArray(lines) || !lines.length) return '';
+  const mapped = lines.map(mapFn).filter(Boolean);
+  const parts = mapped.slice(0, max).map(l => `${l.itemName} (×${l[qtyKey] ?? 0})`);
+  if (mapped.length > max) parts.push(`+${mapped.length - max}`);
+  return parts.join('، ');
+}
+
 function mapPoToLegacy(doc) {
   if (!doc) return doc;
   const o = typeof doc.toObject === 'function' ? doc.toObject() : { ...doc };
   const orderDate = o.order_date ? new Date(o.order_date) : new Date();
   const delivery = o.expected_delivery_date ? new Date(o.expected_delivery_date) : null;
+  const rawLines = Array.isArray(o.items) ? o.items : [];
+  const lineItems = rawLines.map(mapPoLineToLegacy).filter(Boolean);
+  const itemsCount = rawLines.length;
   return {
     ...o,
     _id: o._id,
@@ -92,7 +129,11 @@ function mapPoToLegacy(doc) {
     vendor: o.vendor || o.supplier_name || '',
     date: orderDate.toISOString().slice(0, 10),
     deliveryDate: delivery ? delivery.toISOString().slice(0, 10) : '',
-    items: Array.isArray(o.items) ? o.items.length : o.items || 0,
+    items: itemsCount,
+    itemsCount,
+    lineItems,
+    itemsSummary: buildItemsSummary(rawLines, mapPoLineToLegacy),
+    linkedItemCount: lineItems.filter(l => l.itemId).length,
     totalAmount: o.totalAmount ?? o.total_amount ?? 0,
     status: legacyPoStatus(o.status),
     department: o.department || '',
@@ -102,7 +143,17 @@ function mapPoToLegacy(doc) {
 function mapPrToLegacyRequest(doc) {
   if (!doc) return doc;
   const o = typeof doc.toObject === 'function' ? doc.toObject() : { ...doc };
-  const firstItem = Array.isArray(o.items) && o.items[0];
+  const rawLines = Array.isArray(o.items) ? o.items : [];
+  const lineItems = rawLines.map(it => ({
+    itemId: it.itemId || null,
+    itemName: it.itemName || 'Item',
+    itemCode: it.itemCode,
+    quantity: it.quantity ?? 0,
+    unitCost: it.estimatedUnitPrice ?? 0,
+    unit: it.unit || 'ea',
+  }));
+  const firstItem = rawLines[0];
+  const itemsCount = rawLines.length;
   return {
     ...o,
     _id: o._id,
@@ -118,6 +169,14 @@ function mapPrToLegacyRequest(doc) {
     requestedBy: o.requestedBy || o.requester?.nameSnapshot || '',
     priority: o.priority || 'normal',
     estimatedValue: o.summary?.estimatedValue ?? o.estimatedValue ?? 0,
+    items: itemsCount,
+    itemsCount,
+    lineItems,
+    itemsSummary: buildItemsSummary(rawLines, it => ({
+      itemName: it.itemName || 'Item',
+      quantity: it.quantity ?? 0,
+    })),
+    linkedItemCount: lineItems.filter(l => l.itemId).length,
   };
 }
 
@@ -516,6 +575,7 @@ function mapReceiptToLegacy(doc) {
   if (!doc) return doc;
   const o = typeof doc.toObject === 'function' ? doc.toObject() : { ...doc };
   const lines = o.items || [];
+  const lineItems = lines.map(mapReceiptLineToLegacy).filter(Boolean);
   const ordered = lines.reduce((s, l) => s + (l.quantity_ordered || 0), 0);
   const received = lines.reduce((s, l) => s + (l.quantity_received || 0), 0);
   const d = o.receipt_date ? new Date(o.receipt_date) : new Date();
@@ -530,7 +590,13 @@ function mapReceiptToLegacy(doc) {
     branch: o.branch || (o.branch_id ? String(o.branch_id) : ''),
     date: d.toISOString().slice(0, 10),
     items: lines.length,
+    itemsCount: lines.length,
+    lineItems,
+    itemsSummary: buildItemsSummary(lines, mapReceiptLineToLegacy, {
+      qtyKey: 'quantityReceived',
+    }),
     totalReceived: received,
+    totalOrdered: ordered,
     totalAmount: o.totalAmount ?? o.total_amount ?? 0,
     status: o.status,
     receivedBy: o.receivedBy || o.received_by_name || '',

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -116,6 +116,8 @@ __tests__/purchasing-stats-legacy-wave787.test.js
 __tests__/branch-purchasing-orders-wave788.test.js
 __tests__/branch-purchasing-convert-wave789.test.js
 __tests__/purchasing-pr-item-convert-wave789.test.js
+__tests__/purchasing-po-line-items-wave790.test.js
+__tests__/branch-purchasing-line-items-wave790.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js

--- a/frontend/src/pages/supply-chain/BranchPurchasing.js
+++ b/frontend/src/pages/supply-chain/BranchPurchasing.js
@@ -117,6 +117,76 @@ const contractStatusConfig = {
   expired: { label: 'منتهي', color: 'error' },
 };
 
+function resolveItemsCount(row) {
+  if (row?.itemsCount != null) return row.itemsCount;
+  if (typeof row?.items === 'number') return row.items;
+  if (Array.isArray(row?.items)) return row.items.length;
+  return 0;
+}
+
+function renderItemsCell(row) {
+  const count = resolveItemsCount(row);
+  const summary = row?.itemsSummary;
+  return (
+    <Box>
+      <Typography variant="body2">{summary || `${count} أصناف`}</Typography>
+      {row?.linkedItemCount > 0 && (
+        <Typography variant="caption" color="text.secondary">
+          {row.linkedItemCount} مربوط بالمخزون
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+function LineItemsTable({ rows, showItemId = false }) {
+  const lines = Array.isArray(rows) ? rows : [];
+  if (!lines.length) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        لا توجد بنود
+      </Typography>
+    );
+  }
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>الصنف</TableCell>
+          {showItemId && <TableCell>معرّف المخزون</TableCell>}
+          <TableCell align="right">الكمية</TableCell>
+          <TableCell align="right">المستلم</TableCell>
+          <TableCell align="right">السعر</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {lines.map((line, idx) => (
+          <TableRow key={line._id || line.itemId || idx}>
+            <TableCell>{line.itemName || line.item_name || '—'}</TableCell>
+            {showItemId && (
+              <TableCell>
+                <Typography variant="caption" fontFamily="monospace">
+                  {line.itemId ? String(line.itemId).slice(-8) : '—'}
+                </Typography>
+              </TableCell>
+            )}
+            <TableCell align="right">
+              {line.quantity ?? line.quantityOrdered ?? line.quantity_ordered ?? '—'}
+            </TableCell>
+            <TableCell align="right">
+              {line.quantityReceived ?? line.quantity_received ?? '—'}
+            </TableCell>
+            <TableCell align="right">
+              {(line.unitCost ?? line.unit_cost ?? line.estimatedUnitPrice ?? 0).toLocaleString()}{' '}
+              ر.س
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
 const BranchPurchasing = () => {
   const { showSnackbar } = useSnackbar();
   const [tabValue, setTabValue] = useState(0);
@@ -139,6 +209,7 @@ const BranchPurchasing = () => {
   const [detailDialogOpen, setDetailDialogOpen] = useState(false);
   const [selectedPR, setSelectedPR] = useState(null);
   const [poGrnDialogOpen, setPoGrnDialogOpen] = useState(false);
+  const [poDetailDialogOpen, setPoDetailDialogOpen] = useState(false);
   const [selectedPO, setSelectedPO] = useState(null);
   const [poGrns, setPoGrns] = useState([]);
 
@@ -328,6 +399,17 @@ const BranchPurchasing = () => {
       setPoGrnDialogOpen(true);
     } catch {
       showSnackbar('تعذر تحميل سندات الاستلام', 'error');
+    }
+  };
+
+  const handleViewPoDetail = async po => {
+    try {
+      const detail = (await purchaseOrderService.getById(po._id)) || po;
+      setSelectedPO(detail);
+      setPoDetailDialogOpen(true);
+    } catch {
+      setSelectedPO(po);
+      setPoDetailDialogOpen(true);
     }
   };
 
@@ -618,7 +700,7 @@ const BranchPurchasing = () => {
                   <TableCell>{pr.department}</TableCell>
                   <TableCell>{pr.requestedBy}</TableCell>
                   <TableCell>{pr.date}</TableCell>
-                  <TableCell>{pr.items} أصناف</TableCell>
+                  <TableCell>{renderItemsCell(pr)}</TableCell>
                   <TableCell>{pr.totalEstimated?.toLocaleString()} ر.س</TableCell>
                   <TableCell>
                     <Chip
@@ -732,7 +814,7 @@ const BranchPurchasing = () => {
                   <TableCell>{po.vendor}</TableCell>
                   <TableCell>{po.date}</TableCell>
                   <TableCell>{po.deliveryDate}</TableCell>
-                  <TableCell>{po.items}</TableCell>
+                  <TableCell>{renderItemsCell(po)}</TableCell>
                   <TableCell>{po.totalAmount?.toLocaleString()} ر.س</TableCell>
                   <TableCell>
                     <Chip
@@ -743,6 +825,11 @@ const BranchPurchasing = () => {
                   </TableCell>
                   <TableCell>
                     <Box display="flex" gap={0.5}>
+                      <Tooltip title="تفاصيل الأمر">
+                        <IconButton size="small" onClick={() => handleViewPoDetail(po)}>
+                          <ViewIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
                       <Tooltip title="سندات الاستلام">
                         <IconButton size="small" onClick={() => handleViewPoGrns(po)}>
                           <ReceiptIcon fontSize="small" />
@@ -793,6 +880,7 @@ const BranchPurchasing = () => {
                 <TableCell sx={{ fontWeight: 'bold' }}>رقم السند</TableCell>
                 <TableCell sx={{ fontWeight: 'bold' }}>أمر الشراء</TableCell>
                 <TableCell sx={{ fontWeight: 'bold' }}>المورد</TableCell>
+                <TableCell sx={{ fontWeight: 'bold' }}>الأصناف</TableCell>
                 <TableCell sx={{ fontWeight: 'bold' }}>المستودع</TableCell>
                 <TableCell sx={{ fontWeight: 'bold' }}>الفرع</TableCell>
                 <TableCell sx={{ fontWeight: 'bold' }}>التاريخ</TableCell>
@@ -811,6 +899,7 @@ const BranchPurchasing = () => {
                   </TableCell>
                   <TableCell>{rc.purchaseOrder}</TableCell>
                   <TableCell>{rc.vendor}</TableCell>
+                  <TableCell>{renderItemsCell(rc)}</TableCell>
                   <TableCell>{rc.warehouse}</TableCell>
                   <TableCell>
                     <Chip label={rc.branch} size="small" variant="outlined" />
@@ -1124,9 +1213,25 @@ const BranchPurchasing = () => {
                   عدد الأصناف
                 </Typography>
                 <Typography variant="body1" fontWeight="bold">
-                  {selectedPR.items}
+                  {resolveItemsCount(selectedPR)}
                 </Typography>
               </Grid>
+              {selectedPR.itemsSummary && (
+                <Grid item xs={12}>
+                  <Typography variant="caption" color="text.secondary">
+                    ملخص الأصناف
+                  </Typography>
+                  <Typography variant="body2">{selectedPR.itemsSummary}</Typography>
+                </Grid>
+              )}
+              {(selectedPR.lineItems?.length > 0 || Array.isArray(selectedPR.items)) && (
+                <Grid item xs={12}>
+                  <Divider sx={{ my: 1 }}>
+                    <Chip label="بنود الطلب" size="small" />
+                  </Divider>
+                  <LineItemsTable rows={selectedPR.lineItems || selectedPR.items} showItemId />
+                </Grid>
+              )}
               <Grid item xs={6}>
                 <Typography variant="caption" color="text.secondary">
                   القيمة التقديرية
@@ -1189,6 +1294,57 @@ const BranchPurchasing = () => {
         </DialogActions>
       </Dialog>
 
+      {/* ═══ PO DETAIL DIALOG (W790) ═══ */}
+      <Dialog
+        open={poDetailDialogOpen}
+        onClose={() => setPoDetailDialogOpen(false)}
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle>تفاصيل أمر الشراء — {selectedPO?.orderNumber}</DialogTitle>
+        <DialogContent>
+          {selectedPO && (
+            <Box sx={{ mt: 1 }}>
+              <Grid container spacing={2} sx={{ mb: 2 }}>
+                <Grid item xs={6} sm={4}>
+                  <Typography variant="caption" color="text.secondary">
+                    المورد
+                  </Typography>
+                  <Typography variant="body1">{selectedPO.vendor}</Typography>
+                </Grid>
+                <Grid item xs={6} sm={4}>
+                  <Typography variant="caption" color="text.secondary">
+                    الحالة
+                  </Typography>
+                  <Chip
+                    size="small"
+                    label={poStatusConfig[selectedPO.status]?.label || selectedPO.status}
+                    color={poStatusConfig[selectedPO.status]?.color || 'default'}
+                  />
+                </Grid>
+                <Grid item xs={6} sm={4}>
+                  <Typography variant="caption" color="text.secondary">
+                    الإجمالي
+                  </Typography>
+                  <Typography variant="body1" fontWeight="bold">
+                    {selectedPO.totalAmount?.toLocaleString()} ر.س
+                  </Typography>
+                </Grid>
+              </Grid>
+              {selectedPO.itemsSummary && (
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                  {selectedPO.itemsSummary}
+                </Typography>
+              )}
+              <LineItemsTable rows={selectedPO.lineItems} showItemId />
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPoDetailDialogOpen(false)}>إغلاق</Button>
+        </DialogActions>
+      </Dialog>
+
       {/* ═══ PO GRN DIALOG (W788) ═══ */}
       <Dialog
         open={poGrnDialogOpen}
@@ -1208,6 +1364,7 @@ const BranchPurchasing = () => {
                 <TableRow>
                   <TableCell>رقم السند</TableCell>
                   <TableCell>التاريخ</TableCell>
+                  <TableCell>الأصناف</TableCell>
                   <TableCell>المستلم</TableCell>
                   <TableCell>الحالة</TableCell>
                 </TableRow>
@@ -1217,7 +1374,8 @@ const BranchPurchasing = () => {
                   <TableRow key={grn._id}>
                     <TableCell>{grn.receiptNumber}</TableCell>
                     <TableCell>{grn.date}</TableCell>
-                    <TableCell>{grn.totalReceived ?? grn.items}</TableCell>
+                    <TableCell>{grn.itemsSummary || `${resolveItemsCount(grn)} أصناف`}</TableCell>
+                    <TableCell>{grn.totalReceived ?? resolveItemsCount(grn)}</TableCell>
                     <TableCell>
                       <Chip
                         size="small"


### PR DESCRIPTION
## Summary
- Add lineItems, itemsSummary, itemsCount, linkedItemCount to PR/PO/GRN adapter payloads
- BranchPurchasing shows item summaries in PR/PO/receipt tables, PO detail dialog with line items, enhanced GRN dialog

## Test plan
- [x] npx jest __tests__/purchasing-po-line-items-wave790.test.js __tests__/branch-purchasing-line-items-wave790.test.js (5 assertions)
- [ ] Manual: open /branch-purchasing PO tab, click view icon, verify line items with itemId


Made with [Cursor](https://cursor.com)