### PR TITLE
fix(security): W919 asset-management dashboard branch counters

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1163,6 +1163,12 @@ on:
       - 'backend/__tests__/strategic-planning-branch-isolation-wave915.test.js'
       - 'backend/__tests__/medical-equipment-branch-isolation-wave916.test.js'
       - 'backend/__tests__/asset-catalog-branch-isolation-wave917.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/contracts-routes-branch-isolation-wave920.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/facilities-routes-branch-isolation-wave921.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/subsidies-routes-branch-isolation-wave922.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2309,6 +2315,12 @@ on:
       - 'backend/__tests__/strategic-planning-branch-isolation-wave915.test.js'
       - 'backend/__tests__/medical-equipment-branch-isolation-wave916.test.js'
       - 'backend/__tests__/asset-catalog-branch-isolation-wave917.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/contracts-routes-branch-isolation-wave920.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/facilities-routes-branch-isolation-wave921.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/subsidies-routes-branch-isolation-wave922.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/asset-management-work-orders-branch-isolation-wave912.test.js
+++ b/backend/__tests__/asset-management-work-orders-branch-isolation-wave912.test.js
@@ -40,6 +40,7 @@ let mongod;
 let MaintenanceWorkOrder;
 let AssetInventory;
 let AssetTransfer;
+let ResourceBooking;
 let woB;
 let inventoryA;
 let inventoryB;
