### PR TITLE
W799: cross-tier purchasing platform-stats (ADR-039)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -974,6 +974,8 @@ on:
       - 'backend/__tests__/purchasing-po-adr-wave797.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-modules-doc-wave798.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-platform-stats-wave799.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1931,6 +1933,8 @@ on:
       - 'backend/__tests__/purchasing-po-adr-wave797.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-modules-doc-wave798.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-platform-stats-wave799.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/purchasing-platform-stats-wave799.test.js
+++ b/backend/__tests__/purchasing-platform-stats-wave799.test.js
@@ -1,0 +1,151 @@
+'use strict';
+
+/**
+ * purchasing-platform-stats-wave799.test.js — W799 cross-tier read-only PO stats.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(60000);
+
+const mongoose = require('mongoose');
+const express = require('express');
+const request = require('supertest');
+const fs = require('fs');
+const path = require('path');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const adapter = require('../services/purchasingAdapter.service');
+
+jest.mock('../middleware/auth', () => ({
+  authorize: () => (_req, _res, next) => next(),
+}));
+jest.mock('../middleware/branchScope.middleware', () => ({
+  branchFilter: () => ({}),
+}));
+
+let mongod;
+let app;
+let actorId;
+let branchId;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w799-platform-stats' } });
+  await mongoose.connect(mongod.getUri());
+  require('../models/inventory/PurchaseOrder');
+  require('../models/InventoryStock');
+  require('../models/Warehouse');
+  require('../models/inventory/PurchaseReceipt');
+
+  actorId = new mongoose.Types.ObjectId();
+  branchId = new mongoose.Types.ObjectId();
+  app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = { id: actorId, _id: actorId, role: 'procurement_manager' };
+    next();
+  });
+  app.use('/api/v1/purchasing', require('../routes/purchasing.routes'));
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+beforeEach(async () => {
+  const ModulePo = require('../models/inventory/PurchaseOrder');
+  const { PurchaseOrder: StockPo } = require('../models/InventoryStock');
+  const Receipt = require('../models/inventory/PurchaseReceipt');
+  await ModulePo.deleteMany({});
+  await StockPo.deleteMany({});
+  await Receipt.deleteMany({});
+});
+
+describe('W799 behavioral — getPlatformStats', () => {
+  it('returns separate counts per ADR-039 tier', async () => {
+    const ModulePo = require('../models/inventory/PurchaseOrder');
+    const { PurchaseOrder: StockPo, Supplier } = require('../models/InventoryStock');
+    const Warehouse = require('../models/Warehouse');
+
+    await ModulePo.create({
+      supplier_name: 'Legacy Vendor',
+      status: 'partial',
+      branch_id: branchId,
+      items: [{ item_name_ar: 'A', quantity_ordered: 10, quantity_received: 3, unit_cost: 1 }],
+      created_by: actorId,
+    });
+    await ModulePo.create({
+      supplier_name: 'Legacy Vendor',
+      status: 'received',
+      branch_id: branchId,
+      items: [{ item_name_ar: 'B', quantity_ordered: 5, quantity_received: 5, unit_cost: 2 }],
+      created_by: actorId,
+    });
+
+    const supplier = await Supplier.create({
+      nameAr: 'مورد',
+      code: 'SUP-1',
+      contactPerson: 'أحمد',
+      phone: '0500000000',
+      email: 'supplier@example.com',
+    });
+    const warehouse = await Warehouse.create({
+      nameAr: 'مستودع',
+      code: 'WH-1',
+      branchId,
+    });
+    await StockPo.create({
+      poNumber: 'PO-STOCK-1',
+      supplierId: supplier._id,
+      branchId,
+      warehouseId: warehouse._id,
+      requestedBy: actorId,
+      orderDate: new Date(),
+      status: 'partially_received',
+      items: [],
+    });
+
+    const stats = await adapter.getPlatformStats({ branchId: String(branchId) });
+
+    expect(stats.adr).toBe('039');
+    expect(stats.tiers.legacyPurchasing.totalOrders).toBe(2);
+    expect(stats.tiers.legacyPurchasing.partialOrders).toBe(1);
+    expect(stats.tiers.legacyPurchasing.receivedOrders).toBe(1);
+    expect(stats.tiers.inventoryStock.modelAvailable).toBe(true);
+    expect(stats.tiers.inventoryStock.totalOrders).toBe(1);
+    expect(stats.tiers.inventoryStock.partiallyReceivedOrders).toBe(1);
+  });
+});
+
+describe('W799 HTTP — GET /platform-stats', () => {
+  it('exposes federation payload', async () => {
+    const ModulePo = require('../models/inventory/PurchaseOrder');
+    await ModulePo.create({
+      supplier_name: 'X',
+      status: 'approved',
+      created_by: actorId,
+    });
+
+    const res = await request(app).get('/api/v1/purchasing/platform-stats');
+    expect(res.status).toBe(200);
+    expect(res.body.data.tiers.legacyPurchasing.totalOrders).toBe(1);
+    expect(res.body.data.tiers.inventoryStock).toBeDefined();
+  });
+});
+
+describe('W799 drift — platform-stats wiring', () => {
+  it('adapter and routes export getPlatformStats', () => {
+    const routes = fs.readFileSync(
+      path.join(__dirname, '..', 'routes', 'purchasing.routes.js'),
+      'utf8'
+    );
+    const svc = fs.readFileSync(
+      path.join(__dirname, '..', 'services', 'purchasingAdapter.service.js'),
+      'utf8'
+    );
+    expect(svc).toMatch(/W799/);
+    expect(svc).toMatch(/getPlatformStats/);
+    expect(routes).toMatch(/\/platform-stats/);
+    expect(routes).toMatch(/getPlatformStats/);
+  });
+});

--- a/backend/routes/purchasing.routes.js
+++ b/backend/routes/purchasing.routes.js
@@ -1,6 +1,6 @@
 /**
  * Purchasing Routes — /api/v1/purchasing/*
- * W773 — PR adapter; W780 — vendors/orders; W781 — receipts + vendor contracts; W785 — PO receipts.
+ * W773 — PR adapter; W780 — vendors/orders; W781 — receipts + vendor contracts; W785 — PO receipts; W799 — platform-stats.
  */
 'use strict';
 
