### PR TITLE
docs(ops): W822 supply chain engineering freeze

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1011,6 +1011,8 @@ on:
       - 'backend/__tests__/purchasing-signoff-staging-wire-wave820.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/pilot-supply-chain-scenario-wave821.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/supply-chain-engineering-freeze-wave822.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2005,6 +2007,8 @@ on:
       - 'backend/__tests__/purchasing-signoff-staging-wire-wave820.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/pilot-supply-chain-scenario-wave821.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/supply-chain-engineering-freeze-wave822.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/pilot-supply-chain-scenario-wave821.test.js
+++ b/backend/__tests__/pilot-supply-chain-scenario-wave821.test.js
@@ -47,8 +47,7 @@ describe('W821 — pilot + sign-off email staging verify', () => {
     expect(EMAIL).toMatch(/W780–W820/);
   });
 
-  it('closure index is through W820', () => {
-    expect(CLOSURE).toMatch(/through \*\*W820\*\*/);
+  it('closure index lists W821 pilot drift guard', () => {
     expect(CLOSURE).toMatch(/pilot-supply-chain-scenario-wave821/);
   });
 });

--- a/backend/__tests__/purchasing-signoff-staging-wire-wave820.test.js
+++ b/backend/__tests__/purchasing-signoff-staging-wire-wave820.test.js
@@ -62,6 +62,6 @@ describe('W820 — sign-off staging wire (W819 script)', () => {
   it('PRODUCTION_GAPS and closure index reference staging verify', () => {
     expect(GAPS).toMatch(/verify:supply-chain-staging/);
     expect(GAPS).toMatch(/039-SIGNOFF-EMAIL-AR/);
-    expect(CLOSURE).toMatch(/through \*\*W820\*\*/);
+    expect(CLOSURE).toMatch(/verify:supply-chain-staging/);
   });
 });

--- a/backend/__tests__/supply-chain-engineering-freeze-wave822.test.js
+++ b/backend/__tests__/supply-chain-engineering-freeze-wave822.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * W822 — supply chain engineering freeze drift guard (post W821 doc sync).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CLOSURE = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    'docs',
+    'architecture',
+    'SUPPLY_CHAIN_OPS_CLOSURE_2026-06.md'
+  ),
+  'utf8'
+);
+const PACKET = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    'docs',
+    'architecture',
+    'decisions',
+    '039-SIGNOFF-PACKET.md'
+  ),
+  'utf8'
+);
+const ADR = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    'docs',
+    'architecture',
+    'decisions',
+    '039-purchase-order-triple-backend.md'
+  ),
+  'utf8'
+);
+const PILOT = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'docs', 'PILOT_CYCLE_1.md'),
+  'utf8'
+);
+
+describe('W822 — supply chain engineering freeze', () => {
+  it('closure index declares freeze through W821 and blocks tier URL-only unification', () => {
+    expect(CLOSURE).toMatch(/through \*\*W821\*\*/);
+    expect(CLOSURE).toMatch(/Engineering freeze \(W822\)/);
+    expect(CLOSURE).toMatch(/migration charter/);
+    expect(CLOSURE).toMatch(/supply-chain-engineering-freeze-wave822/);
+  });
+
+  it('ADR-039 and sign-off packet link closure index with W822 freeze', () => {
+    expect(ADR).toMatch(/SUPPLY_CHAIN_OPS_CLOSURE_2026-06/);
+    expect(ADR).toMatch(/verify:supply-chain-staging/);
+    expect(PACKET).toMatch(/W817–W822/);
+    expect(PACKET).toMatch(/engineering freeze/i);
+  });
+
+  it('PILOT_CYCLE_1 optional scenario references W819 staging verify', () => {
+    expect(PILOT).toMatch(/verify:supply-chain-staging/);
+    expect(PILOT).toMatch(/SUPPLY_CHAIN_OPS_CLOSURE_2026-06/);
+  });
+});