@@ -53,6 +54,7 @@ beforeAll(async () => {
   MaintenanceWorkOrder = require('../models/MaintenanceWorkOrder');
   AssetInventory = require('../models/AssetInventory');
   AssetTransfer = require('../models/AssetTransfer');
+  ResourceBooking = require('../models/ResourceBooking');
   const appExpress = express();
   appExpress.use(express.json());
   appExpress.use('/api/v1/asset-management', require('../routes/asset-management.routes'));
@@ -127,6 +129,32 @@ beforeAll(async () => {
     createdBy: USER_A,
   });
   transferB = trB.insertedId;
+
+  const today = new Date();
+  await ResourceBooking.collection.insertOne({
+    bookingNumber: 'BK-A-912',
+    branchId: BRANCH_A,
+    assetId: ASSET_A,
+    bookedBy: USER_A,
+    bookingDate: today,
+    startTime: '10:00',
+    endTime: '11:00',
+    purpose: 'جلسة',
+    status: 'confirmed',
+    createdBy: USER_A,
+  });
+  await ResourceBooking.collection.insertOne({
+    bookingNumber: 'BK-B-912',
+    branchId: BRANCH_B,
+    assetId: ASSET_A,
+    bookedBy: USER_A,
+    bookingDate: today,
+    startTime: '12:00',
+    endTime: '13:00',
+    purpose: 'جلسة',
+    status: 'confirmed',
+    createdBy: USER_A,
+  });
 });
 
 beforeEach(() => {
@@ -166,6 +194,14 @@ describe('W912 — work orders isolation', () => {
   it('returns 404 for foreign-branch inventory GET /inventories/:id', async () => {
     const res = await request(app).get(`/api/v1/asset-management/inventories/${inventoryB}`);
     expect(res.status).toBe(404);
+  });
+
+  it('scopes dashboard branch-aware counters to caller branch', async () => {
+    const res = await request(app).get('/api/v1/asset-management/dashboard');
+    expect(res.status).toBe(200);
+    expect(res.body.data.pendingWorkOrders).toBe(1);
+    expect(res.body.data.pendingTransfers).toBe(1);
+    expect(res.body.data.activeBookingsToday).toBe(1);
   });
 
   it('inherits branchId from parent inventory on item create', async () => {

--- a/backend/__tests__/contracts-routes-branch-isolation-wave920.test.js
+++ b/backend/__tests__/contracts-routes-branch-isolation-wave920.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+/**
+ * contracts-routes-branch-isolation-wave920.test.js — W920.
+ *
+ * contracts.routes.js had requireBranchAccess mounted but list/stats and id-keyed
+ * reads/mutations still queried without tenant scope.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(60000);
+
+const mongoose = require('mongoose');
+const express = require('express');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const mockAuthState = { user: null };
+jest.mock('../middleware/auth', () => ({
+  authenticate: (req, _res, next) => {
+    req.user = mockAuthState.user;
+    next();
+  },
+  authorize: roles => (req, res, next) => {
+    const role = req.user && req.user.role;
+    const allowed = Array.isArray(roles) ? roles : [roles];
+    if (allowed.includes(role)) return next();
+    return res.status(403).json({ success: false });
+  },
+}));
+
+const BRANCH_A = new mongoose.Types.ObjectId();
+const BRANCH_B = new mongoose.Types.ObjectId();
+
+const managerA = {
+  id: String(new mongoose.Types.ObjectId()),
+  role: 'manager',
+  branchId: String(BRANCH_A),
+};
+
+let mongod;
+let Contract;
+let app;
+
+function contractDoc(branchId, suffix, status = 'DRAFT') {
+  return {
+    contractNumber: `CT-2026-${suffix}`,
+    contractTitle: `Contract ${suffix}`,
+    contractType: 'SERVICE_AGREEMENT',
+    startDate: new Date('2026-01-01T00:00:00.000Z'),
+    endDate: new Date('2026-12-31T00:00:00.000Z'),
+    status,
+    branchId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w920-contracts-routes' } });
+  await mongoose.connect(mongod.getUri());
+  require('../config/mongoose.plugins');
+  Contract = require('../models/Contract.model');
+  await Contract.init();
+
+  const appExpress = express();
+  appExpress.use(express.json());
+  appExpress.use('/api/v1/contracts', require('../routes/contracts.routes'));
+  app = appExpress;
+});
+
+beforeEach(() => {
+  mockAuthState.user = managerA;
+});
+
+afterEach(async () => {
+  await Contract.deleteMany({});
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+describe('W920 — contracts routes branch isolation', () => {
+  it('lists only in-scope contracts', async () => {
+    await Contract.collection.insertMany([
+      contractDoc(BRANCH_A, 'A9201'),
+      contractDoc(BRANCH_B, 'B9201'),
+    ]);
+
+    const res = await request(app).get('/api/v1/contracts');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(String(res.body.data[0].branchId)).toBe(String(BRANCH_A));
+  });
+
+  it('returns 404 for foreign-branch GET /:id', async () => {
+    const { insertedId } = await Contract.collection.insertOne(contractDoc(BRANCH_B, 'B9202'));
+    const res = await request(app).get(`/api/v1/contracts/${insertedId}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for foreign-branch PUT /:id', async () => {
+    const { insertedId } = await Contract.collection.insertOne(contractDoc(BRANCH_B, 'B9203'));
+    const res = await request(app)
+      .put(`/api/v1/contracts/${insertedId}`)
+      .send({ contractTitle: 'probe' });
+    expect(res.status).toBe(404);
+  });
+
+  it('scopes /stats/summary counts to caller branch', async () => {
+    await Contract.collection.insertMany([
+      contractDoc(BRANCH_A, 'A9204', 'ACTIVE'),
+      contractDoc(BRANCH_B, 'B9204', 'ACTIVE'),
+    ]);
+    const res = await request(app).get('/api/v1/contracts/stats/summary');
+    expect(res.status).toBe(200);
+    expect(res.body.data.total).toBe(1);
+    expect(res.body.data.active).toBe(1);
+  });
+
+  it('stamps caller branch on POST /', async () => {
+    const res = await request(app).post('/api/v1/contracts').send({
+      contractTitle: 'New Contract A',
+      contractType: 'SERVICE_AGREEMENT',
+      startDate: '2026-01-01',
+      endDate: '2026-12-31',
+      value: 1000,
+      liabilityInsurance: 'covered',
+    });
+    expect(res.status).toBe(201);
+    expect(String(res.body.data.branchId)).toBe(String(BRANCH_A));
+  });
+
+  it('rejects foreign branchId spoofing on POST /', async () => {
+    const res = await request(app)
+      .post('/api/v1/contracts')
+      .send({
+        contractTitle: 'Spoof Contract',
+        contractType: 'SERVICE_AGREEMENT',
+        startDate: '2026-01-01',
+        endDate: '2026-12-31',
+        value: 2000,
+        liabilityInsurance: 'covered',
+        branchId: String(BRANCH_B),
+      });
+    expect(res.status).toBe(403);
+  });
+});

--- a/backend/__tests__/facilities-routes-branch-isolation-wave921.test.js
+++ b/backend/__tests__/facilities-routes-branch-isolation-wave921.test.js
@@ -1,0 +1,232 @@
+'use strict';
+
+/**
+ * facilities-routes-branch-isolation-wave921.test.js — W921.
+ *
+ * Facilities routes previously used global findById/find/count paths for
+ * rooms, bookings, maintenance, and dashboard counters.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(60000);
+
+const mongoose = require('mongoose');
+const express = require('express');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const mockAuthState = { user: null };
+jest.mock('../middleware/auth', () => ({
+  authenticate: (req, _res, next) => {
+    req.user = mockAuthState.user;
+    next();
+  },
+  authorize: roles => (req, res, next) => {
+    const role = req.user && req.user.role;
+    const allowed = Array.isArray(roles) ? roles : [roles];
+    if (allowed.includes(role)) return next();
+    return res.status(403).json({ success: false });
+  },
+}));
+
+const BRANCH_A = new mongoose.Types.ObjectId();
+const BRANCH_B = new mongoose.Types.ObjectId();
+
+const managerA = {
+  _id: new mongoose.Types.ObjectId(),
+  id: String(new mongoose.Types.ObjectId()),
+  role: 'manager',
+  branchId: String(BRANCH_A),
+};
+
+let mongod;
+let Room;
+let RoomBooking;
+let MaintenanceRequest;
+let app;
+
+function roomDoc(branchId, suffix, status = 'available') {
+  return {
+    branchId,
+    code: `R-${suffix}`,
+    nameAr: `غرفة ${suffix}`,
+    type: 'therapy',
+    status,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function bookingDoc(roomId, suffix, status = 'confirmed') {
+  return {
+    room: roomId,
+    title: `Booking ${suffix}`,
+    bookingDate: new Date(),
+    startTime: '09:00',
+    endTime: '10:00',
+    status,
+    bookedBy: new mongoose.Types.ObjectId(),
+    createdBy: new mongoose.Types.ObjectId(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function maintenanceDoc(branchId, suffix, status = 'new', roomId = null) {
+  return {
+    requestId: `MR-${suffix}`,
+    title: `Maintenance ${suffix}`,
+    description: 'Issue',
+    status,
+    branchId,
+    room: roomId || undefined,
+    createdBy: new mongoose.Types.ObjectId(),
+    requestedBy: new mongoose.Types.ObjectId(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w921-facilities' } });
+  await mongoose.connect(mongod.getUri());
+  require('../config/mongoose.plugins');
+  if (!mongoose.models.User) {
+    mongoose.model(
+      'User',
+      new mongoose.Schema({
+        name: String,
+        email: String,
+        branchId: { type: mongoose.Schema.Types.ObjectId, ref: 'Branch' },
+      })
+    );
+  }
+
+  Room = require('../models/Room');
+  RoomBooking = require('../models/RoomBooking');
+  MaintenanceRequest = require('../models/MaintenanceRequest');
+  await Promise.all([Room.init(), RoomBooking.init(), MaintenanceRequest.init()]);
+
+  const appExpress = express();
+  appExpress.use(express.json());
+  appExpress.use('/api/v1/facilities', require('../routes/facilities.routes'));
+  app = appExpress;
+});
+
+beforeEach(() => {
+  mockAuthState.user = managerA;
+});
+
+afterEach(async () => {
+  await Promise.all([
+    Room.deleteMany({}),
+    RoomBooking.deleteMany({}),
+    MaintenanceRequest.deleteMany({}),
+  ]);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+describe('W921 — facilities routes branch isolation', () => {
+  it('lists only in-scope rooms', async () => {
+    await Room.collection.insertMany([roomDoc(BRANCH_A, 'A9211'), roomDoc(BRANCH_B, 'B9211')]);
+    const res = await request(app).get('/api/v1/facilities/rooms');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(String(res.body.data[0].branchId)).toBe(String(BRANCH_A));
+  });
+
+  it('returns 404 for foreign-branch room GET /rooms/:id', async () => {
+    const { insertedId } = await Room.collection.insertOne(roomDoc(BRANCH_B, 'B9212'));
+    const res = await request(app).get(`/api/v1/facilities/rooms/${insertedId}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('lists bookings only for rooms in caller branch', async () => {
+    const roomA = await Room.collection.insertOne(roomDoc(BRANCH_A, 'A9213'));
+    const roomB = await Room.collection.insertOne(roomDoc(BRANCH_B, 'B9213'));
+    await RoomBooking.collection.insertMany([
+      bookingDoc(roomA.insertedId, 'A9213'),
+      bookingDoc(roomB.insertedId, 'B9213'),
+    ]);
+
+    const res = await request(app).get('/api/v1/facilities/bookings');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(String(res.body.data[0].room._id)).toBe(String(roomA.insertedId));
+  });
+
+  it('returns 404 for foreign-branch booking PUT /bookings/:id', async () => {
+    const roomB = await Room.collection.insertOne(roomDoc(BRANCH_B, 'B9214'));
+    const bookingB = await RoomBooking.collection.insertOne(bookingDoc(roomB.insertedId, 'B9214'));
+
+    const res = await request(app)
+      .put(`/api/v1/facilities/bookings/${bookingB.insertedId}`)
+      .send({ status: 'cancelled' });
+    expect(res.status).toBe(404);
+  });
+
+  it('scopes maintenance list by branch', async () => {
+    await MaintenanceRequest.collection.insertMany([
+      maintenanceDoc(BRANCH_A, 'A9215'),
+      maintenanceDoc(BRANCH_B, 'B9215'),
+    ]);
+
+    const res = await request(app).get('/api/v1/facilities/maintenance');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(String(res.body.data[0].branchId)).toBe(String(BRANCH_A));
+  });
+
+  it('scopes dashboard counters to caller branch', async () => {
+    const roomA1 = await Room.collection.insertOne(roomDoc(BRANCH_A, 'A9216-1', 'available'));
+    const roomA2 = await Room.collection.insertOne(roomDoc(BRANCH_A, 'A9216-2', 'occupied'));
+    const roomB = await Room.collection.insertOne(roomDoc(BRANCH_B, 'B9216', 'occupied'));
+    await RoomBooking.collection.insertMany([
+      bookingDoc(roomA1.insertedId, 'A9216', 'confirmed'),
+      bookingDoc(roomB.insertedId, 'B9216', 'confirmed'),
+    ]);
+    await MaintenanceRequest.collection.insertMany([
+      maintenanceDoc(BRANCH_A, 'A9216', 'new', roomA2.insertedId),
+      maintenanceDoc(BRANCH_B, 'B9216', 'new', roomB.insertedId),
+    ]);
+
+    const res = await request(app).get('/api/v1/facilities/dashboard');
+    expect(res.status).toBe(200);
+    expect(res.body.data.totalRooms).toBe(2);
+    expect(res.body.data.occupiedRooms).toBe(1);
+    expect(res.body.data.todayBookings).toBe(1);
+    expect(res.body.data.pendingMaintenance).toBe(1);
+  });
+
+  it('rejects foreign room on booking creation', async () => {
+    const roomB = await Room.collection.insertOne(roomDoc(BRANCH_B, 'B9217'));
+
+    const res = await request(app)
+      .post('/api/v1/facilities/bookings')
+      .send({
+        room: String(roomB.insertedId),
+        title: 'Foreign room booking',
+        bookingDate: new Date().toISOString(),
+        startTime: '11:00',
+        endTime: '12:00',
+      });
+    expect(res.status).toBe(404);
+  });
+
+  it('stamps caller branchId on maintenance creation', async () => {
+    const roomA = await Room.collection.insertOne(roomDoc(BRANCH_A, 'A9218'));
+    const res = await request(app)
+      .post('/api/v1/facilities/maintenance')
+      .send({
+        room: String(roomA.insertedId),
+        title: 'Scoped maintenance',
+        description: 'Leak',
+      });
+    expect(res.status).toBe(201);
+    expect(String(res.body.data.branchId)).toBe(String(BRANCH_A));
+  });
+});

--- a/backend/__tests__/subsidies-routes-branch-isolation-wave922.test.js
+++ b/backend/__tests__/subsidies-routes-branch-isolation-wave922.test.js
@@ -1,0 +1,161 @@
+'use strict';
+
+/**
+ * subsidies-routes-branch-isolation-wave922.test.js — W922.
+ *
+ * Hardens subsidy list/summary and id-keyed mutations with beneficiary scope.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(60000);
+
+const mongoose = require('mongoose');
+const express = require('express');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const mockAuthState = { user: null };
+jest.mock('../middleware/auth', () => ({
+  authenticateToken: (req, _res, next) => {
+    req.user = mockAuthState.user;
+    next();
+  },
+  requireRole: roles => (req, res, next) => {
+    const role = req.user && req.user.role;
+    const allowed = Array.isArray(roles) ? roles : [roles];
+    if (allowed.includes(role)) return next();
+    return res.status(403).json({ success: false });
+  },
+}));
+
+const BRANCH_A = new mongoose.Types.ObjectId();
+const BRANCH_B = new mongoose.Types.ObjectId();
+const BENE_A = new mongoose.Types.ObjectId();
+const BENE_B = new mongoose.Types.ObjectId();
+
+const financeA = {
+  _id: new mongoose.Types.ObjectId(),
+  id: String(new mongoose.Types.ObjectId()),
+  role: 'finance',
+  branchId: String(BRANCH_A),
+};
+
+let mongod;
+let Subsidy;
+let Beneficiary;
+let app;
+
+function subsidyDoc(beneficiaryId, branchId, month, amountSAR, status = 'expected') {
+  return {
+    beneficiaryId,
+    branchId,
+    year: 2026,
+    month,
+    subsidyType: 'social_security',
+    amountSAR,
+    status,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w922-subsidies' } });
+  await mongoose.connect(mongod.getUri());
+  require('../config/mongoose.plugins');
+
+  Subsidy = require('../models/BeneficiarySubsidyEntry');
+  Beneficiary = require('../models/Beneficiary');
+  await Subsidy.init();
+
+  const appExpress = express();
+  appExpress.use(express.json());
+  appExpress.use('/api/v1/subsidies', require('../routes/subsidies.routes'));
+  app = appExpress;
+
+  await Beneficiary.collection.insertMany([
+    { _id: BENE_A, branchId: BRANCH_A, status: 'active' },
+    { _id: BENE_B, branchId: BRANCH_B, status: 'active' },
+  ]);
+});
+
+beforeEach(() => {
+  mockAuthState.user = financeA;
+});
+
+afterEach(async () => {
+  await Subsidy.deleteMany({});
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+describe('W922 — subsidies routes branch isolation', () => {
+  it('lists only subsidies of in-scope beneficiaries', async () => {
+    await Subsidy.collection.insertMany([
+      subsidyDoc(BENE_A, BRANCH_A, 1, 500),
+      subsidyDoc(BENE_B, BRANCH_B, 2, 900),
+    ]);
+    const res = await request(app).get('/api/v1/subsidies');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(String(res.body.items[0].beneficiaryId)).toBe(String(BENE_A));
+  });
+
+  it('returns 404 for foreign beneficiary on /by-beneficiary/:id', async () => {
+    const res = await request(app).get(`/api/v1/subsidies/by-beneficiary/${BENE_B}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('scopes summary to in-scope beneficiaries only', async () => {
+    await Subsidy.collection.insertMany([
+      subsidyDoc(BENE_A, BRANCH_A, 3, 700, 'received'),
+      subsidyDoc(BENE_B, BRANCH_B, 4, 1300, 'received'),
+    ]);
+
+    const res = await request(app).get('/api/v1/subsidies/summary?year=2026');
+    expect(res.status).toBe(200);
+    expect(res.body.grandTotalReceived).toBe(700);
+  });
+
+  it('returns 404 for foreign subsidy PATCH /:id', async () => {
+    const { insertedId } = await Subsidy.collection.insertOne(
+      subsidyDoc(BENE_B, BRANCH_B, 5, 1000)
+    );
+    const res = await request(app)
+      .patch(`/api/v1/subsidies/${insertedId}`)
+      .send({ notes: 'probe' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for foreign subsidy POST /:id/mark-received', async () => {
+    const { insertedId } = await Subsidy.collection.insertOne(
+      subsidyDoc(BENE_B, BRANCH_B, 6, 1200)
+    );
+    const res = await request(app).post(`/api/v1/subsidies/${insertedId}/mark-received`);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for foreign subsidy DELETE /:id', async () => {
+    const { insertedId } = await Subsidy.collection.insertOne(subsidyDoc(BENE_B, BRANCH_B, 7, 600));
+    const res = await request(app).delete(`/api/v1/subsidies/${insertedId}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('stamps branchId from scoped beneficiary on POST /', async () => {
+    const res = await request(app)
+      .post('/api/v1/subsidies')
+      .send({
+        beneficiaryId: String(BENE_A),
+        year: 2026,
+        month: 8,
+        subsidyType: 'social_security',
+        amountSAR: 1111,
+        status: 'expected',
+      });
+    expect(res.status).toBe(201);
+    expect(String(res.body.data.branchId)).toBe(String(BRANCH_A));
+  });
+});

--- a/backend/routes/asset-management.routes.js
+++ b/backend/routes/asset-management.routes.js
@@ -794,6 +794,7 @@ router.get('/dashboard', async (req, res) => {
     const now = new Date();
     const _soon30 = new Date(now.getTime() + 30 * 864e5);
     const soon60 = new Date(now.getTime() + 60 * 864e5);
+    const tenant = branchFilter(req);
     const [
       totalAssets,
       activeAssets,
@@ -808,15 +809,17 @@ router.get('/dashboard', async (req, res) => {
       Asset.countDocuments(),
       Asset.countDocuments({ status: 'active' }),
       Asset.countDocuments({ status: 'maintenance' }),
-      MaintenanceWorkOrder.countDocuments({ status: 'pending' }),
+      MaintenanceWorkOrder.countDocuments({ ...tenant, status: 'pending' }),
       MaintenanceWorkOrder.countDocuments({
+        ...tenant,
         scheduledDate: { $lt: now },
         status: { $in: ['pending', 'approved'] },
       }),
-      AssetTransfer.countDocuments({ status: 'pending' }),
+      AssetTransfer.countDocuments({ ...tenant, status: 'pending' }),
       Asset.countDocuments({ lastMaintenanceDate: { $lte: now }, status: 'active' }),
       Asset.countDocuments({ warrantyExpiryDate: { $gte: now, $lte: soon60 } }),
       ResourceBooking.countDocuments({
+        ...tenant,
         bookingDate: {
           $gte: new Date(now.toDateString()),
           $lt: new Date(new Date(now.toDateString()).getTime() + 864e5),

--- a/backend/routes/contracts.routes.js
+++ b/backend/routes/contracts.routes.js
@@ -9,7 +9,7 @@ const crypto = require('crypto');
 const { body } = require('express-validator');
 const { validate } = require('../middleware/validate');
 const { authenticate, authorize } = require('../middleware/auth');
-const { requireBranchAccess } = require('../middleware/branchScope.middleware');
+const { requireBranchAccess, branchFilter } = require('../middleware/branchScope.middleware');
 const _logger = require('../utils/logger');
 const Contract = require('../models/Contract.model');
 const safeError = require('../utils/safeError');
@@ -17,6 +17,10 @@ const safeError = require('../utils/safeError');
 /** Max page size to prevent memory exhaustion */
 const MAX_PAGE_LIMIT = 100;
 const clampLimit = v => Math.max(1, Math.min(parseInt(v, 10) || 20, MAX_PAGE_LIMIT));
+const randomContractSuffix = () =>
+  typeof crypto.randomInt === 'function'
+    ? crypto.randomInt(1000, 9999)
+    : 1000 + Math.floor(Math.random() * 9000);
 
 /** Guard: reject invalid ObjectIds early (400 instead of CastError 500) */
 const validObjectId = (req, res) => {
@@ -27,6 +31,25 @@ const validObjectId = (req, res) => {
   return true;
 };
 
+const scopedById = (req, id) => ({ _id: id, ...branchFilter(req) });
+const aggregateScope = scope => {
+  if (!scope?.branchId) return scope || {};
+  if (scope.branchId.$in && Array.isArray(scope.branchId.$in)) {
+    return {
+      ...scope,
+      branchId: {
+        $in: scope.branchId.$in
+          .filter(id => mongoose.isValidObjectId(id))
+          .map(id => new mongoose.Types.ObjectId(id)),
+      },
+    };
+  }
+  if (mongoose.isValidObjectId(scope.branchId)) {
+    return { ...scope, branchId: new mongoose.Types.ObjectId(scope.branchId) };
+  }
+  return scope;
+};
+
 router.use(authenticate);
 router.use(requireBranchAccess);
 // ─── List contracts ──────────────────────────────────────────────────────────
@@ -34,7 +57,7 @@ router.get('/', async (req, res) => {
   try {
     const { status, type, page = 1, limit: rawLimit = 20 } = req.query;
     const limit = clampLimit(rawLimit);
-    const filter = {};
+    const filter = { ...branchFilter(req) };
     if (status) filter.status = status.toUpperCase();
     if (type) filter.contractType = type.toUpperCase();
     const skip = (Math.max(1, +page) - 1) * limit;
@@ -56,9 +79,14 @@ router.get('/', async (req, res) => {
 // ─── Contract statistics (must be before /:id) ───────────────────────────────
 router.get('/stats/summary', async (req, res) => {
   try {
+    const scope = branchFilter(req);
+    const scopedForAggregate = aggregateScope(scope);
     const [total, byStatus] = await Promise.all([
-      Contract.countDocuments(),
-      Contract.aggregate([{ $group: { _id: '$status', count: { $sum: 1 } } }]),
+      Contract.countDocuments(scope),
+      Contract.aggregate([
+        { $match: scopedForAggregate },
+        { $group: { _id: '$status', count: { $sum: 1 } } },
+      ]),
     ]);
     const stats = { total, active: 0, expired: 0, draft: 0, suspended: 0, terminated: 0 };
     byStatus.forEach(s => {
@@ -68,6 +96,7 @@ router.get('/stats/summary', async (req, res) => {
     const now = new Date();
     const soon = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
     stats.expiringSoon = await Contract.countDocuments({
+      ...scope,
       status: 'ACTIVE',
       endDate: { $gte: now, $lte: soon },
     });
@@ -81,7 +110,7 @@ router.get('/stats/summary', async (req, res) => {
 router.get('/:id', async (req, res) => {
   if (!validObjectId(req, res)) return;
   try {
-    const contract = await Contract.findById(req.params.id).lean();
+    const contract = await Contract.findOne(scopedById(req, req.params.id)).lean();
     if (!contract) return res.status(404).json({ success: false, message: 'العقد غير موجود' });
     res.json({ success: true, data: contract, message: 'بيانات العقد' });
   } catch (error) {
@@ -102,14 +131,23 @@ router.post(
   ]),
   async (req, res) => {
     try {
-      const { contractTitle, contractType, supplier, startDate, endDate, value } = req.body;
+      const {
+        contractTitle,
+        contractType,
+        supplier,
+        startDate,
+        endDate,
+        value,
+        branchId,
+        liabilityInsurance,
+      } = req.body;
       if (!contractTitle || !contractType) {
         return res.status(400).json({ success: false, message: 'العنوان والنوع مطلوبان' });
       }
       // Atomic counter — avoids race condition where two concurrent requests
       // both read the same countDocuments() value and produce duplicate numbers.
       const year = new Date().getFullYear();
-      const seq = crypto.randomInt(1000, 9999);
+      const seq = randomContractSuffix();
       const ts = Date.now().toString(36).slice(-4).toUpperCase();
       const contractNumber = `CT-${year}-${ts}${seq}`;
       const contract = await Contract.create({
@@ -120,7 +158,9 @@ router.post(
         startDate,
         endDate,
         value,
+        liabilityInsurance,
         status: 'DRAFT',
+        branchId: req.branchScope?.branchId || branchId || null,
         createdBy: req.user?.id,
       });
       res.status(201).json({ success: true, data: contract, message: 'تم إنشاء العقد بنجاح' });
@@ -144,10 +184,22 @@ router.put('/:id', authorize(['admin', 'manager']), async (req, res) => {
       status,
       terms,
       notes,
+      liabilityInsurance,
     } = req.body;
-    const contract = await Contract.findByIdAndUpdate(
-      req.params.id,
-      { contractTitle, contractType, supplier, startDate, endDate, value, status, terms, notes },
+    const contract = await Contract.findOneAndUpdate(
+      scopedById(req, req.params.id),
+      {
+        contractTitle,
+        contractType,
+        supplier,
+        startDate,
+        endDate,
+        value,
+        status,
+        terms,
+        notes,
+        liabilityInsurance,
+      },
       { returnDocument: 'after', runValidators: true }
     ).lean();
     if (!contract) return res.status(404).json({ success: false, message: 'العقد غير موجود' });
@@ -161,7 +213,7 @@ router.put('/:id', authorize(['admin', 'manager']), async (req, res) => {
 router.delete('/:id', authorize(['admin']), async (req, res) => {
   if (!validObjectId(req, res)) return;
   try {
-    const contract = await Contract.findByIdAndDelete(req.params.id);
+    const contract = await Contract.findOneAndDelete(scopedById(req, req.params.id));
     if (!contract) return res.status(404).json({ success: false, message: 'العقد غير موجود' });
     res.json({ success: true, message: 'تم حذف العقد بنجاح' });
   } catch (error) {
@@ -173,7 +225,7 @@ router.delete('/:id', authorize(['admin']), async (req, res) => {
 router.post('/:id/renew', authorize(['admin', 'manager']), async (req, res) => {
   if (!validObjectId(req, res)) return;
   try {
-    const contract = await Contract.findById(req.params.id);
+    const contract = await Contract.findOne(scopedById(req, req.params.id));
     if (!contract) return res.status(404).json({ success: false, message: 'العقد غير موجود' });
     contract.status = 'ACTIVE';
     if (contract.endDate) {

--- a/backend/routes/facilities.routes.js
+++ b/backend/routes/facilities.routes.js
@@ -4,10 +4,11 @@
  */
 const express = require('express');
 const router = express.Router();
+const mongoose = require('mongoose');
 const { body, param } = require('express-validator');
 const { validate } = require('../middleware/validate');
 const { authenticate, authorize } = require('../middleware/auth');
-const { requireBranchAccess } = require('../middleware/branchScope.middleware');
+const { requireBranchAccess, branchFilter } = require('../middleware/branchScope.middleware');
 const _logger = require('../utils/logger');
 const Room = require('../models/Room');
 const RoomBooking = require('../models/RoomBooking');
@@ -17,6 +18,62 @@ const safeError = require('../utils/safeError');
 
 router.use(authenticate);
 router.use(requireBranchAccess);
+
+const scopedById = (req, id) => ({ _id: id, ...branchFilter(req) });
+
+const aggregateScope = scope => {
+  if (!scope?.branchId) return scope || {};
+  if (scope.branchId?.$in && Array.isArray(scope.branchId.$in)) {
+    return {
+      ...scope,
+      branchId: {
+        $in: scope.branchId.$in
+          .filter(id => mongoose.isValidObjectId(id))
+          .map(id => new mongoose.Types.ObjectId(id)),
+      },
+    };
+  }
+  if (mongoose.isValidObjectId(scope.branchId)) {
+    return { ...scope, branchId: new mongoose.Types.ObjectId(scope.branchId) };
+  }
+  return scope;
+};
+
+async function getScopedRoomIds(req) {
+  if (req.branchScope?.allBranches) return null;
+  if (Array.isArray(req._facilitiesScopedRoomIds)) return req._facilitiesScopedRoomIds;
+  const rooms = await Room.find(branchFilter(req)).select('_id').lean();
+  req._facilitiesScopedRoomIds = rooms.map(r => r._id);
+  return req._facilitiesScopedRoomIds;
+}
+
+async function mergeBookingFilter(req, filter = {}) {
+  const roomIds = await getScopedRoomIds(req);
+  if (roomIds === null) return filter;
+  if (filter.room) {
+    const inScope = roomIds.some(id => String(id) === String(filter.room));
+    if (!inScope) return { ...filter, room: { $in: [] } };
+    return filter;
+  }
+  return { ...filter, room: { $in: roomIds } };
+}
+
+async function ensureRoomInScope(req, roomId) {
+  if (!mongoose.isValidObjectId(roomId)) return null;
+  return Room.findOne({ _id: roomId, ...branchFilter(req) })
+    .select('_id')
+    .lean();
+}
+
+async function mergeMaintenanceFilter(req, filter = {}) {
+  const scope = branchFilter(req);
+  if (!scope.branchId) return filter;
+  const roomIds = await getScopedRoomIds(req);
+  return {
+    ...filter,
+    $or: [{ ...scope }, { branchId: { $exists: false }, room: { $in: roomIds } }],
+  };
+}
 // ═══════════════════════════════════════════════════════════════
 //  ROOMS (الغرف والمرافق)
 // ═══════════════════════════════════════════════════════════════
@@ -25,7 +82,7 @@ router.use(requireBranchAccess);
 router.get('/rooms', async (req, res) => {
   try {
     const { type, status, building, page = 1, limit = 50 } = req.query;
-    const filter = {};
+    const filter = { ...branchFilter(req) };
     if (type) filter.type = type;
     if (status) filter.status = status;
     if (building) filter.building = building;
@@ -49,7 +106,7 @@ router.get('/rooms', async (req, res) => {
 // GET /rooms/:id
 router.get('/rooms/:id', async (req, res) => {
   try {
-    const room = await Room.findById(req.params.id).lean();
+    const room = await Room.findOne(scopedById(req, req.params.id)).lean();
     if (!room) return res.status(404).json({ success: false, message: 'الغرفة غير موجودة' });
     res.json({ success: true, data: room });
   } catch (err) {
@@ -64,7 +121,13 @@ router.post(
   validate([body('name').trim().notEmpty().withMessage('اسم الغرفة مطلوب')]),
   async (req, res) => {
     try {
-      const room = new Room({ ...req.body, createdBy: req.user._id || req.userId });
+      const payload = stripUpdateMeta(req.body);
+      if (req.branchScope?.branchId) {
+        payload.branchId = req.branchScope.branchId;
+      } else if (!payload.branchId) {
+        return res.status(400).json({ success: false, message: 'معرف الفرع مطلوب' });
+      }
+      const room = new Room({ ...payload, createdBy: req.user._id || req.userId });
       await room.save();
       res.status(201).json({ success: true, data: room, message: 'تم إنشاء الغرفة بنجاح' });
     } catch (err) {
@@ -87,7 +150,9 @@ router.put(
   ]),
   async (req, res) => {
     try {
-      const room = await Room.findByIdAndUpdate(req.params.id, stripUpdateMeta(req.body), {
+      const updates = stripUpdateMeta(req.body);
+      delete updates.branchId;
+      const room = await Room.findOneAndUpdate(scopedById(req, req.params.id), updates, {
         returnDocument: 'after',
         runValidators: true,
       });
@@ -102,7 +167,7 @@ router.put(
 // DELETE /rooms/:id
 router.delete('/rooms/:id', authorize(['admin', 'super_admin']), async (req, res) => {
   try {
-    const room = await Room.findByIdAndDelete(req.params.id);
+    const room = await Room.findOneAndDelete(scopedById(req, req.params.id));
     if (!room) return res.status(404).json({ success: false, message: 'الغرفة غير موجودة' });
     res.json({ success: true, message: 'تم حذف الغرفة بنجاح' });
   } catch (err) {
@@ -129,16 +194,17 @@ router.get('/bookings', async (req, res) => {
       };
     }
 
+    const scopedFilter = await mergeBookingFilter(req, filter);
     const skip = (parseInt(page) - 1) * parseInt(limit);
     const [data, total] = await Promise.all([
-      RoomBooking.find(filter)
+      RoomBooking.find(scopedFilter)
         .sort({ bookingDate: -1 })
         .skip(skip)
         .limit(parseInt(limit))
         .populate('room', 'name type')
         .populate('bookedBy', 'name email')
         .lean(),
-      RoomBooking.countDocuments(filter),
+      RoomBooking.countDocuments(scopedFilter),
     ]);
 
     res.json({
@@ -163,6 +229,11 @@ router.post(
   ]),
   async (req, res) => {
     try {
+      const scopedRoom = await ensureRoomInScope(req, req.body.room);
+      if (!scopedRoom) {
+        return res.status(404).json({ success: false, message: 'الغرفة غير موجودة' });
+      }
+
       // Check for conflicts
       const conflict = await RoomBooking.findOne({
         room: req.body.room,
@@ -175,7 +246,7 @@ router.post(
       }
 
       const booking = new RoomBooking({
-        ...req.body,
+        ...stripUpdateMeta(req.body),
         bookedBy: req.user._id || req.userId,
         createdBy: req.user._id || req.userId,
       });
@@ -201,11 +272,18 @@ router.put(
   ]),
   async (req, res) => {
     try {
-      const updates = req.body;
+      const updates = stripUpdateMeta(req.body);
+      if (updates.room) {
+        const scopedRoom = await ensureRoomInScope(req, updates.room);
+        if (!scopedRoom) {
+          return res.status(404).json({ success: false, message: 'الغرفة غير موجودة' });
+        }
+      }
       // If time changed, re-check conflicts
+      const scopedCurrentFilter = await mergeBookingFilter(req, { _id: req.params.id });
+      const existing = await RoomBooking.findOne(scopedCurrentFilter);
+      if (!existing) return res.status(404).json({ success: false, message: 'الحجز غير موجود' });
       if (updates.startTime || updates.endTime || updates.bookingDate) {
-        const existing = await RoomBooking.findById(req.params.id);
-        if (!existing) return res.status(404).json({ success: false, message: 'الحجز غير موجود' });
         const conflict = await RoomBooking.findOne({
           _id: { $ne: req.params.id },
           room: updates.room || existing.room,
@@ -222,7 +300,8 @@ router.put(
           return res.status(409).json({ success: false, message: 'يوجد تعارض في الحجز' });
         }
       }
-      const booking = await RoomBooking.findByIdAndUpdate(req.params.id, updates, {
+      const scopedUpdateFilter = await mergeBookingFilter(req, { _id: req.params.id });
+      const booking = await RoomBooking.findOneAndUpdate(scopedUpdateFilter, updates, {
         returnDocument: 'after',
         runValidators: true,
       });
@@ -237,8 +316,9 @@ router.put(
 // DELETE /bookings/:id — Cancel booking
 router.delete('/bookings/:id', authorize(['admin', 'super_admin', 'manager']), async (req, res) => {
   try {
-    const booking = await RoomBooking.findByIdAndUpdate(
-      req.params.id,
+    const scopedFilter = await mergeBookingFilter(req, { _id: req.params.id });
+    const booking = await RoomBooking.findOneAndUpdate(
+      scopedFilter,
       { status: 'cancelled' },
       { returnDocument: 'after' }
     );
@@ -263,15 +343,16 @@ router.get('/maintenance', async (req, res) => {
     if (priority) filter.priority = priority;
     if (type) filter.type = type;
 
+    const scopedFilter = await mergeMaintenanceFilter(req, filter);
     const skip = (parseInt(page) - 1) * parseInt(limit);
     const [data, total] = await Promise.all([
-      MaintenanceRequest.find(filter)
+      MaintenanceRequest.find(scopedFilter)
         .sort({ createdAt: -1 })
         .skip(skip)
         .limit(parseInt(limit))
         .populate('room', 'name building')
         .lean(),
-      MaintenanceRequest.countDocuments(filter),
+      MaintenanceRequest.countDocuments(scopedFilter),
     ]);
 
     res.json({
@@ -293,8 +374,16 @@ router.post(
   ]),
   async (req, res) => {
     try {
+      if (req.body.room) {
+        const scopedRoom = await ensureRoomInScope(req, req.body.room);
+        if (!scopedRoom) {
+          return res.status(404).json({ success: false, message: 'الغرفة غير موجودة' });
+        }
+      }
+      const payload = stripUpdateMeta(req.body);
+      if (req.branchScope?.branchId) payload.branchId = req.branchScope.branchId;
       const mr = new MaintenanceRequest({
-        ...req.body,
+        ...payload,
         requestedBy: req.user._id || req.userId,
         createdBy: req.user._id || req.userId,
       });
@@ -319,11 +408,19 @@ router.put(
   ]),
   async (req, res) => {
     try {
-      const updates = { ...req.body };
+      const updates = stripUpdateMeta(req.body);
+      delete updates.branchId;
+      if (updates.room) {
+        const scopedRoom = await ensureRoomInScope(req, updates.room);
+        if (!scopedRoom) {
+          return res.status(404).json({ success: false, message: 'الغرفة غير موجودة' });
+        }
+      }
       if (updates.status === 'completed' && !updates.completedDate) {
         updates.completedDate = new Date();
       }
-      const mr = await MaintenanceRequest.findByIdAndUpdate(req.params.id, updates, {
+      const scopedFilter = await mergeMaintenanceFilter(req, { _id: req.params.id });
+      const mr = await MaintenanceRequest.findOneAndUpdate(scopedFilter, updates, {
         returnDocument: 'after',
         runValidators: true,
       });
@@ -341,7 +438,8 @@ router.delete(
   authorize(['admin', 'super_admin', 'manager']),
   async (req, res) => {
     try {
-      const mr = await MaintenanceRequest.findByIdAndDelete(req.params.id);
+      const scopedFilter = await mergeMaintenanceFilter(req, { _id: req.params.id });
+      const mr = await MaintenanceRequest.findOneAndDelete(scopedFilter);
       if (!mr) return res.status(404).json({ success: false, message: 'الطلب غير موجود' });
       res.json({ success: true, data: mr, message: 'تم حذف طلب الصيانة بنجاح' });
     } catch (err) {
@@ -356,6 +454,19 @@ router.delete(
 
 router.get('/dashboard', async (req, res) => {
   try {
+    const roomScope = branchFilter(req);
+    const roomsAggregateScope = aggregateScope(roomScope);
+    const bookingsScope = await mergeBookingFilter(req, {
+      bookingDate: {
+        $gte: new Date(new Date().setHours(0, 0, 0, 0)),
+        $lte: new Date(new Date().setHours(23, 59, 59, 999)),
+      },
+      status: { $in: ['confirmed', 'pending'] },
+    });
+    const maintenanceScope = await mergeMaintenanceFilter(req, {
+      status: { $in: ['new', 'assigned', 'in_progress'] },
+    });
+
     const [
       totalRooms,
       availableRooms,
@@ -365,19 +476,16 @@ router.get('/dashboard', async (req, res) => {
       pendingMaintenance,
       roomsByType,
     ] = await Promise.all([
-      Room.countDocuments(),
-      Room.countDocuments({ status: 'available' }),
-      Room.countDocuments({ status: 'occupied' }),
-      Room.countDocuments({ status: 'under_maintenance' }),
-      RoomBooking.countDocuments({
-        bookingDate: {
-          $gte: new Date(new Date().setHours(0, 0, 0, 0)),
-          $lte: new Date(new Date().setHours(23, 59, 59, 999)),
-        },
-        status: { $in: ['confirmed', 'pending'] },
-      }),
-      MaintenanceRequest.countDocuments({ status: { $in: ['new', 'assigned', 'in_progress'] } }),
-      Room.aggregate([{ $group: { _id: '$type', count: { $sum: 1 } } }]),
+      Room.countDocuments(roomScope),
+      Room.countDocuments({ ...roomScope, status: 'available' }),
+      Room.countDocuments({ ...roomScope, status: 'occupied' }),
+      Room.countDocuments({ ...roomScope, status: 'under_maintenance' }),
+      RoomBooking.countDocuments(bookingsScope),
+      MaintenanceRequest.countDocuments(maintenanceScope),
+      Room.aggregate([
+        { $match: roomsAggregateScope },
+        { $group: { _id: '$type', count: { $sum: 1 } } },
+      ]),
     ]);
 
     res.json({

--- a/backend/routes/subsidies.routes.js
+++ b/backend/routes/subsidies.routes.js
@@ -17,13 +17,16 @@ const express = require('express');
 const router = express.Router();
 const mongoose = require('mongoose');
 const { authenticateToken, requireRole } = require('../middleware/auth');
+const { requireBranchAccess, branchFilter } = require('../middleware/branchScope.middleware');
 
 const Subsidy = require('../models/BeneficiarySubsidyEntry');
 const Beneficiary = require('../models/Beneficiary');
 const safeError = require('../utils/safeError');
 const { bodyScopedBeneficiaryGuard } = require('../middleware/assertBranchMatch');
+const { assertBeneficiaryInScope } = require('../utils/beneficiaryBranchGate');
 
 router.use(authenticateToken);
+router.use(requireBranchAccess);
 router.use(bodyScopedBeneficiaryGuard); // W441: enforce branch on req.body.beneficiaryId
 
 const READ_ROLES = [
@@ -39,6 +42,25 @@ const READ_ROLES = [
 const WRITE_ROLES = ['admin', 'superadmin', 'super_admin', 'manager', 'social_worker', 'finance'];
 
 const { TYPES, STATUSES } = Subsidy;
+
+async function getScopedBeneficiaryIds(req) {
+  if (req.branchScope?.allBranches) return null;
+  if (Array.isArray(req._subsidyScopedBeneficiaryIds)) return req._subsidyScopedBeneficiaryIds;
+  const kids = await Beneficiary.find(branchFilter(req)).select('_id').lean();
+  req._subsidyScopedBeneficiaryIds = kids.map(k => k._id);
+  return req._subsidyScopedBeneficiaryIds;
+}
+
+async function mergeScopedBeneficiaryFilter(req, filter = {}) {
+  const scopedIds = await getScopedBeneficiaryIds(req);
+  if (scopedIds === null) return filter;
+  if (filter.beneficiaryId) {
+    const inScope = scopedIds.some(id => String(id) === String(filter.beneficiaryId));
+    if (!inScope) return { ...filter, beneficiaryId: { $in: [] } };
+    return filter;
+  }
+  return { ...filter, beneficiaryId: { $in: scopedIds } };
+}
 
 async function hydrate(items) {
   const ids = [...new Set(items.map(r => String(r.beneficiaryId)).filter(Boolean))].filter(id =>
@@ -68,15 +90,16 @@ router.get('/', requireRole(READ_ROLES), async (req, res) => {
     if (req.query.status && STATUSES.includes(String(req.query.status))) {
       filter.status = String(req.query.status);
     }
+    const scopedFilter = await mergeScopedBeneficiaryFilter(req, filter);
     const p = Math.max(1, parseInt(req.query.page, 10) || 1);
     const l = Math.min(200, Math.max(1, parseInt(req.query.limit, 10) || 50));
     const [raw, total] = await Promise.all([
-      Subsidy.find(filter)
+      Subsidy.find(scopedFilter)
         .sort({ year: -1, month: -1, subsidyType: 1 })
         .skip((p - 1) * l)
         .limit(l)
         .lean(),
-      Subsidy.countDocuments(filter),
+      Subsidy.countDocuments(scopedFilter),
     ]);
     const items = await hydrate(raw);
     res.json({
@@ -95,6 +118,8 @@ router.get('/by-beneficiary/:id', requireRole(READ_ROLES), async (req, res) => {
     if (!mongoose.isValidObjectId(req.params.id)) {
       return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
     }
+    const denied = await assertBeneficiaryInScope(req, req.params.id, res);
+    if (denied) return denied;
     const items = await Subsidy.find({ beneficiaryId: req.params.id })
       .sort({ year: -1, month: -1 })
       .lean();
@@ -112,6 +137,10 @@ router.get('/summary', requireRole(READ_ROLES), async (req, res) => {
     if (req.query.month) match.month = parseInt(req.query.month, 10);
     if (req.query.branchId && mongoose.isValidObjectId(req.query.branchId)) {
       match.branchId = new mongoose.Types.ObjectId(req.query.branchId);
+    }
+    const scopedBeneficiaryIds = await getScopedBeneficiaryIds(req);
+    if (scopedBeneficiaryIds !== null) {
+      match.beneficiaryId = { $in: scopedBeneficiaryIds };
     }
     const rows = await Subsidy.aggregate([
       { $match: match },
@@ -166,6 +195,9 @@ router.post('/', requireRole(WRITE_ROLES), async (req, res) => {
     if (!body.beneficiaryId || !mongoose.isValidObjectId(body.beneficiaryId)) {
       return res.status(400).json({ success: false, message: 'beneficiaryId مطلوب' });
     }
+    const denied = await assertBeneficiaryInScope(req, body.beneficiaryId, res);
+    if (denied) return denied;
+    const beneficiary = await Beneficiary.findById(body.beneficiaryId).select('branchId').lean();
     const year = parseInt(body.year, 10);
     const month = parseInt(body.month, 10);
     if (!year || year < 2020 || year > 2050) {
@@ -185,7 +217,7 @@ router.post('/', requireRole(WRITE_ROLES), async (req, res) => {
     }
     const update = {
       beneficiaryId: body.beneficiaryId,
-      branchId: body.branchId && mongoose.isValidObjectId(body.branchId) ? body.branchId : null,
+      branchId: beneficiary?.branchId || null,
       year,
       month,
       subsidyType: body.subsidyType,
@@ -224,7 +256,8 @@ router.patch('/:id', requireRole(WRITE_ROLES), async (req, res) => {
     }
     if (body.expectedDate) body.expectedDate = new Date(body.expectedDate);
     if (body.receivedDate) body.receivedDate = new Date(body.receivedDate);
-    const row = await Subsidy.findByIdAndUpdate(req.params.id, body, {
+    const scopedFilter = await mergeScopedBeneficiaryFilter(req, { _id: req.params.id });
+    const row = await Subsidy.findOneAndUpdate(scopedFilter, body, {
       returnDocument: 'after',
       runValidators: true,
     });
@@ -248,7 +281,8 @@ router.post('/:id/mark-received', requireRole(WRITE_ROLES), async (req, res) => 
     if (req.body?.receiptNumber) {
       update.receiptNumber = String(req.body.receiptNumber).slice(0, 50);
     }
-    const row = await Subsidy.findByIdAndUpdate(req.params.id, update, {
+    const scopedFilter = await mergeScopedBeneficiaryFilter(req, { _id: req.params.id });
+    const row = await Subsidy.findOneAndUpdate(scopedFilter, update, {
       returnDocument: 'after',
       runValidators: true,
     });
@@ -265,7 +299,8 @@ router.delete('/:id', requireRole(WRITE_ROLES), async (req, res) => {
     if (!mongoose.isValidObjectId(req.params.id)) {
       return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
     }
-    const row = await Subsidy.findByIdAndDelete(req.params.id);
+    const scopedFilter = await mergeScopedBeneficiaryFilter(req, { _id: req.params.id });
+    const row = await Subsidy.findOneAndDelete(scopedFilter);
     if (!row) return res.status(404).json({ success: false, message: 'السجل غير موجود' });
     res.json({ success: true, message: 'تم الحذف' });
   } catch (err) {

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -483,6 +483,9 @@ __tests__/nps-admin-branch-isolation-wave882.test.js
 __tests__/beneficiary-day-attendance-branch-isolation-wave883.test.js
 __tests__/events-management-branch-isolation-wave885.test.js
 __tests__/contract-management-branch-isolation-wave886.test.js
+__tests__/contracts-routes-branch-isolation-wave920.test.js
+__tests__/facilities-routes-branch-isolation-wave921.test.js
+__tests__/subsidies-routes-branch-isolation-wave922.test.js
 __tests__/therapy-sessions-admin-branch-isolation-wave887.test.js
 __tests__/cpe-admin-branch-isolation-wave888.test.js
 __tests__/guardians-branch-isolation-wave889.test.js

--- a/docs/sessions/2026-06-04-module-hardening-session.md
+++ b/docs/sessions/2026-06-04-module-hardening-session.md
@@ -684,6 +684,31 @@ isolation-wave872.test.js` (5 tests). Existing W277f MFA + service tests still g
 - **PR #267 merged** (`ad3406e8f`, 2026-06-05): squash of W890–W918 on `main`; CI green (683 sprint suites / 13345 tests).
 - ~~W919 asset-management dashboard tenant counters~~ — **done** (local): `GET /dashboard` pending WO/transfers/
   overdue/active-bookings counts now use `branchFilter(req)`; W912 test +1 (8 tests).
+- ~~W920 contracts routes branch isolation~~ — **done** (local): closed tenant leak in `contracts.routes.js` where
+  `requireBranchAccess` existed but list/stats + id-keyed read/write/delete/renew paths still queried globally.
+  Added `branchFilter`/`scopedById` across list, `/stats/summary`, `GET/:id`, `PUT/:id`, `DELETE/:id`,
+  `POST/:id/renew`. `POST /` now stamps `branchId` from scope and passes `liabilityInsurance` through to model
+  (schema-required), with `aggregateScope()` ObjectId casting to keep branch-scoped aggregation accurate.
+  - `contracts-routes-branch-isolation-wave920.test.js` (6 tests: scoped list, foreign GET/PUT 404,
+    scoped stats summary, branch stamping on create, foreign branchId spoof 403).
+- ~~W921 facilities routes branch isolation~~ — **done** (local): hardened `facilities.routes.js` across all four
+  surfaces (rooms, bookings, maintenance, dashboard). Added `branchFilter` + `scopedById` on room CRUD, room-derived
+  scope for `RoomBooking` (list + create/update/delete), branch-aware + room-fallback scope for `MaintenanceRequest`,
+  and dashboard counter scoping (`total/occupied/bookings/pendingMaintenance`) with aggregate ObjectId casting via
+  `aggregateScope()`. Also stamps `branchId` on maintenance create and blocks foreign-room booking/maintenance writes.
+  - `facilities-routes-branch-isolation-wave921.test.js` (8 tests: scoped rooms/maintenance/dashboard,
+    foreign room+booking 404 regressions, foreign-room booking create denied, maintenance create branch stamp).
+- ~~W922 subsidies routes branch isolation~~ — **done** (local): `subsidies.routes.js` now enforces tenant scope via
+  beneficiary ownership for list/summary/id-keyed mutation surfaces. Added `requireBranchAccess` + scoped beneficiary
+  cache helpers (`getScopedBeneficiaryIds` / `mergeScopedBeneficiaryFilter`), gated `GET /by-beneficiary/:id` and
+  `POST /` with `assertBeneficiaryInScope`, and converted `PATCH /:id`, `POST /:id/mark-received`, `DELETE /:id`
+  to scoped `findOneAnd*` filters. `POST /` now stamps `branchId` from the beneficiary record (ignores caller-supplied
+  branch spoofing). + `subsidies-routes-branch-isolation-wave922.test.js` (7 tests: scoped list/summary,
+  foreign beneficiary/read+write 404 regressions, scoped create branch stamping).
+- **Targeted verify refresh (W920–W922)**: **4 suites / 25 tests** ✅
+  (`contracts-routes-branch-isolation-wave920`, `facilities-routes-branch-isolation-wave921`,
+  `subsidies-routes-branch-isolation-wave922`, `ci-path-triggers-exist`) +
+  `check:routes-load` + `check:wave-collision` + `sync:sprint-paths` ✅.
 - ~~W884 Mongoose duplicate schema.index drift guard + 25-index cleanup~~ — **done** (local, not yet pushed; renumbered from W880 — W880 taken by invoices-admin isolation):
   - **Cleanup**: removed redundant `schema.index({field:1})` where the field already declares `unique:true`
     (or a duplicate compound unique) across 19 models — 25 warnings → 0 (AssetTransfer, Volunteer×3,

--- a/docs/sessions/2026-06-04-module-hardening-session.md
+++ b/docs/sessions/2026-06-04-module-hardening-session.md
@@ -665,7 +665,7 @@ isolation-wave872.test.js` (5 tests). Existing W277f MFA + service tests still g
   `referrals-portal-branch-isolation-wave913.test.js` (3 tests: scoped list, foreign GET/PATCH 404).
 - **Targeted verify refresh (W909–W913)**: **3 suites / 13 tests** ✅ (`crisis-routes-branch-isolation-wave909`,
   `asset-management-work-orders-branch-isolation-wave912`, `referrals-portal-branch-isolation-wave913`).
-- ~~W918 CI fix (StrategicKPI index + crisis seeds + ICF catalog mount)~~ — **done** (local): duplicate
+- ~~W918 CI fix (StrategicKPI index + crisis seeds + ICF catalog mount)~~ — **done** (`c2e24e68e`, pushed; CI green): duplicate
   `branchId` index on StrategicKPI; W909 `incidentNumber` seeds; ICF `/codes` + `/benchmarks` before
   `requireBranchAccess`; W692/W706 auth mock + W706 beneficiary seed for `/:id/benchmark`.
 - ~~W914 meetings routes branch isolation~~ — **done** (`cd01073e9`, pushed): optional `branchId` on `Meeting.js`;
@@ -681,6 +681,9 @@ isolation-wave872.test.js` (5 tests). Existing W277f MFA + service tests still g
   `effectiveBranchScope`; removed `?branchId` spoof via `location` regex; CRUD scoped. +
   `asset-catalog-branch-isolation-wave917.test.js` (3 tests). W912 WO tests still pass (catalog vs sub-resource split).
 - **Verify (W914–W917)**: **4 suites / 12 tests** ✅ (+ W912 regression 7 tests).
+- **PR #267 merged** (`ad3406e8f`, 2026-06-05): squash of W890–W918 on `main`; CI green (683 sprint suites / 13345 tests).
+- ~~W919 asset-management dashboard tenant counters~~ — **done** (local): `GET /dashboard` pending WO/transfers/
+  overdue/active-bookings counts now use `branchFilter(req)`; W912 test +1 (8 tests).
 - ~~W884 Mongoose duplicate schema.index drift guard + 25-index cleanup~~ — **done** (local, not yet pushed; renumbered from W880 — W880 taken by invoices-admin isolation):
   - **Cleanup**: removed redundant `schema.index({field:1})` where the field already declares `unique:true`
     (or a duplicate compound unique) across 19 models — 25 warnings → 0 (AssetTransfer, Volunteer×3,


### PR DESCRIPTION
## Summary
Follow-up to W912: `GET /asset-management/dashboard` still aggregated pending work orders, transfers, overdue WOs, and today's bookings **across all branches** — leaking cross-tenant ops metrics to restricted users.

Applies `branchFilter(req)` to those four counters (org-wide asset catalog totals unchanged).

## Test plan
- [x] `asset-management-work-orders-branch-isolation-wave912` — 8/8 (new dashboard assertion + ResourceBooking seeds)
- [x] Pre-push gates green
