### PR TITLE
W791: PurchasingManagement line items + PR-to-PO route flow

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -957,6 +957,9 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-po-line-items-wave790.test.js'
       - 'backend/__tests__/branch-purchasing-line-items-wave790.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-routes-flow-wave791.test.js'
+      - 'backend/__tests__/purchasing-management-lines-wave791.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1897,6 +1900,9 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-po-line-items-wave790.test.js'
       - 'backend/__tests__/branch-purchasing-line-items-wave790.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-routes-flow-wave791.test.js'
+      - 'backend/__tests__/purchasing-management-lines-wave791.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/purchasing-management-lines-wave791.test.js
+++ b/backend/__tests__/purchasing-management-lines-wave791.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/**
+ * purchasing-management-lines-wave791.test.js — W791 /purchasing UI line-items drift guard.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PAGE = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    'frontend',
+    'src',
+    'pages',
+    'supply-chain',
+    'PurchasingManagement.js'
+  ),
+  'utf8'
+);
+const SERVICE = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'frontend', 'src', 'services', 'operationsService.js'),
+  'utf8'
+);
+
+describe('W791 — PurchasingManagement line items', () => {
+  it('operationsService exposes getPurchaseOrder + getOrderReceipts', () => {
+    expect(SERVICE).toMatch(/getPurchaseOrder/);
+    expect(SERVICE).toMatch(/getOrderReceipts/);
+    expect(SERVICE).toMatch(/orders\/\$\{id\}\/receipts/);
+  });
+
+  it('PurchasingManagement renders itemsSummary and PO line table', () => {
+    expect(PAGE).toMatch(/renderItemsCell/);
+    expect(PAGE).toMatch(/itemsSummary/);
+    expect(PAGE).toMatch(/PoLineItemsTable/);
+    expect(PAGE).toMatch(/handleViewPO/);
+    expect(PAGE).toMatch(/getPurchaseOrder/);
+    expect(PAGE).toMatch(/getOrderReceipts/);
+    expect(PAGE).toMatch(/linkedItemCount/);
+  });
+});

--- a/backend/__tests__/purchasing-routes-flow-wave791.test.js
+++ b/backend/__tests__/purchasing-routes-flow-wave791.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+/**
+ * purchasing-routes-flow-wave791.test.js — W791 HTTP flow PR→PO→receive with lineItems.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(60000);
+
+const mongoose = require('mongoose');
+const express = require('express');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+jest.mock('../middleware/auth', () => ({
+  authorize: () => (_req, _res, next) => next(),
+}));
+
+jest.mock('../middleware/branchScope.middleware', () => ({
+  branchFilter: () => ({}),
+}));
+
+let mongod;
+let app;
+let actorId;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w791-purchasing-routes' } });
+  await mongoose.connect(mongod.getUri());
+  require('../models/inventory/PurchaseOrder');
+  require('../models/inventory/PurchaseReceipt');
+  require('../models/inventory/InventoryItem');
+  require('../models/operations/PurchaseRequest.model');
+
+  actorId = new mongoose.Types.ObjectId();
+  app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = {
+      id: actorId,
+      _id: actorId,
+      roles: ['admin', 'department_head', 'procurement_manager'],
+    };
+    next();
+  });
+  app.use('/api/v1/purchasing', require('../routes/purchasing.routes'));
+  app.use((err, _req, res, _next) => {
+    res.status(err.status || 500).json({ success: false, message: err.message, code: err.code });
+  });
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+beforeEach(async () => {
+  const Po = require('../models/inventory/PurchaseOrder');
+  const Receipt = require('../models/inventory/PurchaseReceipt');
+  const PR = require('../models/operations/PurchaseRequest.model');
+  const Item = require('../models/inventory/InventoryItem');
+  await Po.deleteMany({});
+  await Receipt.deleteMany({});
+  await PR.deleteMany({});
+  await Item.deleteMany({});
+});
+
+describe('W791 behavioral — purchasing routes PR→PO→receive', () => {
+  it('convert-to-po then approve/receive returns lineItems on order and GRN', async () => {
+    const Item = require('../models/inventory/InventoryItem');
+    const inv = await Item.create({
+      name_ar: 'قفازات',
+      category: 'medical_supplies',
+      quantity_on_hand: 2,
+      created_by: actorId,
+    });
+
+    const prRes = await request(app)
+      .post('/api/v1/purchasing/requests')
+      .send({
+        requiredDate: new Date(Date.now() + 86400000).toISOString(),
+        items: [{ itemId: inv._id, product: 'قفازات', quantity: 3, estimatedPrice: 5 }],
+      })
+      .expect(201);
+    const prId = prRes.body.data._id;
+
+    await request(app).post(`/api/v1/purchasing/requests/${prId}/submit`).expect(200);
+    await request(app)
+      .post(`/api/v1/purchasing/requests/${prId}/approve`)
+      .send({ role: 'department_head' })
+      .expect(200);
+
+    const convertRes = await request(app)
+      .post(`/api/v1/purchasing/requests/${prId}/convert-to-po`)
+      .expect(201);
+    const orderId = convertRes.body.data.order._id;
+    expect(convertRes.body.data.order.lineItems).toHaveLength(1);
+    expect(String(convertRes.body.data.order.lineItems[0].itemId)).toBe(String(inv._id));
+
+    await request(app).patch(`/api/v1/purchasing/orders/${orderId}/approve`).expect(200);
+    const receiveRes = await request(app)
+      .patch(`/api/v1/purchasing/orders/${orderId}/receive`)
+      .expect(200);
+    expect(receiveRes.body.data.lineItems).toHaveLength(1);
+    expect(receiveRes.body.data.itemsSummary).toMatch(/قفازات/);
+
+    const grnRes = await request(app)
+      .get(`/api/v1/purchasing/orders/${orderId}/receipts`)
+      .expect(200);
+    expect(grnRes.body.data).toHaveLength(1);
+    expect(grnRes.body.data[0].lineItems).toHaveLength(1);
+    expect(grnRes.body.data[0].itemsSummary).toMatch(/قفازات/);
+
+    const orderRes = await request(app).get(`/api/v1/purchasing/orders/${orderId}`).expect(200);
+    expect(orderRes.body.data.linkedItemCount).toBe(1);
+  });
+});

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -118,6 +118,8 @@ __tests__/branch-purchasing-convert-wave789.test.js
 __tests__/purchasing-pr-item-convert-wave789.test.js
 __tests__/purchasing-po-line-items-wave790.test.js
 __tests__/branch-purchasing-line-items-wave790.test.js
+__tests__/purchasing-routes-flow-wave791.test.js
+__tests__/purchasing-management-lines-wave791.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js

--- a/frontend/src/__tests__/services-operationsService.test.js
+++ b/frontend/src/__tests__/services-operationsService.test.js
@@ -32,6 +32,8 @@ describe('services/operationsService.js', () => {
 
   test('exports purchasingService', () => {
     expect(source).toMatch(/purchasingService/);
+    expect(source).toMatch(/getPurchaseOrder/);
+    expect(source).toMatch(/getOrderReceipts/);
   });
 
   test('exports equipmentService', () => {

--- a/frontend/src/pages/supply-chain/PurchasingManagement.js
+++ b/frontend/src/pages/supply-chain/PurchasingManagement.js
@@ -63,6 +63,73 @@ const paymentTermLabels = {
   net60: 'صافي 60 يوم',
 };
 
+function resolveItemsCount(row) {
+  if (row?.itemsCount != null) return row.itemsCount;
+  if (typeof row?.items === 'number') return row.items;
+  if (Array.isArray(row?.items)) return row.items.length;
+  return 0;
+}
+
+function renderItemsCell(row) {
+  const count = resolveItemsCount(row);
+  const summary = row?.itemsSummary;
+  return (
+    <Box>
+      <Typography variant="body2">{summary || `${count} أصناف`}</Typography>
+      {row?.linkedItemCount > 0 && (
+        <Typography variant="caption" color="text.secondary">
+          {row.linkedItemCount} مربوط بالمخزون
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+function PoLineItemsTable({ rows }) {
+  const lines = Array.isArray(rows) ? rows : [];
+  if (!lines.length) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        لا توجد بنود
+      </Typography>
+    );
+  }
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>الصنف</TableCell>
+          <TableCell>معرّف المخزون</TableCell>
+          <TableCell align="right">الكمية</TableCell>
+          <TableCell align="right">المستلم</TableCell>
+          <TableCell align="right">السعر</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {lines.map((line, idx) => (
+          <TableRow key={line._id || line.itemId || idx}>
+            <TableCell>{line.itemName || line.item_name || '—'}</TableCell>
+            <TableCell>
+              <Typography variant="caption" fontFamily="monospace">
+                {line.itemId ? String(line.itemId).slice(-8) : '—'}
+              </Typography>
+            </TableCell>
+            <TableCell align="right">
+              {line.quantity ?? line.quantityOrdered ?? line.quantity_ordered ?? '—'}
+            </TableCell>
+            <TableCell align="right">
+              {line.quantityReceived ?? line.quantity_received ?? '—'}
+            </TableCell>
+            <TableCell align="right">
+              {(line.unitCost ?? line.unit_cost ?? 0).toLocaleString()} ر.س
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
 const PurchasingManagement = () => {
   const showSnackbar = useSnackbar();
   const [tab, setTab] = useState(0);
@@ -134,6 +201,18 @@ const PurchasingManagement = () => {
       loadData();
     } catch {
       showSnackbar('فشل في تسجيل الاستلام', 'error');
+    }
+  };
+
+  const handleViewPO = async po => {
+    try {
+      const [detail, grns] = await Promise.all([
+        purchasingService.getPurchaseOrder(po._id),
+        purchasingService.getOrderReceipts(po._id),
+      ]);
+      setViewPO({ ...po, ...(detail || {}), grns: grns || [] });
+    } catch {
+      setViewPO({ ...po, grns: [] });
     }
   };
 
@@ -307,7 +386,7 @@ const PurchasingManagement = () => {
                       <TableCell>
                         <Chip label={po.department} size="small" variant="outlined" />
                       </TableCell>
-                      <TableCell align="center">{po.items}</TableCell>
+                      <TableCell align="center">{renderItemsCell(po)}</TableCell>
                       <TableCell align="left">
                         <Typography fontWeight={700} sx={{ color: brandColors.primary }}>
                           {po.totalAmount?.toLocaleString()} ر.س
@@ -322,11 +401,11 @@ const PurchasingManagement = () => {
                       </TableCell>
                       <TableCell>
                         <Tooltip title="عرض">
-                          <IconButton size="small" onClick={() => setViewPO(po)}>
+                          <IconButton size="small" onClick={() => handleViewPO(po)}>
                             <ViewIcon fontSize="small" />
                           </IconButton>
                         </Tooltip>
-                        {po.status === 'pending' && (
+                        {(po.status === 'pending' || po.status === 'draft') && (
                           <Tooltip title="اعتماد">
                             <IconButton
                               size="small"
@@ -435,7 +514,7 @@ const PurchasingManagement = () => {
       <Dialog
         open={!!viewPO}
         onClose={() => setViewPO(null)}
-        maxWidth="sm"
+        maxWidth="md"
         fullWidth
         PaperProps={{ sx: { borderRadius: 3 } }}
       >
@@ -479,8 +558,53 @@ const PurchasingManagement = () => {
                 <Typography variant="body2" color="textSecondary">
                   عدد الأصناف
                 </Typography>
-                <Typography fontWeight={600}>{viewPO.items}</Typography>
+                <Typography fontWeight={600}>{resolveItemsCount(viewPO)}</Typography>
               </Grid>
+              {viewPO.itemsSummary && (
+                <Grid item xs={12}>
+                  <Typography variant="body2" color="textSecondary">
+                    ملخص الأصناف
+                  </Typography>
+                  <Typography variant="body2">{viewPO.itemsSummary}</Typography>
+                </Grid>
+              )}
+              <Grid item xs={12}>
+                <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 1 }}>
+                  بنود الأمر
+                </Typography>
+                <PoLineItemsTable rows={viewPO.lineItems} />
+              </Grid>
+              {viewPO.grns?.length > 0 && (
+                <Grid item xs={12}>
+                  <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 1 }}>
+                    سندات الاستلام (GRN)
+                  </Typography>
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>رقم السند</TableCell>
+                        <TableCell>التاريخ</TableCell>
+                        <TableCell>الأصناف</TableCell>
+                        <TableCell>الحالة</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {viewPO.grns.map(grn => (
+                        <TableRow key={grn._id}>
+                          <TableCell>{grn.receiptNumber}</TableCell>
+                          <TableCell>{grn.date}</TableCell>
+                          <TableCell>
+                            {grn.itemsSummary || `${resolveItemsCount(grn)} أصناف`}
+                          </TableCell>
+                          <TableCell>
+                            <Chip label={grn.status} size="small" />
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </Grid>
+              )}
               <Grid item xs={6}>
                 <Typography variant="body2" color="textSecondary">
                   الحالة

--- a/frontend/src/services/operationsService.js
+++ b/frontend/src/services/operationsService.js
@@ -133,6 +133,17 @@ export const purchasingService = {
     const r = await apiClient.patch(`/api/v1/purchasing/orders/${id}/receive`, data);
     return r.data;
   }),
+  getPurchaseOrder: safe(async id => {
+    const r = await apiClient.get(`/api/v1/purchasing/orders/${id}`);
+    const payload = r.data;
+    return payload?.data ?? payload;
+  }),
+  getOrderReceipts: safe(async id => {
+    const r = await apiClient.get(`/api/v1/purchasing/orders/${id}/receipts`);
+    const payload = r.data;
+    const rows = payload?.data ?? payload;
+    return Array.isArray(rows) ? rows : [];
+  }),
 
   getStats: safe(async () => {
     const r = await apiClient.get('/api/v1/purchasing/stats');


### PR DESCRIPTION
## Summary
- Align /purchasing (PurchasingManagement) with W790 lineItems/itemsSummary on PO table and detail dialog + GRN list
- Add getPurchaseOrder + getOrderReceipts to operationsService
- First supertest HTTP flow test: PR submit/approve/convert-to-po, PO approve/receive, GRN lineItems

## Test plan
- [x] purchasing-routes-flow-wave791.test.js (supertest + MongoMemoryServer)
- [x] purchasing-management-lines-wave791.test.js (UI drift)


Made with [Cursor](https://cursor.com)