### PR TITLE
W793: production cutover doc for W780-W792 purchasing vertical

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -962,6 +962,8 @@ on:
       - 'backend/__tests__/purchasing-management-lines-wave791.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-routes-stock-wave792.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-cutover-doc-wave793.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1907,6 +1909,8 @@ on:
       - 'backend/__tests__/purchasing-management-lines-wave791.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-routes-stock-wave792.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-cutover-doc-wave793.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/purchasing-cutover-doc-wave793.test.js
+++ b/backend/__tests__/purchasing-cutover-doc-wave793.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+/**
+ * purchasing-cutover-doc-wave793.test.js — W793 cutover doc drift guard.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DOC = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    'docs',
+    'architecture',
+    'PRODUCTION_CUTOVER_W780_W792_PURCHASING.md'
+  ),
+  'utf8'
+);
+const REGISTRY = fs.readFileSync(
+  path.join(__dirname, '..', 'routes', 'registries', 'features.registry.js'),
+  'utf8'
+);
+
+describe('W793 — purchasing cutover documentation', () => {
+  it('cutover doc exists with three-PO-model warning', () => {
+    expect(DOC).toMatch(/Production Cutover.*W780.*W792/i);
+    expect(DOC).toMatch(/three PO models/i);
+    expect(DOC).toMatch(/InventoryModulePurchaseOrder/);
+    expect(DOC).toMatch(/\/api\/v1\/inventory\/purchase-orders/);
+  });
+
+  it('documents W786 stock path and W789–W792 workflow', () => {
+    expect(DOC).toMatch(/purchasingStockReceive/);
+    expect(DOC).toMatch(/convert-to-po/);
+    expect(DOC).toMatch(/lineItems/);
+    expect(DOC).toMatch(/purchasing-routes-stock-wave792/);
+    expect(DOC).toMatch(/branch-purchasing/);
+    expect(DOC).toMatch(/PurchasingManagement/);
+  });
+
+  it('registry still dualMountAuth purchasing (doc ↔ code sync)', () => {
+    expect(REGISTRY).toMatch(/dualMountAuth\(app,\s*['"]purchasing['"]/);
+  });
+});

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -121,6 +121,7 @@ __tests__/branch-purchasing-line-items-wave790.test.js
 __tests__/purchasing-routes-flow-wave791.test.js
 __tests__/purchasing-management-lines-wave791.test.js
 __tests__/purchasing-routes-stock-wave792.test.js
+__tests__/purchasing-cutover-doc-wave793.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js

--- a/docs/architecture/PRODUCTION_CUTOVER_W780_W792_PURCHASING.md
+++ b/docs/architecture/PRODUCTION_CUTOVER_W780_W792_PURCHASING.md
@@ -1,0 +1,174 @@
+# Production Cutover — W780–W792 Legacy Purchasing / Supply Chain
+
+Date: 2026-06-02  
+Scope: 13 waves (W780–W792) closing the legacy `/api/v1/purchasing/*` vertical for
+66666 React surfaces (`/purchasing`, `/branch-purchasing`). Zero new env flags —
+deploy-ready on next push once roles are provisioned.
+
+This document is the ops checklist for verifying the purchasing adapter chain in
+production. Read top-to-bottom; sections follow deployment dependency order.
+
+---
+
+## 0. Pre-flight: three PO models (do NOT merge blindly)
+
+The platform still has **three** purchase-order backends. This series wires the
+**legacy purchasing adapter** only:
+
+| Surface                             | API path                                   | Mongoose model                      | Consumer                                               |
+| ----------------------------------- | ------------------------------------------ | ----------------------------------- | ------------------------------------------------------ |
+| **Legacy purchasing (this series)** | `/api/v1/purchasing/orders`                | `InventoryModulePurchaseOrder`      | `66666/frontend` — `/purchasing`, `/branch-purchasing` |
+| Inventory module                    | `/api/v1/inventory-module/purchase-orders` | same `InventoryModulePurchaseOrder` | Item picker in branch PR form (W789)                   |
+| Web-admin inventory                 | `/api/v1/inventory/purchase-orders`        | `PurchaseOrder` (InventoryStock)    | `alawael-rehab-platform/web-admin`                     |
+
+**Cutover rule:** legacy React pages MUST call `/api/v1/purchasing/*`. Web-admin
+inventory pages stay on `/api/v1/inventory/*` until a deliberate ADR unifies PO
+models. W783 added `/api/v1/inventory` as an alias to `inventory-enhanced` for
+web-admin only — not a PO unification.
+
+---
+
+## 1. Mongoose models (auto-register on route load)
+
+| Model                          | Collection                      | Used by                      |
+| ------------------------------ | ------------------------------- | ---------------------------- |
+| `InventoryModulePurchaseOrder` | `inventorymodulepurchaseorders` | PO create/receive/approve    |
+| `PurchaseReceipt`              | `purchasereceipts`              | GRN (goods receipt notes)    |
+| `Vendor`                       | `vendors`                       | Supplier master              |
+| `VendorSupplyContract`         | `vendorsupplycontracts`         | Branch contracts tab         |
+| `PurchaseRequest`              | `purchaserequests`              | PR workflow (ops engine)     |
+| `InventoryModuleItem`          | `inventorymoduleitems`          | Stock bump on receive (W786) |
+| `InventoryModuleTransaction`   | `inventorymoduletransactions`   | Receipt audit trail          |
+
+No migrations required — indexes created on first use. Stock receive requires PO
+lines with `item_id` pointing at a registered `InventoryModuleItem`.
+
+---
+
+## 2. HTTP mount
+
+Registered in `backend/routes/registries/features.registry.js`:
+
+```text
+dualMountAuth(app, 'purchasing', purchasing.routes)
+→ /api/purchasing/*  AND  /api/v1/purchasing/*
+```
+
+**Primary endpoints** (legacy UI):
+
+| Area                   | Methods                                    | Notes                                              |
+| ---------------------- | ------------------------------------------ | -------------------------------------------------- |
+| `/stats`, `/dashboard` | GET                                        | W787 legacy tile aliases                           |
+| `/vendors`             | CRUD                                       | W780                                               |
+| `/requests`            | CRUD + submit/approve/reject/convert-to-po | W773/W789                                          |
+| `/orders`              | CRUD + approve/receive/status              | W780/W784                                          |
+| `/orders/:id/receipts` | GET                                        | W785 — must be registered **before** `/orders/:id` |
+| `/receipts`            | CRUD                                       | W781 GRN                                           |
+| `/contracts`           | list + expiring + create                   | W781                                               |
+
+Auth: per-route `authorize(...)` — see section 5.
+
+---
+
+## 3. Legacy UI surfaces (66666/frontend)
+
+| Route                | Page                      | Service                               | Waves                             |
+| -------------------- | ------------------------- | ------------------------------------- | --------------------------------- |
+| `/purchasing`        | `PurchasingManagement.js` | `operationsService.purchasingService` | W787 stats, W791 lineItems        |
+| `/branch-purchasing` | `BranchPurchasing.js`     | `branchWarehouseService`              | W788–W790 PO tab, convert, picker |
+
+**End-to-end workflow (branch path):**
+
+```text
+PR (optional itemId picker) → submit → approve → convert-to-po
+  → PO tab → approve → receive → GRN dialog + stock ↑ (if item_id)
+```
+
+**Central purchasing path:** list POs → view line items (W791) → approve → receive.
+
+---
+
+## 4. Verification (post-deploy smoke)
+
+Run against staging with a procurement_manager JWT:
+
+```bash
+# Adapter unit (fast)
+cd backend && npx jest --config=jest.config.js \
+  __tests__/purchasing-vendor-order-wave780.test.js \
+  __tests__/purchasing-po-receipt-bridge-wave784.test.js \
+  __tests__/purchasing-receive-stock-wave786.test.js \
+  __tests__/purchasing-pr-item-convert-wave789.test.js \
+  __tests__/purchasing-po-line-items-wave790.test.js \
+  __tests__/purchasing-routes-flow-wave791.test.js \
+  __tests__/purchasing-routes-stock-wave792.test.js \
+  --no-coverage
+
+# HTTP E2E (MongoMemoryServer — no external DB)
+cd backend && npx jest --config=jest.config.js \
+  __tests__/purchasing-routes-flow-wave791.test.js \
+  __tests__/purchasing-routes-stock-wave792.test.js \
+  --no-coverage
+
+# Route load gate (pre-push)
+cd backend && npm run check:routes-load
+```
+
+**Manual UI checklist:**
+
+1. `/branch-purchasing` — create PR with inventory item → convert → PO tab shows `itemsSummary`.
+2. Approve + receive PO — GRN appears; inventory item qty increases if `item_id` linked.
+3. `/purchasing` — PO table shows summary; detail dialog lists `lineItems` + GRNs.
+
+---
+
+## 5. Roles to provision
+
+Backend accepts (non-exhaustive; see `purchasing.routes.js`):
+
+- `admin`, `manager`, `procurement_manager` — full PO/vendor/convert
+- `department_head`, `cfo`, `ceo` — PR approval chain
+- `staff` — PR create/submit
+
+Missing roles → 403 on mutate endpoints (not silent fallback).
+
+---
+
+## 6. Wave map (W780–W792)
+
+| Wave | Deliverable                                      |
+| ---- | ------------------------------------------------ |
+| W780 | Vendors + orders adapter; real data (no stubs)   |
+| W781 | `PurchaseReceipt` + `VendorSupplyContract`       |
+| W782 | Frontend `unwrapApiList` for legacy envelopes    |
+| W783 | `/api/v1/inventory` alias for web-admin          |
+| W784 | PO receive ↔ GRN sync (idempotent)              |
+| W785 | `GET /orders/:id/receipts` + stats receipt count |
+| W786 | Stock bump via `purchasingStockReceive.lib.js`   |
+| W787 | Stats aliases for `PurchasingManagement` tiles   |
+| W788 | BranchPurchasing PO tab + GRN dialog             |
+| W789 | PR `itemId` picker + convert-to-po UI            |
+| W790 | `lineItems` / `itemsSummary` on adapter payloads |
+| W791 | `/purchasing` line items + HTTP PR→PO flow test  |
+| W792 | HTTP receive verifies stock bump (supertest)     |
+
+**Sprint-gated drift guards:** 15+ test files under `backend/__tests__/purchasing-*-wave78*.test.js` and `branch-purchasing-*-wave788*.test.js` (enumerated in `backend/sprint-tests.txt`).
+
+---
+
+## 7. Open follow-ups (post-W792)
+
+- **Web-admin PO unification** — separate `PurchaseOrder` model at
+  `/api/v1/inventory/purchase-orders`; needs ADR before redirecting web-admin to
+  `/api/v1/purchasing`.
+- **Behavioral supertest for auth/403 paths** — W791/W792 mock `authorize`; add
+  negative tests when auth test harness is standardized.
+- **Partial receive** — current receive marks all lines fully received (W784); partial GRN UI deferred.
+
+---
+
+## 8. Related docs
+
+- `CLAUDE.md` — repo routing doctrine (66666 backend vs web-admin)
+- `docs/MIGRATION_LEDGER.md` — two-repo topology
+- `docs/architecture/PRODUCTION_CUTOVER_W356_W370.md` — template for clinical cutover pattern


### PR DESCRIPTION
## Summary
- Add \docs/architecture/PRODUCTION_CUTOVER_W780_W792_PURCHASING.md\ — ops checklist for legacy \/api/v1/purchasing/*\ deploy (three PO models, wave map W780–W792, verification commands, roles, open follow-ups).
- Add drift guard \purchasing-cutover-doc-wave793.test.js\ syncing doc ↔ \eatures.registry.js\ dualMountAuth purchasing mount.
- Enumerate W793 test in sprint-tests.txt / sprint-tests.yml.

## Test plan
- [x] \
px jest __tests__/purchasing-cutover-doc-wave793.test.js\ — 3/3 pass
- [x] \
pm run check:sprint-paths\ — in sync
- [ ] CI sprint-tests + backend pipeline green


Made with [Cursor](https://cursor.com)