--- a/backend/__tests__/supply-chain-staging-verify-wave819.test.js
+++ b/backend/__tests__/supply-chain-staging-verify-wave819.test.js
@@ -32,7 +32,7 @@ describe('W819 — supply chain staging verification', () => {
   });
 
   it('closure index documents W818 engineering complete and W819 staging script', () => {
-    expect(CLOSURE).toMatch(/through \*\*W820\*\*/);
+    expect(CLOSURE).toMatch(/verify:supply-chain-staging/);
     expect(CLOSURE).toMatch(/verify:supply-chain-staging/);
     expect(CLOSURE).toMatch(/purchasing-adr-signoff-email-wave818/);
     expect(CLOSURE).toMatch(/supply-chain-staging-verify-wave819/);

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -138,6 +138,7 @@ __tests__/purchasing-adr-signoff-email-wave818.test.js
 __tests__/supply-chain-staging-verify-wave819.test.js
 __tests__/purchasing-signoff-staging-wire-wave820.test.js
 __tests__/pilot-supply-chain-scenario-wave821.test.js
+__tests__/supply-chain-engineering-freeze-wave822.test.js
 __tests__/stub-surface-cleanup-wave774.test.js
 __tests__/stub-surface-cleanup-wave775.test.js
 __tests__/stub-audit-ratchet-wave813.test.js

--- a/docs/PILOT_CYCLE_1.md
+++ b/docs/PILOT_CYCLE_1.md
@@ -326,6 +326,7 @@ Does **not** block Section 8 go/no-go. Run in **week 3–4** if procurement + fa
 | Legacy purchasing (Tier B) | PR→PO→partial receive + ADR-039 banner | `PRODUCTION_CUTOVER_W780_W792_PURCHASING.md` |
 | Maintenance hub | snapshot + bulk spawn + branch PPM tile | `PRODUCTION_CUTOVER_W801_W810_MAINTENANCE.md` |
 | Policy | Approach B sign-off | `039-SIGNOFF-PACKET.md` |
+| Staging smoke | `npm run verify:supply-chain-staging` (W819) | `SUPPLY_CHAIN_OPS_CLOSURE_2026-06.md` §5 |
 
 ---
 

--- a/docs/architecture/SUPPLY_CHAIN_OPS_CLOSURE_2026-06.md
+++ b/docs/architecture/SUPPLY_CHAIN_OPS_CLOSURE_2026-06.md
@@ -1,7 +1,11 @@
 # Supply Chain + Facility Ops — Closure Index (2026-06)
 
-**Status:** Engineering complete on `main` through **W820**. Stakeholder ADR-039 sign-off is the
+**Status:** Engineering complete on `main` through **W821**. Stakeholder ADR-039 sign-off is the
 remaining gate before any PO unification program.
+
+**Engineering freeze (W822):** No further supply-chain / facility-ops waves on `66666/backend`
+unless (a) ADR-039 is signed and only doc/status updates are needed, or (b) a stakeholder-approved
+migration charter (Approach A or C) is filed. Tier URL unification without migration is out of scope.
 
 This page is the single navigation index — not a fourth cutover doc.
 
@@ -13,9 +17,9 @@ This page is the single navigation index — not a fourth cutover doc.
 | ----- | ----- | -------- | ----------- |
 | Legacy purchasing | W780–W804 | `66666/frontend` `/purchasing`, `/branch-purchasing` | [PRODUCTION_CUTOVER_W780_W792_PURCHASING.md](PRODUCTION_CUTOVER_W780_W792_PURCHASING.md) |
 | Facility maintenance | W801–W810 | web-admin `/ops/*` + REST | [PRODUCTION_CUTOVER_W801_W810_MAINTENANCE.md](PRODUCTION_CUTOVER_W801_W810_MAINTENANCE.md) |
-| ADR-039 policy | W797–W818 | All tiers | [039-SIGNOFF-PACKET.md](decisions/039-SIGNOFF-PACKET.md) + [039-SIGNOFF-EMAIL-AR.md](decisions/039-SIGNOFF-EMAIL-AR.md) |
+| ADR-039 policy | W797–W821 | All tiers | [039-SIGNOFF-PACKET.md](decisions/039-SIGNOFF-PACKET.md) + [039-SIGNOFF-EMAIL-AR.md](decisions/039-SIGNOFF-EMAIL-AR.md) |
 | Platform hygiene | W812–W813 | Ops / CI | [PRODUCTION_GAPS_BEFORE_LIVE.md](../PRODUCTION_GAPS_BEFORE_LIVE.md) |
-| Pilot optional | W816 | Week 3–4 operators | [SCENARIO_7](../pilot/SCENARIO_7_SUPPLY_CHAIN_MAINTENANCE_OPS.md) |
+| Pilot optional | W816–W821 | Week 3–4 operators | [SCENARIO_7](../pilot/SCENARIO_7_SUPPLY_CHAIN_MAINTENANCE_OPS.md) |
 
 ---
 
@@ -44,6 +48,7 @@ This page is the single navigation index — not a fourth cutover doc.
 | W819 | `supply-chain-staging-verify-wave819` | Staging smoke script + closure links |
 | W820 | `purchasing-signoff-staging-wire-wave820` | Sign-off packet ↔ W819 script in cutover/gaps |
 | W821 | `pilot-supply-chain-scenario-wave821` | Pilot Scenario 7 + Arabic email ↔ W819 verify |
+| W822 | `supply-chain-engineering-freeze-wave822` | Engineering freeze banner + doc sync |
 
 ---
 

--- a/docs/architecture/decisions/039-SIGNOFF-PACKET.md
+++ b/docs/architecture/decisions/039-SIGNOFF-PACKET.md
@@ -8,7 +8,7 @@
 **Full ADR:** [039-purchase-order-triple-backend.md](039-purchase-order-triple-backend.md)  
 **Decision brief:** [039-DECISION-BRIEF.md](039-DECISION-BRIEF.md)  
 **Ops cutover:** [PRODUCTION_CUTOVER_W780_W792_PURCHASING.md](../PRODUCTION_CUTOVER_W780_W792_PURCHASING.md)  
-**Closure index:** [SUPPLY_CHAIN_OPS_CLOSURE_2026-06.md](../SUPPLY_CHAIN_OPS_CLOSURE_2026-06.md) (W817–W819)
+**Closure index:** [SUPPLY_CHAIN_OPS_CLOSURE_2026-06.md](../SUPPLY_CHAIN_OPS_CLOSURE_2026-06.md) (W817–W822 — engineering freeze)
 
 ---
 

--- a/docs/architecture/decisions/039-purchase-order-triple-backend.md
+++ b/docs/architecture/decisions/039-purchase-order-triple-backend.md
@@ -38,6 +38,8 @@ Mongoose model** as legacy purchasing but uses inline routes (item picker in W78
 - Status enum mismatch (`partial` vs `partially_received`).
 
 Ops checklist: [`PRODUCTION_CUTOVER_W780_W792_PURCHASING.md`](../PRODUCTION_CUTOVER_W780_W792_PURCHASING.md).
+Closure index (W817–W822, engineering freeze): [`SUPPLY_CHAIN_OPS_CLOSURE_2026-06.md`](../SUPPLY_CHAIN_OPS_CLOSURE_2026-06.md).
+Staging smoke: `cd backend && npm run verify:supply-chain-staging` (W819).
 
 ## Decision
 


### PR DESCRIPTION
## Summary
- Declares engineering freeze after W821 (no new supply-chain waves without sign-off or migration charter).
- Syncs closure index, ADR-039, sign-off packet, and PILOT_CYCLE_1 §11.

## Test plan
- [x] \
px jest supply-chain-engineering-freeze-wave822\
- [ ] CI green

Made with [Cursor](https://cursor.com)