### PR TITLE
feat(purchasing): W803-W804 platform-stats banner on legacy UI

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -980,10 +980,6 @@ on:
       - 'backend/__tests__/purchasing-cutover-doc-wave800.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-platform-stats-ui-wave803.test.js'
-      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
-      - 'backend/__tests__/facility-maintenance-bridge-wave801.test.js'
-      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
-      - 'backend/__tests__/facility-asset-spawn-work-order-wave802.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1947,10 +1943,6 @@ on:
       - 'backend/__tests__/purchasing-cutover-doc-wave800.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-platform-stats-ui-wave803.test.js'
-      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
-      - 'backend/__tests__/facility-maintenance-bridge-wave801.test.js'
-      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
-      - 'backend/__tests__/facility-asset-spawn-work-order-wave802.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -978,6 +978,12 @@ on:
       - 'backend/__tests__/purchasing-platform-stats-wave799.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-cutover-doc-wave800.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-platform-stats-ui-wave803.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/facility-maintenance-bridge-wave801.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/facility-asset-spawn-work-order-wave802.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1939,6 +1945,12 @@ on:
       - 'backend/__tests__/purchasing-platform-stats-wave799.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-cutover-doc-wave800.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-platform-stats-ui-wave803.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/facility-maintenance-bridge-wave801.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/facility-asset-spawn-work-order-wave802.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/purchasing-cutover-doc-wave800.test.js
