### PR TITLE
W797: ADR-039 purchase order triple-backend formalization

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -970,6 +970,8 @@ on:
       - 'backend/__tests__/purchasing-partial-receive-wave795.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-cutover-doc-wave796.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-po-adr-wave797.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1923,6 +1925,8 @@ on:
       - 'backend/__tests__/purchasing-partial-receive-wave795.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-cutover-doc-wave796.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-po-adr-wave797.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/purchasing-po-adr-wave797.test.js
+++ b/backend/__tests__/purchasing-po-adr-wave797.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+/**
+ * purchasing-po-adr-wave797.test.js — W797 ADR-039 triple-backend drift guard.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ADR = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    'docs',
+    'architecture',
+    'decisions',
+    '039-purchase-order-triple-backend.md'
+  ),
+  'utf8'
+);
+const CUTOVER = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    'docs',
+    'architecture',
+    'PRODUCTION_CUTOVER_W780_W792_PURCHASING.md'
+  ),
+  'utf8'
+);
+const FEATURES = fs.readFileSync(
+  path.join(__dirname, '..', 'routes', 'registries', 'features.registry.js'),
+  'utf8'
+);
+
+describe('W797 — ADR-039 purchase order triple-backend', () => {
+  it('ADR documents three tiers and rejects redirect-only unification', () => {
+    expect(ADR).toMatch(/039\. Purchase Order Triple-Backend/);
+    expect(ADR).toMatch(/InventoryStock/);
+    expect(ADR).toMatch(/InventoryModulePurchaseOrder/);
+    expect(ADR).toMatch(/\/api\/v1\/inventory\/purchase-orders/);
+    expect(ADR).toMatch(/\/api\/v1\/purchasing\/orders/);
+    expect(ADR).toMatch(/partially_received/);
+    expect(ADR).toMatch(/Approach B/);
+    expect(ADR).toMatch(/no cross-redirect/i);
+  });
+
+  it('cutover doc points to ADR-039 for web-admin follow-up', () => {
+    expect(CUTOVER).toMatch(/039-purchase-order-triple-backend/);
+    expect(CUTOVER).toMatch(/ADR-039/);
+  });
+
+  it('registry keeps purchasing and inventory mounts separate', () => {
+    expect(FEATURES).toMatch(/dualMountAuth\(app,\s*['"]purchasing['"]/);
+    expect(FEATURES).toMatch(/dualMount\(app,\s*['"]inventory['"]/);
+    expect(FEATURES).not.toMatch(
+      /dualMountAuth\(app,\s*['"]purchasing['"][\s\S]*inventory-enhanced\.routes/
+    );
+  });
+});

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -125,6 +125,7 @@ __tests__/purchasing-cutover-doc-wave793.test.js
 __tests__/purchasing-routes-auth-wave794.test.js
 __tests__/purchasing-partial-receive-wave795.test.js
 __tests__/purchasing-cutover-doc-wave796.test.js
+__tests__/purchasing-po-adr-wave797.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js

--- a/docs/architecture/PRODUCTION_CUTOVER_W780_W792_PURCHASING.md
+++ b/docs/architecture/PRODUCTION_CUTOVER_W780_W792_PURCHASING.md
@@ -168,9 +168,11 @@ Missing roles → 403 on mutate endpoints (not silent fallback).
 
 ## 7. Open follow-ups (post-W795)
 
-- **Web-admin PO unification** — separate `PurchaseOrder` model at
-  `/api/v1/inventory/purchase-orders`; needs ADR before redirecting web-admin to
-  `/api/v1/purchasing`.
+- **Web-admin PO unification** — **blocked on ADR-039 sign-off**
+  ([`docs/architecture/decisions/039-purchase-order-triple-backend.md`](decisions/039-purchase-order-triple-backend.md)).
+  Web-admin `/inventory/purchase-orders` stays on `/api/v1/inventory/purchase-orders`
+  (InventoryStock). Do **not** redirect to `/api/v1/purchasing` without migration.
+  Stakeholder brief: [`039-DECISION-BRIEF.md`](decisions/039-DECISION-BRIEF.md).
 
 ---
 

--- a/docs/architecture/decisions/039-DECISION-BRIEF.md
+++ b/docs/architecture/decisions/039-DECISION-BRIEF.md
@@ -1,0 +1,44 @@
+# ADR-039 Decision Brief — Purchase Order Triple-Backend
+
+**Audience:** Product owner (supply chain) + web-admin lead + backend platform  
+**Date:** 2026-06-03  
+**Full ADR:** [039-purchase-order-triple-backend.md](039-purchase-order-triple-backend.md)
+
+## Meeting question (15 minutes)
+
+> Do we **keep two live PO backends** (web-admin InventoryStock + legacy adapter)
+> until a funded migration, or **force one API** now?
+
+## Recommendation
+
+**Keep separate (ADR-039 Approach B)** — ship nothing that redirects web-admin to
+`/api/v1/purchasing`.
+
+## Facts
+
+| Question                       | Answer                                                                                |
+| ------------------------------ | ------------------------------------------------------------------------------------- |
+| Is legacy purchasing done?     | Yes — W780–W795 on `main`; cutover doc published.                                     |
+| What does web-admin use today? | `GET/POST /api/v1/inventory/purchase-orders` (InventoryStock).                        |
+| Same database collection?      | **No** — `purchaseorders` (Stock) vs `inventorymodulepurchaseorders` (module).        |
+| Can we alias URLs only?        | **No** — field shapes and stock services differ.                                      |
+| Partial receive                | Tier B: `partial` + W795 dialog; Tier A: `partially_received` + `receiveGoodsFromPO`. |
+
+## Options
+
+| Option                               | Effort     | Risk                                             |
+| ------------------------------------ | ---------- | ------------------------------------------------ |
+| **B — Keep tiers (recommended)**     | 0 waves    | Low — status quo + ADR guard                     |
+| **A — Migrate module → Stock**       | 8–12 waves | Medium — data migration + legacy UI rewrite      |
+| **C — Adapter facade for web-admin** | 5–7 waves  | High — projection drift, dual stock paths remain |
+
+## Sign-off needed
+
+- [ ] Supply chain: legacy `/purchasing` remains Tier B for 12 months.
+- [ ] Web-admin: `/inventory/purchase-orders` remains Tier A; no path change without ADR-039 amendment.
+- [ ] Platform: reporting/BI documents two PO sources until migration.
+
+## No-regrets pre-work (either sign-off)
+
+1. Link ADR-039 from cutover doc §7 (W797).
+2. Add drift guard so new `dualMount` redirects between tiers fail CI review checklist.

--- a/docs/architecture/decisions/039-purchase-order-triple-backend.md
+++ b/docs/architecture/decisions/039-purchase-order-triple-backend.md
@@ -1,0 +1,90 @@
+# 039. Purchase Order Triple-Backend — Keep Separate, Do Not Redirect
+
+Date: 2026-06-03
+
+## Status
+
+Proposed
+
+## Context
+
+After W780–W795 the **legacy purchasing adapter** (`/api/v1/purchasing/*` →
+`InventoryModulePurchaseOrder`) is production-ready for 66666 React surfaces.
+**Web-admin** (`alawael-rehab-platform`) already ships inventory PO pages at
+`/inventory/purchase-orders` and `/procurement/orders`, both calling
+`/api/v1/inventory/purchase-orders` → `models/InventoryStock.js` `PurchaseOrder`.
+
+A fourth mount, `/api/v1/inventory-module/purchase-orders`, shares the **same
+Mongoose model** as legacy purchasing but uses inline routes (item picker in W789).
+
+| Tier                          | API prefix                                 | Model                            | Primary consumer                                           |
+| ----------------------------- | ------------------------------------------ | -------------------------------- | ---------------------------------------------------------- |
+| A — Web-admin inventory       | `/api/v1/inventory/purchase-orders`        | `PurchaseOrder` (InventoryStock) | web-admin `/inventory/*`, `/procurement/orders`            |
+| B — Legacy supply chain       | `/api/v1/purchasing/orders`                | `InventoryModulePurchaseOrder`   | 66666 `/purchasing`, `/branch-purchasing`                  |
+| C — Inventory module (picker) | `/api/v1/inventory-module/purchase-orders` | same as B                        | Branch PR `itemId` picker (W789)                           |
+| (orphan comment)              | `/api/v1/purchase-orders`                  | —                                | Referenced in stale TS types only; **no live 66666 route** |
+
+**Schema divergence (cannot merge by URL redirect alone):**
+
+- InventoryStock PO: `supplierId`, `warehouseId`, `partially_received`, embedded
+  `items[].itemId` ref `InventoryItem` (stock service `receiveGoodsFromPO`).
+- InventoryModule PO: `supplier_name` string, `partial` status, `items[].item_id` →
+  `InventoryModuleItem`, GRN via `PurchaseReceipt` + `purchasingAdapter` (W784–W795).
+
+**Risk if we redirect web-admin to `/api/v1/purchasing` without migration:**
+
+- Broken forms (missing warehouse/supplier FK shapes).
+- Split stock ledgers (`InventoryItem` vs `InventoryModuleItem` collections).
+- Status enum mismatch (`partial` vs `partially_received`).
+
+Ops checklist: [`PRODUCTION_CUTOVER_W780_W792_PURCHASING.md`](../PRODUCTION_CUTOVER_W780_W792_PURCHASING.md).
+
+## Decision
+
+**Approach B — Formalize three tiers; no cross-redirect in 2026-Q2.**
+
+1. **Web-admin stays on Tier A** (`inventory-enhanced` + InventoryStock PO) until a
+   funded consolidation program ships with explicit data migration + UI rewrite.
+2. **Legacy React stays on Tier B** (`purchasingAdapter`); W780–W795 is the
+   canonical path for branch/central supply-chain — do not point legacy UI at
+   `/api/v1/inventory/*`.
+3. **Tier C is read/write scoped to inventory-module flows only** (picker, module
+   CRUD); new supply-chain features must not add a fourth PO writer.
+4. **No “unification PR”** that only changes `NEXT_PUBLIC_API_URL` paths or
+   `dualMount` aliases — rejected as silent data fork.
+5. **Future consolidation (optional, Phase 2)** — only after stakeholder sign-off
+   on [`039-DECISION-BRIEF.md`](039-DECISION-BRIEF.md) Approach A or C:
+   - **A:** Migrate InventoryModule PO docs → InventoryStock schema + retire adapter.
+   - **C:** Facade service projecting InventoryStock shape from adapter reads (higher
+     drift risk).
+
+## Consequences
+
+### Positive
+
+- Zero regression risk to web-admin inventory PO pages already in production use.
+- Legacy W780–W795 investment preserved; ops doc remains accurate.
+- Clear ownership: web-admin inventory team ↔ InventoryStock service; supply-chain ↔
+  purchasing adapter.
+
+### Negative
+
+- Two stock item collections (`InventoryItem` vs `InventoryModuleItem`) until
+  consolidation.
+- Reporting across branches may need union queries or BI layer normalization.
+- Procurement staff may see different PO numbers in legacy vs web-admin UIs.
+
+### Guardrails (enforce now)
+
+- New PO features: pick **one** tier in the PR description; cross-tier requires ADR
+  amendment.
+- Drift guard: `purchasing-po-adr-wave797.test.js` + cutover doc §7 link.
+- Wave namespace: backend adapter waves continue `W78x`; web-admin PO changes ship
+  in `alawael-rehab-platform` with separate wave collision scope.
+
+## References
+
+- W783 — `/api/v1/inventory` alias mount (web-admin only).
+- W795 — partial receive on Tier B (`body.items` on `PATCH …/receive`).
+- ADR-021 — duplicate model registration pattern (InventoryModulePurchaseOrder vs
+  `PurchaseOrder` name collision rationale in `models/inventory/PurchaseOrder.js`).


### PR DESCRIPTION
## Summary
- Add **ADR-039** — formalize three PO backends (InventoryStock/web-admin, InventoryModule/legacy purchasing, inventory-module picker); reject redirect-only unification.
- Add stakeholder brief \