### PR TITLE
feat(ops): W819 supply chain staging verify script

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1005,6 +1005,8 @@ on:
       - 'backend/__tests__/supply-chain-ops-closure-wave817.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-adr-signoff-email-wave818.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/supply-chain-staging-verify-wave819.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -1993,6 +1995,8 @@ on:
       - 'backend/__tests__/supply-chain-ops-closure-wave817.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/purchasing-adr-signoff-email-wave818.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/supply-chain-staging-verify-wave819.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/supply-chain-ops-closure-wave817.test.js
+++ b/backend/__tests__/supply-chain-ops-closure-wave817.test.js
@@ -43,6 +43,8 @@ describe('W817 — supply chain ops closure index', () => {
     expect(CLOSURE).toMatch(/SCENARIO_7_SUPPLY_CHAIN_MAINTENANCE_OPS/);
     expect(CLOSURE).toMatch(/purchasing-tier-consumer-wave814/);
     expect(CLOSURE).toMatch(/stub-audit-ratchet-wave813/);
+    expect(CLOSURE).toMatch(/purchasing-adr-signoff-email-wave818/);
+    expect(CLOSURE).toMatch(/verify:supply-chain-staging/);
   });
 
   it('cutover docs link back to closure index', () => {

--- a/backend/__tests__/supply-chain-staging-verify-wave819.test.js
+++ b/backend/__tests__/supply-chain-staging-verify-wave819.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * W819 — supply chain staging verify script + closure index drift guard.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CLOSURE = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'docs', 'architecture', 'SUPPLY_CHAIN_OPS_CLOSURE_2026-06.md'),
+  'utf8'
+);
+const SCRIPT = fs.readFileSync(
+  path.join(__dirname, '..', 'scripts', 'verify-supply-chain-staging.js'),
+  'utf8'
+);
+const PKG = fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8');
+
+describe('W819 — supply chain staging verification', () => {
+  it('verify script hits platform-stats and maintenance-hub snapshot', () => {
+    expect(SCRIPT).toMatch(/\/api\/v1\/purchasing\/platform-stats/);
+    expect(SCRIPT).toMatch(/\/api\/v1\/ops\/maintenance-hub\/snapshot/);
+    expect(SCRIPT).toMatch(/legacyPurchasing/);
+    expect(SCRIPT).toMatch(/facilityAssets/);
+    expect(SCRIPT).toMatch(/SUPPLY_CHAIN_API_URL/);
+  });
+
+  it('package.json exposes verify:supply-chain-staging npm script', () => {
+    expect(PKG).toMatch(/verify:supply-chain-staging/);
+    expect(PKG).toMatch(/verify-supply-chain-staging\.js/);
+  });
+
+  it('closure index documents W818 engineering complete and W819 staging script', () => {
+    expect(CLOSURE).toMatch(/through \*\*W818\*\*/);
+    expect(CLOSURE).toMatch(/verify:supply-chain-staging/);
+    expect(CLOSURE).toMatch(/purchasing-adr-signoff-email-wave818/);
+    expect(CLOSURE).toMatch(/supply-chain-staging-verify-wave819/);
+  });
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -57,6 +57,8 @@
     "audit:unauthenticated-routes": "node scripts/audit-unauthenticated-routes.js",
     "audit:stub-routes": "node scripts/audit-stub-routes.js",
     "audit:stub-routes:json": "node scripts/audit-stub-routes.js --json",
+    "verify:supply-chain-staging": "node scripts/verify-supply-chain-staging.js",
+    "verify:supply-chain-staging:json": "node scripts/verify-supply-chain-staging.js --json",
     "backfill:complaint-branchid": "node scripts/backfill-complaint-branchid.js",
     "backfill:referral-branchid": "node scripts/backfill-referral-branchid.js",
     "backfill:rehabplan-branchid": "node scripts/backfill-rehabplan-branchid.js",

--- a/backend/scripts/verify-supply-chain-staging.js
+++ b/backend/scripts/verify-supply-chain-staging.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * W819 — Staging smoke for supply-chain + facility ops (ADR-039 closure §5).
+ *
+ * Usage:
+ *   SUPPLY_CHAIN_API_URL=https://staging.example.com \
+ *   SUPPLY_CHAIN_TOKEN=<jwt> \
+ *   node backend/scripts/verify-supply-chain-staging.js
+ *
+ *   node backend/scripts/verify-supply-chain-staging.js --json
+ *
+ * Env (aliases accepted):
+ *   SUPPLY_CHAIN_API_URL | API_URL — base URL without trailing slash
+ *   SUPPLY_CHAIN_TOKEN     | TOKEN  — Bearer JWT
+ */
+
+'use strict';
+
+const CHECKS = [
+  {
+    name: 'purchasing-platform-stats',
+    path: '/api/v1/purchasing/platform-stats',
+    validate(body) {
+      if (!body?.success) return 'missing success:true';
+      const tiers = body?.data?.tiers;
+      if (!tiers?.legacyPurchasing || !tiers?.inventoryStock) {
+        return 'data.tiers must include legacyPurchasing and inventoryStock';
+      }
+      if (tiers.legacyPurchasing.tier !== 'B' || tiers.inventoryStock.tier !== 'A') {
+        return 'unexpected tier labels (expected B and A)';
+      }
+      return null;
+    },
+  },
+  {
+    name: 'maintenance-hub-snapshot',
+    path: '/api/v1/ops/maintenance-hub/snapshot',
+    validate(body) {
+      if (!body?.success) return 'missing success:true';
+      if (!body?.data?.facilityAssets) return 'missing data.facilityAssets';
+      if (!body?.data?.workOrders) return 'missing data.workOrders';
+      return null;
+    },
+  },
+];
+
+function baseUrl() {
+  const raw = (process.env.SUPPLY_CHAIN_API_URL || process.env.API_URL || '').trim();
+  if (!raw) return null;
+  return raw.replace(/\/+$/, '');
+}
+
+function token() {
+  return (process.env.SUPPLY_CHAIN_TOKEN || process.env.TOKEN || '').trim() || null;
+}
+
+async function runCheck(base, jwt, check) {
+  const url = `${base}${check.path}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
+  });
+  let body;
+  try {
+    body = await res.json();
+  } catch {
+    body = null;
+  }
+  const shapeErr = res.ok && body ? check.validate(body) : null;
+  return {
+    name: check.name,
+    path: check.path,
+    status: res.status,
+    ok: res.ok && !shapeErr,
+    error: !res.ok ? `HTTP ${res.status}` : shapeErr,
+  };
+}
+
+async function main() {
+  const json = process.argv.includes('--json');
+  const base = baseUrl();
+  const jwt = token();
+
+  if (!base || !jwt) {
+    const msg =
+      'Set SUPPLY_CHAIN_API_URL (or API_URL) and SUPPLY_CHAIN_TOKEN (or TOKEN) before running.';
+    if (json) {
+      console.log(JSON.stringify({ ok: false, error: msg }, null, 2));
+    } else {
+      console.error(msg);
+    }
+    process.exit(2);
+  }
+
+  const results = [];
+  for (const check of CHECKS) {
+    results.push(await runCheck(base, jwt, check));
+  }
+
+  const ok = results.every((r) => r.ok);
+  const payload = { ok, base, results };
+
+  if (json) {
+    console.log(JSON.stringify(payload, null, 2));
+  } else {
+    for (const r of results) {
+      const mark = r.ok ? 'OK' : 'FAIL';
+      console.log(`${mark}  ${r.name}  ${r.path}  (${r.status})${r.error ? ` — ${r.error}` : ''}`);
+    }
+    console.log(ok ? '\nAll supply-chain staging checks passed.' : '\nOne or more checks failed.');
+  }
+
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err?.message || err);
+  process.exit(1);
+});

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -135,6 +135,7 @@ __tests__/purchasing-adr-signoff-packet-wave815.test.js
 __tests__/pilot-supply-chain-scenario-wave816.test.js
 __tests__/supply-chain-ops-closure-wave817.test.js
 __tests__/purchasing-adr-signoff-email-wave818.test.js
+__tests__/supply-chain-staging-verify-wave819.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/stub-audit-ratchet-wave813.test.js

--- a/docs/architecture/SUPPLY_CHAIN_OPS_CLOSURE_2026-06.md
+++ b/docs/architecture/SUPPLY_CHAIN_OPS_CLOSURE_2026-06.md
@@ -1,6 +1,6 @@
 # Supply Chain + Facility Ops — Closure Index (2026-06)
 
-**Status:** Engineering complete on `main` through **W816**. Stakeholder ADR-039 sign-off is the
+**Status:** Engineering complete on `main` through **W818**. Stakeholder ADR-039 sign-off is the
 remaining gate before any PO unification program.
 
 This page is the single navigation index — not a fourth cutover doc.
@@ -40,6 +40,8 @@ This page is the single navigation index — not a fourth cutover doc.
 | W801–W810 | `facility-maintenance-bridge`, `maintenance-hub`, … | Ops mount regressions |
 | W813 | `stub-audit-ratchet-wave813` | New hollow route files |
 | W816 | `pilot-supply-chain-scenario-wave816` | Pilot doc links |
+| W818 | `purchasing-adr-signoff-email-wave818` | Arabic sign-off email drift |
+| W819 | `supply-chain-staging-verify-wave819` | Staging smoke script + closure links |
 
 ---
 
@@ -53,6 +55,17 @@ This page is the single navigation index — not a fourth cutover doc.
 ---
 
 ## 5. Quick verification (staging)
+
+**One command** (after staging deploy; needs procurement or facility JWT):
+
+```bash
+cd backend
+SUPPLY_CHAIN_API_URL=https://<staging-host> \
+SUPPLY_CHAIN_TOKEN=<jwt> \
+npm run verify:supply-chain-staging
+```
+
+Manual curls (same checks):
 
 ```bash
 # Purchasing federation (Tier B + A counts)


### PR DESCRIPTION
## Summary
- Adds \
pm run verify:supply-chain-staging\ — HTTP smoke for \platform-stats\ (ADR-039 tiers A/B) and \maintenance-hub/snapshot\.
- Updates \SUPPLY_CHAIN_OPS_CLOSURE_2026-06.md\ status to W818 + drift guard rows W818/W819.
- Extends W817 closure drift guard for new links.

## Test plan
- [x] \
px jest supply-chain-staging-verify-wave819 supply-chain-ops-closure-wave817\
- [ ] CI green

Made with [Cursor](https://cursor.com)