+++ b/backend/__tests__/purchasing-cutover-doc-wave800.test.js
@@ -26,6 +26,8 @@ describe('W800 — purchasing cutover doc W796–W799 extensions', () => {
     expect(DOC).toMatch(/\| W798 \|/);
     expect(DOC).toMatch(/\| W799 \|/);
     expect(DOC).toMatch(/\| W800 \|/);
+    expect(DOC).toMatch(/\| W803 \|/);
+    expect(DOC).toMatch(/\| W804 \|/);
   });
 
   it('documents platform-stats verification and sprint test', () => {

--- a/backend/__tests__/purchasing-platform-stats-ui-wave803.test.js
+++ b/backend/__tests__/purchasing-platform-stats-ui-wave803.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+/**
+ * purchasing-platform-stats-ui-wave803.test.js — W803 legacy UI drift guard.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const OPS = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'frontend', 'src', 'services', 'operationsService.js'),
+  'utf8'
+);
+const PAGE = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    'frontend',
+    'src',
+    'pages',
+    'supply-chain',
+    'PurchasingManagement.js'
+  ),
+  'utf8'
+);
+const BRANCH = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    'frontend',
+    'src',
+    'pages',
+    'supply-chain',
+    'BranchPurchasing.js'
+  ),
+  'utf8'
+);
+const BANNER = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    'frontend',
+    'src',
+    'pages',
+    'supply-chain',
+    'PurchasingPlatformStatsBanner.js'
+  ),
+  'utf8'
+);
+
+describe('W803 — purchasing platform-stats legacy UI', () => {
+  it('operationsService exposes getPlatformStats', () => {
+    expect(OPS).toMatch(/getPlatformStats/);
+    expect(OPS).toMatch(/\/api\/v1\/purchasing\/platform-stats/);
+  });
+
+  it('shared banner component calls platform-stats', () => {
+    expect(BANNER).toMatch(/getPlatformStats/);
+    expect(BANNER).toMatch(/ADR-039/);
+    expect(BANNER).toMatch(/legacyPurchasing/);
+    expect(BANNER).toMatch(/inventoryStock/);
+  });
+
+  it('PurchasingManagement and BranchPurchasing mount the banner (W803/W804)', () => {
+    expect(PAGE).toMatch(/PurchasingPlatformStatsBanner/);
+    expect(BRANCH).toMatch(/PurchasingPlatformStatsBanner/);
+  });
+});

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -576,5 +576,3 @@ __tests__/ops-alert-model-wave733.test.js
 tests/unit/ops-alerter.test.js
 __tests__/email-transport-wave735.test.js
 __tests__/reporting-scheduler-bootstrap-wave762.test.js
-__tests__/facility-maintenance-bridge-wave801.test.js
-__tests__/facility-asset-spawn-work-order-wave802.test.js

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -129,6 +129,7 @@ __tests__/purchasing-po-adr-wave797.test.js
 __tests__/purchasing-modules-doc-wave798.test.js
 __tests__/purchasing-platform-stats-wave799.test.js
 __tests__/purchasing-cutover-doc-wave800.test.js
+__tests__/purchasing-platform-stats-ui-wave803.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/dashboard-mount-wave776.test.js
@@ -575,3 +576,5 @@ __tests__/ops-alert-model-wave733.test.js
 tests/unit/ops-alerter.test.js
 __tests__/email-transport-wave735.test.js
 __tests__/reporting-scheduler-bootstrap-wave762.test.js
+__tests__/facility-maintenance-bridge-wave801.test.js
+__tests__/facility-asset-spawn-work-order-wave802.test.js

--- a/docs/architecture/PRODUCTION_CUTOVER_W780_W792_PURCHASING.md
+++ b/docs/architecture/PRODUCTION_CUTOVER_W780_W792_PURCHASING.md
@@ -134,7 +134,8 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
 1. `/branch-purchasing` — create PR with inventory item → convert → PO tab shows `itemsSummary`.
 2. Approve + receive PO — partial qty dialog (W795) or full receive; GRN appears; stock ↑ for linked `item_id`.
 3. `/purchasing` — PO table shows summary; detail dialog lists `lineItems` + GRNs; `partial` status chip when applicable.
-4. `GET /api/v1/purchasing/platform-stats` — returns both tiers without mutating either collection (W799).
+4. `/purchasing` + `/branch-purchasing` — `PurchasingPlatformStatsBanner` shows Tier B + Tier A (W803/W804).
+5. `GET /api/v1/purchasing/platform-stats` — returns both tiers without mutating either collection (W799).
 
 ---
 
@@ -175,6 +176,8 @@ Missing roles → 403 on mutate endpoints (not silent fallback).
 | W798 | MODULES.md + PRODUCTION_GAPS discoverability links                |
 | W799 | `GET /platform-stats` cross-tier read-only PO counts (ADR-039)    |
 | W800 | Cutover doc verification sync through W799 (this section §4 curl) |
+| W803 | `PurchasingPlatformStatsBanner` on `/purchasing`                  |
+| W804 | Same banner on `/branch-purchasing`                               |
 
 **Sprint-gated drift guards:** 19+ test files under `backend/__tests__/purchasing-*-wave78*.test.js` (enumerated in `backend/sprint-tests.txt`).
 

--- a/frontend/src/__tests__/services-operationsService.test.js
+++ b/frontend/src/__tests__/services-operationsService.test.js
@@ -34,6 +34,8 @@ describe('services/operationsService.js', () => {
     expect(source).toMatch(/purchasingService/);
     expect(source).toMatch(/getPurchaseOrder/);
     expect(source).toMatch(/getOrderReceipts/);
+    expect(source).toMatch(/getPlatformStats/);
+    expect(source).toMatch(/\/api\/v1\/purchasing\/platform-stats/);
   });
 
   test('exports equipmentService', () => {

--- a/frontend/src/pages/supply-chain/BranchPurchasing.js
+++ b/frontend/src/pages/supply-chain/BranchPurchasing.js
@@ -65,6 +65,7 @@ import {
   inventoryModuleItemService,
 } from 'services/branchWarehouseService';
 import PartialReceiveDialog from './PartialReceiveDialog';
+import PurchasingPlatformStatsBanner from './PurchasingPlatformStatsBanner';
 
 const prStatusConfig = {
   draft: { label: 'مسودة', color: 'default' },
@@ -579,6 +580,8 @@ const BranchPurchasing = () => {
           </Box>
         </CardContent>
       </Card>
+
+      <PurchasingPlatformStatsBanner />
 
       {loading && <LinearProgress sx={{ mb: 2 }} />}
 

--- a/frontend/src/pages/supply-chain/PurchasingManagement.js
+++ b/frontend/src/pages/supply-chain/PurchasingManagement.js
@@ -44,6 +44,7 @@ import {
 } from '@mui/icons-material';
 import { purchasingService } from 'services/operationsService';
 import PartialReceiveDialog from './PartialReceiveDialog';
+import PurchasingPlatformStatsBanner from './PurchasingPlatformStatsBanner';
 import { gradients, brandColors, statusColors, surfaceColors, neutralColors } from 'theme/palette';
 import { useSnackbar } from '../../contexts/SnackbarContext';
 
@@ -275,6 +276,8 @@ const PurchasingManagement = () => {
           </Box>
         </CardContent>
       </Card>
+
+      <PurchasingPlatformStatsBanner />
 
       {/* Stats */}
       {stats && (

--- a/frontend/src/pages/supply-chain/PurchasingPlatformStatsBanner.js
+++ b/frontend/src/pages/supply-chain/PurchasingPlatformStatsBanner.js
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react';
+import { Alert, Typography, Box, Chip } from '@mui/material';
+import { purchasingService } from 'services/operationsService';
+
+/** W803/W804 — ADR-039 cross-tier PO counts (read-only). */
+export default function PurchasingPlatformStatsBanner() {
+  const [platformStats, setPlatformStats] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    purchasingService
+      .getPlatformStats()
+      .then(ps => {
+        if (cancelled) return;
+        const tierPayload = ps?.data ?? ps;
+        setPlatformStats(tierPayload?.tiers ? tierPayload : null);
+      })
+      .catch(() => {
+        if (!cancelled) setPlatformStats(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const tiers = platformStats?.tiers;
+  if (!tiers?.legacyPurchasing) return null;
+
+  return (
+    <Alert severity="info" sx={{ mb: 2, borderRadius: 2 }}>
+      <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 0.5 }}>
+        نظرة عبر الطبقات (ADR-039 — للقراءة فقط)
+      </Typography>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+        <Chip
+          size="small"
+          label={`مشتريات (Tier B): ${tiers.legacyPurchasing.totalOrders ?? 0} أمر — ${
+            tiers.legacyPurchasing.partialOrders ?? 0
+          } جزئي`}
+        />
+        {tiers.inventoryStock?.modelAvailable !== false ? (
+          <Chip
+            size="small"
+            color="secondary"
+            variant="outlined"
+            label={`مخزون web-admin (Tier A): ${
+              tiers.inventoryStock?.totalOrders ?? 0
+            } أمر — ${tiers.inventoryStock?.partiallyReceivedOrders ?? 0} جزئي`}
+          />
+        ) : (
+          <Chip size="small" variant="outlined" label="مخزون web-admin: غير مسجّل في هذه البيئة" />
+        )}
+      </Box>
+    </Alert>
+  );
+}

--- a/frontend/src/services/operationsService.js
+++ b/frontend/src/services/operationsService.js
@@ -150,6 +150,12 @@ export const purchasingService = {
     return r.data;
   }),
 
+  /** W803 — ADR-039 cross-tier read-only counts (legacy + InventoryStock). */
+  getPlatformStats: safe(async (params = {}) => {
+    const r = await apiClient.get('/api/v1/purchasing/platform-stats', { params });
+    return r.data;
+  }),
+
   getMockVendors: () => MOCK_VENDORS,
   getMockPOs: () => MOCK_PURCHASE_ORDERS,
   getMockStats: () => MOCK_PUR_STATS,


### PR DESCRIPTION
## Summary
- Legacy React purchasing UI banner for cross-tier platform stats (W803-W804).
- Drift guard purchasing-platform-stats-ui-wave803.

## Test plan
- [ ] npx jest __tests__/purchasing-platform-stats-ui-wave803.test.js
- [ ] Merge **after** #248 (maintenance) or rebase on main if #248 lands first — no file overlap expected.

Independent of W801-W810 maintenance arc (PR #248).

Made with [Cursor](https://cursor.com)