@@ -51,6 +51,18 @@ router.get(
   '/stats',
   wrap(async (req, res) => {
     const data = await adapter.getStats();
+    res.json({ success: true, data });
+  })
+);
+
+router.get(
+  '/platform-stats',
+  wrap(async (req, res) => {
+    const scope = branchFilter(req);
+    const data = await adapter.getPlatformStats({
+      ...req.query,
+      branchId: scope.branchId || req.query.branchId,
+    });
     res.json({ success: true, data });
   })
 );

--- a/backend/services/purchasingAdapter.service.js
+++ b/backend/services/purchasingAdapter.service.js
@@ -7,6 +7,7 @@
  * W781: receipts → PurchaseReceipt; contracts → VendorSupplyContract.
  * W784: PO receive ↔ GRN sync on InventoryModulePurchaseOrder.
  * W795: optional body.items on receiveOrder for partial GRN shipments.
+ * W799: read-only cross-tier PO counts (legacy + InventoryStock) for ADR-039 reporting.
  * W785: list receipts by PO + dashboard receipt count.
  * W786: stock receipt when PO lines include item_id (InventoryModuleItem).
  * W787: legacy stats field aliases for PurchasingManagement.js tiles.
@@ -924,6 +925,99 @@ async function getStats() {
   };
 }
 
