### PR TITLE
feat(purchasing): W814 ADR-039 tier consumer guard

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -995,6 +995,8 @@ on:
       - 'backend/__tests__/maintenance-cutover-doc-wave811.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/stub-audit-ratchet-wave813.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-tier-consumer-wave814.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1973,6 +1975,8 @@ on:
       - 'backend/__tests__/maintenance-cutover-doc-wave811.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/stub-audit-ratchet-wave813.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/purchasing-tier-consumer-wave814.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/purchasing-tier-consumer-wave814.test.js
+++ b/backend/__tests__/purchasing-tier-consumer-wave814.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * W814 — ADR-039 consumer-tier drift guard (decision brief § no-regrets #2).
+ *
+ * Tier A (web-admin): /api/v1/inventory/purchase-orders
+ * Tier B (legacy React): /api/v1/purchasing/*
+ * Tier C (picker): /api/v1/inventory-module/purchase-orders
+ *
+ * Prevents accidental cross-tier redirects in registry mounts or UI clients.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const BACKEND = path.join(__dirname, '..');
+const FEATURES = fs.readFileSync(
+  path.join(BACKEND, 'routes', 'registries', 'features.registry.js'),
+  'utf8'
+);
+const LEGACY_OPS = fs.readFileSync(
+  path.join(BACKEND, '..', 'frontend', 'src', 'services', 'operationsService.js'),
+  'utf8'
+);
+
+const DEFAULT_WEB_ADMIN_API = path.resolve(
+  BACKEND,
+  '..',
+  '..',
+  'alawael-rehab-platform',
+  'apps',
+  'web-admin',
+  'src',
+  'lib',
+  'api.ts'
+);
+
+function resolveWebAdminApi() {
+  const fromEnv = process.env.CHECK_WEB_ADMIN_API_PATH;
+  if (fromEnv && fs.existsSync(fromEnv)) return fromEnv;
+  if (fs.existsSync(DEFAULT_WEB_ADMIN_API)) return DEFAULT_WEB_ADMIN_API;
+  return null;
+}
+
+describe('W814 — ADR-039 tier consumer isolation', () => {
+  it('features.registry keeps purchasing mount on purchasing.routes only', () => {
+    expect(FEATURES).toMatch(/dualMountAuth\(app,\s*['"]purchasing['"]/);
+    expect(FEATURES).toMatch(/purchasing\.routes/);
+    expect(FEATURES).not.toMatch(
+      /dualMountAuth\(app,\s*['"]purchasing['"][\s\S]{0,200}inventory-enhanced/
+    );
+    expect(FEATURES).not.toMatch(
+      /dualMountAuth\(app,\s*['"]purchasing['"][\s\S]{0,200}inventory\/purchase-orders/
+    );
+  });
+
+  it('legacy purchasingService uses Tier B paths (not web-admin Tier A)', () => {
+    expect(LEGACY_OPS).toMatch(/\/api\/v1\/purchasing\/orders/);
+    expect(LEGACY_OPS).not.toMatch(/\/api\/v1\/inventory\/purchase-orders/);
+  });
+
+  it('legacy purchasingService exposes platform-stats on Tier B', () => {
+    expect(LEGACY_OPS).toMatch(/\/api\/v1\/purchasing\/platform-stats/);
+  });
+
+  const webAdminApi = resolveWebAdminApi();
+  (webAdminApi ? it : it.skip)(
+    'web-admin api.ts stays on Tier A inventory PO (no Tier B purchasing orders)',
+    () => {
+      const src = fs.readFileSync(webAdminApi, 'utf8');
+      expect(src).toMatch(/\/api\/v1\/inventory\/purchase-orders/);
+      expect(src).not.toMatch(/\/api\/v1\/purchasing\/orders/);
+      expect(src).not.toMatch(/\/api\/v1\/purchasing\/requests/);
+    }
+  );
+});

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -130,6 +130,7 @@ __tests__/purchasing-modules-doc-wave798.test.js
 __tests__/purchasing-platform-stats-wave799.test.js
 __tests__/purchasing-cutover-doc-wave800.test.js
 __tests__/purchasing-platform-stats-ui-wave803.test.js
+__tests__/purchasing-tier-consumer-wave814.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/stub-audit-ratchet-wave813.test.js

--- a/docs/architecture/decisions/039-DECISION-BRIEF.md
+++ b/docs/architecture/decisions/039-DECISION-BRIEF.md
@@ -40,5 +40,5 @@
 
 ## No-regrets pre-work (either sign-off)
 
-1. Link ADR-039 from cutover doc §7 (W797).
-2. Add drift guard so new `dualMount` redirects between tiers fail CI review checklist.
+1. Link ADR-039 from cutover doc §7 (W797). ✅
+2. Add drift guard so new `dualMount` redirects between tiers fail CI review checklist. ✅ W814 `purchasing-tier-consumer-wave814.test.js`


### PR DESCRIPTION
## Summary
- Sprint drift guard locks Tier B legacy \operationsService\ to \/api/v1/purchasing/*\ (not Tier A inventory PO).
- Registry must not mount inventory routes on \purchasing\ key.
- Optional web-admin \pi.ts\ check when sibling repo path exists.
- ADR-039 decision brief pre-work #2 marked complete.

## Test plan
- [x] \
px jest __tests__/purchasing-tier-consumer-wave814.test.js\

Made with [Cursor](https://cursor.com)