### PR TITLE
feat(ci): W813 stub-route audit ratchet (0 hollow routes)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -993,6 +993,8 @@ on:
       - 'backend/__tests__/purchasing-platform-stats-ui-wave803.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/maintenance-cutover-doc-wave811.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/stub-audit-ratchet-wave813.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1969,6 +1971,8 @@ on:
       - 'backend/__tests__/purchasing-platform-stats-ui-wave803.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/maintenance-cutover-doc-wave811.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/stub-audit-ratchet-wave813.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/stub-audit-ratchet-wave813.test.js
+++ b/backend/__tests__/stub-audit-ratchet-wave813.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * W813 — ratchet: hollow stub route count must not regress above Phase-0 floor.
+ *
+ * W768 audit found 39 stubs; W775 de-bloat drove the count to 5 library/fs-backed
+ * surfaces that the heuristic misclassified. W813 extends audit signals and
+ * locks stubCount at 0 — any new hollow route file fails CI.
+ */
+
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const BACKEND = path.join(__dirname, '..');
+
+function runAuditJson() {
+  const out = execFileSync(process.execPath, [path.join(BACKEND, 'scripts', 'audit-stub-routes.js'), '--json'], {
+    cwd: BACKEND,
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return JSON.parse(out);
+}
+
+describe('W813 stub-audit ratchet', () => {
+  it('audit reports zero hollow stubs after W813 signal extensions', () => {
+    const { stubCount, stubs } = runAuditJson();
+    expect(stubCount).toBe(0);
+    expect(stubs).toEqual([]);
+  });
+
+  it('W775 intentional surfaces remain mounted (not deleted as hollow)', () => {
+    const fs = require('fs');
+    const kept = [
+      'routes/rehab-measures.routes.js',
+      'routes/rehab-templates.routes.js',
+      'routes/uploads.routes.js',
+      'routes/build-info.routes.js',
+      'routes/public-uploads.routes.js',
+    ];
+    kept.forEach(rel => {
+      expect(fs.existsSync(path.join(BACKEND, rel))).toBe(true);
+    });
+  });
+});

--- a/backend/scripts/audit-stub-routes.js
+++ b/backend/scripts/audit-stub-routes.js
@@ -68,6 +68,12 @@ const SIGNALS = {
   // requires a controller / model / service / domain / repository / lib
   realRequire:
     /require\(\s*['"][^'"]*\/(controllers|models|services|domains|repositories|intelligence|workflow|students|vehicles)\//,
+  // W813 — in-process rehab catalog/engine (web-admin /rehab/* surfaces)
+  rehabEngine: /require\(\s*['"][^'"]*rehabilitation-services\//,
+  // W813 — disk-backed uploads (Phase 27) are real, not hollow placeholders
+  fsBacked:
+    /\bfs\.(?:readFile(?:Sync)?|writeFile(?:Sync)?|appendFile(?:Sync)?|unlink(?:Sync)?|mkdir(?:Sync)?|createWriteStream|statSync)\s*\(/,
+  multer: /\bmulter\b/,
   mongoose: /\bmongoose\b/,
   dbOps:
     /\.(find|findOne|findById|findByIdAndUpdate|findOneAndUpdate|aggregate|countDocuments|count|create|insertMany|updateOne|updateMany|deleteOne|deleteMany|save|populate)\s*\(/,
@@ -76,6 +82,8 @@ const SIGNALS = {
   appStore: /req\.app\.(_[A-Za-z]|get\s*\()/,
   // factory that receives wired collaborators (createXRouter({ service, ... }))
   factory: /function\s+create[A-Za-z0-9]*Router\s*\(/,
+  // deploy identity endpoint — reads BUILD_SHA / git at load time
+  childProcess: /\bexecSync\s*\(/,
 };
 
 // Stubs that are intentionally hollow placeholders by design (documented).

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -132,6 +132,7 @@ __tests__/purchasing-cutover-doc-wave800.test.js
 __tests__/purchasing-platform-stats-ui-wave803.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
+__tests__/stub-audit-ratchet-wave813.test.js
 __tests__/dashboard-mount-wave776.test.js
 __tests__/duplicate-mount-cleanup-wave777.test.js
 __tests__/registry-mount-resilience-wave778.test.js


### PR DESCRIPTION
## Summary
- Extends \udit-stub-routes.js\ signals (rehab engine, fs/multer uploads, build-info execSync).
- Sprint drift guard locks hollow stub count at **0** (down from 39 at W768 / 5 misclassified at W775).

## Test plan
- [x] \
px jest __tests__/stub-audit-ratchet-wave813.test.js\
- [ ] Sprint Tests CI

Made with [Cursor](https://cursor.com)