+function tryGetInventoryStockPoModel() {
+  try {
+    const { PurchaseOrder } = require('../models/InventoryStock');
+    return PurchaseOrder;
+  } catch {
+    return null;
+  }
+}
+
+function buildBranchFilter(query, fieldName) {
+  const branchId = query.branchId || query.branch_id;
+  if (!branchId) return {};
+  return { [fieldName]: branchId };
+}
+
+async function countLegacyPurchasingTierStats(query = {}) {
+  const Po = getPoModel();
+  const base = { deleted_at: null, ...buildBranchFilter(query, 'branch_id') };
+  const [totalOrders, partialOrders, receivedOrders, pendingApproval, activeOrders] =
+    await Promise.all([
+      Po.countDocuments(base),
+      Po.countDocuments({ ...base, status: 'partial' }),
+      Po.countDocuments({ ...base, status: { $in: ['received', 'closed'] } }),
+      Po.countDocuments({ ...base, status: { $in: ['draft', 'pending_approval'] } }),
+      Po.countDocuments({
+        ...base,
+        status: { $in: ['approved', 'sent', 'partial'] },
+      }),
+    ]);
+  return { totalOrders, partialOrders, receivedOrders, pendingApproval, activeOrders };
+}
+
+async function countInventoryStockTierStats(query = {}) {
+  const StockPo = tryGetInventoryStockPoModel();
+  if (!StockPo) {
+    return {
+      modelAvailable: false,
+      totalOrders: 0,
+      partiallyReceivedOrders: 0,
+      receivedOrders: 0,
+      pendingApproval: 0,
+      activeOrders: 0,
+    };
+  }
+  const base = { ...buildBranchFilter(query, 'branchId') };
+  const [totalOrders, partiallyReceivedOrders, receivedOrders, pendingApproval, activeOrders] =
+    await Promise.all([
+      StockPo.countDocuments(base),
+      StockPo.countDocuments({ ...base, status: 'partially_received' }),
+      StockPo.countDocuments({ ...base, status: 'received' }),
+      StockPo.countDocuments({ ...base, status: { $in: ['draft', 'pending_approval'] } }),
+      StockPo.countDocuments({
+        ...base,
+        status: { $in: ['approved', 'ordered', 'partially_received'] },
+      }),
+    ]);
+  return {
+    modelAvailable: true,
+    totalOrders,
+    partiallyReceivedOrders,
+    receivedOrders,
+    pendingApproval,
+    activeOrders,
+  };
+}
+
+/** W799 — ADR-039 read-only federation; does not merge PO documents. */
+async function getPlatformStats(query = {}) {
+  const [legacyCounts, stockCounts] = await Promise.all([
+    countLegacyPurchasingTierStats(query),
+    countInventoryStockTierStats(query),
+  ]);
+  return {
+    generatedAt: new Date().toISOString(),
+    adr: '039',
+    note: 'Read-only per-tier counts; web-admin uses /api/v1/inventory, legacy React uses /api/v1/purchasing.',
+    tiers: {
+      legacyPurchasing: {
+        tier: 'B',
+        apiPath: '/api/v1/purchasing/orders',
+        mongooseModel: 'InventoryModulePurchaseOrder',
+        ...legacyCounts,
+      },
+      inventoryStock: {
+        tier: 'A',
+        apiPath: '/api/v1/inventory/purchase-orders',
+        mongooseModel: 'PurchaseOrder',
+        ...stockCounts,
+      },
+    },
+  };
+}
+
 module.exports = {
   listVendors,
   getVendor,
@@ -951,4 +1045,5 @@ module.exports = {
   listExpiringContracts,
   createContract,
   getStats,
+  getPlatformStats,
 };

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -127,6 +127,7 @@ __tests__/purchasing-partial-receive-wave795.test.js
 __tests__/purchasing-cutover-doc-wave796.test.js
 __tests__/purchasing-po-adr-wave797.test.js
 __tests__/purchasing-modules-doc-wave798.test.js
+__tests__/purchasing-platform-stats-wave799.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js

--- a/docs/architecture/PRODUCTION_CUTOVER_W780_W792_PURCHASING.md
+++ b/docs/architecture/PRODUCTION_CUTOVER_W780_W792_PURCHASING.md
@@ -59,6 +59,7 @@ dualMountAuth(app, 'purchasing', purchasing.routes)
 | Area                   | Methods                                    | Notes                                              |
 | ---------------------- | ------------------------------------------ | -------------------------------------------------- |
 | `/stats`, `/dashboard` | GET                                        | W787 legacy tile aliases                           |
+| `/platform-stats`      | GET                                        | W799 — ADR-039 cross-tier read-only counts         |
 | `/vendors`             | CRUD                                       | W780                                               |
 | `/requests`            | CRUD + submit/approve/reject/convert-to-po | W773/W789                                          |
 | `/orders`              | CRUD + approve/receive/status              | W780/W784/W795 partial `body.items` on receive     |
@@ -143,27 +144,28 @@ Missing roles → 403 on mutate endpoints (not silent fallback).
 
 ## 6. Wave map (W780–W795)
 
-| Wave | Deliverable                                        |
-| ---- | -------------------------------------------------- |
-| W780 | Vendors + orders adapter; real data (no stubs)     |
-| W781 | `PurchaseReceipt` + `VendorSupplyContract`         |
-| W782 | Frontend `unwrapApiList` for legacy envelopes      |
-| W783 | `/api/v1/inventory` alias for web-admin            |
-| W784 | PO receive ↔ GRN sync (idempotent full receive)   |
-| W785 | `GET /orders/:id/receipts` + stats receipt count   |
-| W786 | Stock bump via `purchasingStockReceive.lib.js`     |
-| W787 | Stats aliases for `PurchasingManagement` tiles     |
-| W788 | BranchPurchasing PO tab + GRN dialog               |
-| W789 | PR `itemId` picker + convert-to-po UI              |
-| W790 | `lineItems` / `itemsSummary` on adapter payloads   |
-| W791 | `/purchasing` line items + HTTP PR→PO flow test    |
-| W792 | HTTP receive verifies stock bump (supertest)       |
-| W793 | This cutover doc + registry drift guard            |
-| W794 | Real `authorize()` 401/403 route negatives         |
-| W795 | Partial receive via `body.items` + receive dialog  |
-| W796 | Cutover doc sync through W795                      |
-| W797 | ADR-039 triple-backend formalization               |
-| W798 | MODULES.md + PRODUCTION_GAPS discoverability links |
+| Wave | Deliverable                                                    |
+| ---- | -------------------------------------------------------------- |
+| W780 | Vendors + orders adapter; real data (no stubs)                 |
+| W781 | `PurchaseReceipt` + `VendorSupplyContract`                     |
+| W782 | Frontend `unwrapApiList` for legacy envelopes                  |
+| W783 | `/api/v1/inventory` alias for web-admin                        |
+| W784 | PO receive ↔ GRN sync (idempotent full receive)               |
+| W785 | `GET /orders/:id/receipts` + stats receipt count               |
+| W786 | Stock bump via `purchasingStockReceive.lib.js`                 |
+| W787 | Stats aliases for `PurchasingManagement` tiles                 |
+| W788 | BranchPurchasing PO tab + GRN dialog                           |
+| W789 | PR `itemId` picker + convert-to-po UI                          |
+| W790 | `lineItems` / `itemsSummary` on adapter payloads               |
+| W791 | `/purchasing` line items + HTTP PR→PO flow test                |
+| W792 | HTTP receive verifies stock bump (supertest)                   |
+| W793 | This cutover doc + registry drift guard                        |
+| W794 | Real `authorize()` 401/403 route negatives                     |
+| W795 | Partial receive via `body.items` + receive dialog              |
+| W796 | Cutover doc sync through W795                                  |
+| W797 | ADR-039 triple-backend formalization                           |
+| W798 | MODULES.md + PRODUCTION_GAPS discoverability links             |
+| W799 | `GET /platform-stats` cross-tier read-only PO counts (ADR-039) |
 
 **Sprint-gated drift guards:** 18+ test files under `backend/__tests__/purchasing-*-wave78*.test.js` (enumerated in `backend/sprint-tests.txt`).
 


### PR DESCRIPTION
## Summary
- Adds read-only `GET /api/v1/purchasing/platform-stats` returning per-tier PO counts for legacy (Tier B) and InventoryStock (Tier A) without merging APIs.
- Adapter: `getPlatformStats` with branch-scoped counts; drift + behavioral tests (3 assertions).

## Test plan
- [x] `npx jest --config=jest.config.js __tests__/purchasing-platform-stats-wave799.test.js`
- [ ] CI sprint + purchasing suite green


Made with [Cursor](https://cursor.com)