### PR TITLE
fix(security): W923 quality-enhanced branch isolation

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1169,6 +1169,8 @@ on:
       - 'backend/__tests__/facilities-routes-branch-isolation-wave921.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/subsidies-routes-branch-isolation-wave922.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/quality-enhanced-branch-isolation-wave923.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2321,6 +2323,8 @@ on:
       - 'backend/__tests__/facilities-routes-branch-isolation-wave921.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/subsidies-routes-branch-isolation-wave922.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/quality-enhanced-branch-isolation-wave923.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/quality-enhanced-branch-isolation-wave923.test.js
+++ b/backend/__tests__/quality-enhanced-branch-isolation-wave923.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+/**
+ * quality-enhanced-branch-isolation-wave923.test.js — W923.
+ *
+ * Pre-W923 quality-enhanced lists honoured ?branchId= spoofing and instance
+ * routes used bare findById/findByIdAndUpdate. Real branchScope + MongoMemoryServer.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(60000);
+
+const mongoose = require('mongoose');
+const express = require('express');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const mockAuthState = { user: null };
+jest.mock('../middleware/auth', () => ({
+  authenticate: (req, _res, next) => {
+    req.user = mockAuthState.user;
+    next();
+  },
+  authorize:
+    (..._roles) =>
+    (_req, _res, next) =>
+      next(),
+}));
+
+const BRANCH_A = new mongoose.Types.ObjectId();
+const BRANCH_B = new mongoose.Types.ObjectId();
+const USER_A = new mongoose.Types.ObjectId();
+
+const qualityManagerA = {
+  _id: USER_A,
+  role: 'quality_manager',
+  branchId: String(BRANCH_A),
+};
+
+let mongod;
+let Incident;
+let Complaint;
+let incidentB;
+let complaintB;
+let app;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w923-quality-enhanced' } });
+  await mongoose.connect(mongod.getUri());
+  require('../config/mongoose.plugins');
+  require('../models/User');
+  ({ Incident, Complaint } = require('../models/QualityModels'));
+
+  const appExpress = express();
+  appExpress.use(express.json());
+  appExpress.use('/api/v1/quality-enhanced', require('../routes/quality-enhanced.routes'));
+  app = appExpress;
+
+  const now = new Date();
+  await Incident.collection.insertOne({
+    incidentNumber: 'INC-W923-A',
+    branchId: BRANCH_A,
+    reportedBy: USER_A,
+    type: 'near_miss',
+    severity: 'minor',
+    category: 'operational',
+    occurredAt: now,
+    location: 'قاعة A',
+    description: 'حادث فرع أ',
+  });
+  const insB = await Incident.collection.insertOne({
+    incidentNumber: 'INC-W923-B',
+    branchId: BRANCH_B,
+    reportedBy: USER_A,
+    type: 'fall',
+    severity: 'major',
+    category: 'patient_safety',
+    occurredAt: now,
+    location: 'قاعة B',
+    description: 'حادث فرع ب',
+  });
+  incidentB = insB.insertedId;
+
+  await Complaint.collection.insertOne({
+    complaintNumber: 'CMP-W923-A',
+    branchId: BRANCH_A,
+    source: 'employee',
+    category: 'service_quality',
+    description: 'شكوى فرع أ',
+  });
+  const cmpB = await Complaint.collection.insertOne({
+    complaintNumber: 'CMP-W923-B',
+    branchId: BRANCH_B,
+    source: 'beneficiary',
+    category: 'waiting_time',
+    description: 'شكوى فرع ب',
+  });
+  complaintB = cmpB.insertedId;
+});
+
+beforeEach(() => {
+  mockAuthState.user = qualityManagerA;
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+describe('W923 — quality-enhanced branch isolation', () => {
+  it('lists only in-scope incidents', async () => {
+    const res = await request(app).get('/api/v1/quality-enhanced/incidents');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(String(res.body.data[0].branchId)).toBe(String(BRANCH_A));
+  });
+
+  it('rejects foreign ?branchId= on incident list (requireBranchAccess)', async () => {
+    const res = await request(app)
+      .get('/api/v1/quality-enhanced/incidents')
+      .query({ branchId: String(BRANCH_B) });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for foreign incident GET /incidents/:id', async () => {
+    const res = await request(app).get(`/api/v1/quality-enhanced/incidents/${incidentB}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for foreign incident PUT /incidents/:id', async () => {
+    const res = await request(app)
+      .put(`/api/v1/quality-enhanced/incidents/${incidentB}`)
+      .send({ description: 'محاولة تعديل' });
+    expect(res.status).toBe(404);
+  });
+
+  it('lists only in-scope complaints', async () => {
+    const res = await request(app).get('/api/v1/quality-enhanced/complaints');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(String(res.body.data[0].branchId)).toBe(String(BRANCH_A));
+  });
+
+  it('returns 404 for foreign complaint GET /complaints/:id', async () => {
+    const res = await request(app).get(`/api/v1/quality-enhanced/complaints/${complaintB}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('denies foreign branch dashboard GET /dashboard/:branchId', async () => {
+    const res = await request(app).get(`/api/v1/quality-enhanced/dashboard/${BRANCH_B}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('denies foreign branch risk matrix GET /risks/matrix/:branchId', async () => {
+    const res = await request(app).get(`/api/v1/quality-enhanced/risks/matrix/${BRANCH_B}`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/backend/routes/quality-enhanced.routes.js
+++ b/backend/routes/quality-enhanced.routes.js
@@ -1,7 +1,11 @@
 const express = require('express');
 const router = express.Router();
 const { authenticate, authorize } = require('../middleware/auth');
-const { requireBranchAccess } = require('../middleware/branchScope.middleware');
+const { requireBranchAccess, branchFilter } = require('../middleware/branchScope.middleware');
+const { assertBranchMatch } = require('../middleware/assertBranchMatch');
+
+const scopedById = (req, id) => ({ _id: id, ...branchFilter(req) });
+const mergeTenantFilter = (req, extra = {}) => ({ ...extra, ...branchFilter(req) });
 // Service exports a singleton instance — use directly (no `new`)
 const svc = require('../services/quality/quality-enhanced.service');
 const { stripUpdateMeta } = require('../utils/sanitize');
@@ -10,6 +14,7 @@ const safeError = require('../utils/safeError');
 // ── لوحة مؤشرات الجودة ───────────────────────────────
 router.get('/dashboard/:branchId', authenticate, requireBranchAccess, async (req, res) => {
   try {
+    assertBranchMatch(req, req.params.branchId, 'quality dashboard');
     const data = await svc.getQualityDashboard(req.params.branchId, req.query.period || 'month');
     res.json({ success: true, data });
   } catch (err) {
@@ -74,11 +79,15 @@ router.put(
 router.get('/checklists', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { Checklist } = require('../models/QualityModels');
-    const { type, frequency, branchId } = req.query;
-    const filter = { isActive: true };
+    const { type, frequency } = req.query;
+    const filter = mergeTenantFilter(req, { isActive: true });
     if (type) filter.type = type;
     if (frequency) filter.frequency = frequency;
-    if (branchId) filter.$or = [{ branchId }, { branchId: null }];
+    if (filter.branchId) {
+      const scopedBranch = filter.branchId;
+      delete filter.branchId;
+      filter.$or = [{ branchId: scopedBranch }, { branchId: null }];
+    }
     const checklists = await Checklist.find(filter).sort({ titleAr: 1 });
     res.json({ success: true, data: checklists });
   } catch (err) {
@@ -112,11 +121,17 @@ router.put(
   async (req, res) => {
     try {
       const { Checklist } = require('../models/QualityModels');
-      const checklist = await Checklist.findByIdAndUpdate(
-        req.params.id,
-        stripUpdateMeta(req.body),
-        { returnDocument: 'after' }
-      );
+      const tenant = branchFilter(req);
+      const query = { _id: req.params.id };
+      if (tenant.branchId) {
+        query.$or = [{ branchId: tenant.branchId }, { branchId: null }];
+      }
+      const checklist = await Checklist.findOneAndUpdate(query, stripUpdateMeta(req.body), {
+        returnDocument: 'after',
+      });
+      if (!checklist) {
+        return res.status(404).json({ success: false, message: 'قائمة الفحص غير موجودة' });
+      }
       res.json({ success: true, data: checklist });
     } catch (err) {
       res.status(400).json({ success: false, message: err.message });
@@ -128,9 +143,8 @@ router.put(
 router.get('/checklist-submissions', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { ChecklistSubmission } = require('../models/QualityModels');
-    const { branchId, checklistId, status, from, to } = req.query;
-    const filter = {};
-    if (branchId) filter.branchId = branchId;
+    const { checklistId, status, from, to } = req.query;
+    const filter = mergeTenantFilter(req);
     if (checklistId) filter.checklistId = checklistId;
     if (status) filter.status = status;
     if (from || to) filter.submissionDate = {};
@@ -159,9 +173,8 @@ router.post('/checklist-submissions', authenticate, requireBranchAccess, async (
 router.get('/incidents', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { Incident } = require('../models/QualityModels');
-    const { branchId, status, severity, type, from, to } = req.query;
-    const filter = {};
-    if (branchId) filter.branchId = branchId;
+    const { status, severity, type, from, to } = req.query;
+    const filter = mergeTenantFilter(req);
     if (status) filter.status = status;
     if (severity) filter.severity = severity;
     if (type) filter.type = type;
@@ -189,7 +202,7 @@ router.post('/incidents', authenticate, requireBranchAccess, async (req, res) =>
 router.get('/incidents/:incidentId', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { Incident } = require('../models/QualityModels');
-    const incident = await Incident.findById(req.params.incidentId).populate(
+    const incident = await Incident.findOne(scopedById(req, req.params.incidentId)).populate(
       'reportedBy assignedTo closedBy branchId'
     );
     if (!incident) return res.status(404).json({ success: false, message: 'الحادثة غير موجودة' });
@@ -202,11 +215,12 @@ router.get('/incidents/:incidentId', authenticate, requireBranchAccess, async (r
 router.put('/incidents/:incidentId', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { Incident } = require('../models/QualityModels');
-    const incident = await Incident.findByIdAndUpdate(
-      req.params.incidentId,
+    const incident = await Incident.findOneAndUpdate(
+      scopedById(req, req.params.incidentId),
       stripUpdateMeta(req.body),
       { returnDocument: 'after' }
     );
+    if (!incident) return res.status(404).json({ success: false, message: 'الحادثة غير موجودة' });
     res.json({ success: true, data: incident });
   } catch (err) {
     res.status(400).json({ success: false, message: err.message });
@@ -216,7 +230,7 @@ router.put('/incidents/:incidentId', authenticate, requireBranchAccess, async (r
 router.post('/incidents/:incidentId/rca', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { Incident } = require('../models/QualityModels');
-    const incident = await Incident.findById(req.params.incidentId);
+    const incident = await Incident.findOne(scopedById(req, req.params.incidentId));
     if (!incident) return res.status(404).json({ success: false, message: 'الحادثة غير موجودة' });
     const updated = await svc.submitRca(
       incident._id,
@@ -237,8 +251,8 @@ router.post(
   async (req, res) => {
     try {
       const { Incident } = require('../models/QualityModels');
-      const incident = await Incident.findByIdAndUpdate(
-        req.params.incidentId,
+      const incident = await Incident.findOneAndUpdate(
+        scopedById(req, req.params.incidentId),
         {
           $push: {
             correctiveActions: {
@@ -249,6 +263,7 @@ router.post(
         },
         { returnDocument: 'after' }
       );
+      if (!incident) return res.status(404).json({ success: false, message: 'الحادثة غير موجودة' });
       res.json({ success: true, data: incident });
     } catch (err) {
       res.status(400).json({ success: false, message: err.message });
@@ -265,8 +280,8 @@ router.put(
   async (req, res) => {
     try {
       const { Incident } = require('../models/QualityModels');
-      const incident = await Incident.findByIdAndUpdate(
-        req.params.incidentId,
+      const incident = await Incident.findOneAndUpdate(
+        scopedById(req, req.params.incidentId),
         {
           status: 'closed',
           closedBy: req.user._id,
@@ -275,6 +290,7 @@ router.put(
         },
         { returnDocument: 'after' }
       );
+      if (!incident) return res.status(404).json({ success: false, message: 'الحادثة غير موجودة' });
       res.json({ success: true, data: incident });
     } catch (err) {
       res.status(400).json({ success: false, message: err.message });
@@ -286,9 +302,8 @@ router.put(
 router.get('/complaints', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { Complaint } = require('../models/QualityModels');
-    const { branchId, status, category, priority } = req.query;
-    const filter = {};
-    if (branchId) filter.branchId = branchId;
+    const { status, category, priority } = req.query;
+    const filter = mergeTenantFilter(req);
     if (status) filter.status = status;
     if (category) filter.category = category;
     if (priority) filter.priority = priority;
@@ -313,7 +328,7 @@ router.post('/complaints', authenticate, requireBranchAccess, async (req, res) =
 router.get('/complaints/:complaintId', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { Complaint } = require('../models/QualityModels');
-    const complaint = await Complaint.findById(req.params.complaintId).populate(
+    const complaint = await Complaint.findOne(scopedById(req, req.params.complaintId)).populate(
       'assignedTo resolvedBy'
     );
     if (!complaint) return res.status(404).json({ success: false, message: 'الشكوى غير موجودة' });
@@ -326,11 +341,12 @@ router.get('/complaints/:complaintId', authenticate, requireBranchAccess, async 
 router.put('/complaints/:complaintId', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { Complaint } = require('../models/QualityModels');
-    const complaint = await Complaint.findByIdAndUpdate(
-      req.params.complaintId,
+    const complaint = await Complaint.findOneAndUpdate(
+      scopedById(req, req.params.complaintId),
       stripUpdateMeta(req.body),
       { returnDocument: 'after' }
     );
+    if (!complaint) return res.status(404).json({ success: false, message: 'الشكوى غير موجودة' });
     res.json({ success: true, data: complaint });
   } catch (err) {
     res.status(400).json({ success: false, message: err.message });
@@ -343,6 +359,9 @@ router.put(
   requireBranchAccess,
   async (req, res) => {
     try {
+      const { Complaint } = require('../models/QualityModels');
+      const exists = await Complaint.findOne(scopedById(req, req.params.complaintId)).select('_id');
+      if (!exists) return res.status(404).json({ success: false, message: 'الشكوى غير موجودة' });
       const result = await svc.resolveComplaint(
         req.params.complaintId,
         req.body.resolution,
@@ -359,9 +378,8 @@ router.put(
 router.get('/surveys', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { SatisfactionSurvey } = require('../models/QualityModels');
-    const { branchId, surveyType, from, to } = req.query;
-    const filter = {};
-    if (branchId) filter.branchId = branchId;
+    const { surveyType, from, to } = req.query;
+    const filter = mergeTenantFilter(req);
     if (surveyType) filter.surveyType = surveyType;
     if (from || to) filter.createdAt = {};
     if (from) filter.createdAt.$gte = new Date(from);
@@ -386,6 +404,7 @@ router.post('/surveys', async (req, res) => {
 
 router.get('/surveys/nps/:branchId', authenticate, requireBranchAccess, async (req, res) => {
   try {
+    assertBranchMatch(req, req.params.branchId, 'NPS survey');
     const { from, to } = req.query;
     const data = await svc.calculateNps(req.params.branchId, from, to);
     res.json({ success: true, data });
@@ -398,9 +417,8 @@ router.get('/surveys/nps/:branchId', authenticate, requireBranchAccess, async (r
 router.get('/audits', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { Audit } = require('../models/QualityModels');
-    const { branchId, standard, status, type } = req.query;
-    const filter = {};
-    if (branchId) filter.branchId = branchId;
+    const { standard, status, type } = req.query;
+    const filter = mergeTenantFilter(req);
     if (standard) filter.standard = standard;
     if (status) filter.status = status;
     if (type) filter.type = type;
@@ -430,7 +448,7 @@ router.post(
 router.get('/audits/:auditId', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { Audit } = require('../models/QualityModels');
-    const audit = await Audit.findById(req.params.auditId);
+    const audit = await Audit.findOne(scopedById(req, req.params.auditId));
     if (!audit) return res.status(404).json({ success: false, message: 'التدقيق غير موجود' });
     res.json({ success: true, data: audit });
   } catch (err) {
@@ -447,9 +465,12 @@ router.put(
   async (req, res) => {
     try {
       const { Audit } = require('../models/QualityModels');
-      const audit = await Audit.findByIdAndUpdate(req.params.auditId, stripUpdateMeta(req.body), {
-        returnDocument: 'after',
-      });
+      const audit = await Audit.findOneAndUpdate(
+        scopedById(req, req.params.auditId),
+        stripUpdateMeta(req.body),
+        { returnDocument: 'after' }
+      );
+      if (!audit) return res.status(404).json({ success: false, message: 'التدقيق غير موجود' });
       res.json({ success: true, data: audit });
     } catch (err) {
       res.status(400).json({ success: false, message: err.message });
@@ -461,9 +482,8 @@ router.put(
 router.get('/improvements', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { ImprovementProject } = require('../models/QualityModels');
-    const { branchId, status, currentPhase } = req.query;
-    const filter = {};
-    if (branchId) filter.branchId = branchId;
+    const { status, currentPhase } = req.query;
+    const filter = mergeTenantFilter(req);
     if (status) filter.status = status;
     if (currentPhase) filter.currentPhase = currentPhase;
     const projects = await ImprovementProject.find(filter)
@@ -487,7 +507,9 @@ router.post('/improvements', authenticate, requireBranchAccess, async (req, res)
 router.get('/improvements/:projectId', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { ImprovementProject } = require('../models/QualityModels');
-    const project = await ImprovementProject.findById(req.params.projectId).populate('ownerId');
+    const project = await ImprovementProject.findOne(
+      scopedById(req, req.params.projectId)
+    ).populate('ownerId');
     if (!project) return res.status(404).json({ success: false, message: 'المشروع غير موجود' });
     res.json({ success: true, data: project });
   } catch (err) {
@@ -498,11 +520,12 @@ router.get('/improvements/:projectId', authenticate, requireBranchAccess, async 
 router.put('/improvements/:projectId', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { ImprovementProject } = require('../models/QualityModels');
-    const project = await ImprovementProject.findByIdAndUpdate(
-      req.params.projectId,
+    const project = await ImprovementProject.findOneAndUpdate(
+      scopedById(req, req.params.projectId),
       stripUpdateMeta(req.body),
       { returnDocument: 'after' }
     );
+    if (!project) return res.status(404).json({ success: false, message: 'المشروع غير موجود' });
     res.json({ success: true, data: project });
   } catch (err) {
     res.status(400).json({ success: false, message: err.message });
@@ -519,9 +542,12 @@ router.put(
       const { phase, data: phaseData } = req.body;
       const update = { currentPhase: phase };
       update[`${phase}Phase`] = phaseData;
-      const project = await ImprovementProject.findByIdAndUpdate(req.params.projectId, update, {
-        returnDocument: 'after',
-      });
+      const project = await ImprovementProject.findOneAndUpdate(
+        scopedById(req, req.params.projectId),
+        update,
+        { returnDocument: 'after' }
+      );
+      if (!project) return res.status(404).json({ success: false, message: 'المشروع غير موجود' });
       res.json({ success: true, data: project });
     } catch (err) {
       res.status(400).json({ success: false, message: err.message });
@@ -533,9 +559,8 @@ router.put(
 router.get('/risks', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { Risk } = require('../models/QualityModels');
-    const { branchId, category, status, riskLevel } = req.query;
-    const filter = {};
-    if (branchId) filter.branchId = branchId;
+    const { category, status, riskLevel } = req.query;
+    const filter = mergeTenantFilter(req);
     if (category) filter.category = category;
     if (status) filter.status = status;
     if (riskLevel) filter.riskLevel = riskLevel;
@@ -558,6 +583,7 @@ router.post('/risks', authenticate, requireBranchAccess, async (req, res) => {
 
 router.get('/risks/matrix/:branchId', authenticate, requireBranchAccess, async (req, res) => {
   try {
+    assertBranchMatch(req, req.params.branchId, 'risk matrix');
     const { Risk } = require('../models/QualityModels');
     const risks = await Risk.find({
       branchId: req.params.branchId,
@@ -580,7 +606,7 @@ router.get('/risks/matrix/:branchId', authenticate, requireBranchAccess, async (
 router.get('/risks/:riskId', authenticate, requireBranchAccess, async (req, res) => {
   try {
     const { Risk } = require('../models/QualityModels');
-    const risk = await Risk.findById(req.params.riskId).populate('ownerId');
+    const risk = await Risk.findOne(scopedById(req, req.params.riskId)).populate('ownerId');
     if (!risk) return res.status(404).json({ success: false, message: 'المخاطرة غير موجودة' });
     res.json({ success: true, data: risk });
   } catch (err) {
@@ -592,14 +618,19 @@ router.put('/risks/:riskId', authenticate, requireBranchAccess, async (req, res)
   try {
     const { Risk } = require('../models/QualityModels');
     if (req.body.likelihood || req.body.impact) {
-      const existing = await Risk.findById(req.params.riskId);
+      const existing = await Risk.findOne(scopedById(req, req.params.riskId));
+      if (!existing)
+        return res.status(404).json({ success: false, message: 'المخاطرة غير موجودة' });
       const likelihood = req.body.likelihood || existing.likelihood;
       const impact = req.body.impact || existing.impact;
       req.body.riskLevel = svc.assessRiskLevel(likelihood, impact);
     }
-    const risk = await Risk.findByIdAndUpdate(req.params.riskId, stripUpdateMeta(req.body), {
-      returnDocument: 'after',
-    });
+    const risk = await Risk.findOneAndUpdate(
+      scopedById(req, req.params.riskId),
+      stripUpdateMeta(req.body),
+      { returnDocument: 'after' }
+    );
+    if (!risk) return res.status(404).json({ success: false, message: 'المخاطرة غير موجودة' });
     res.json({ success: true, data: risk });
   } catch (err) {
     res.status(400).json({ success: false, message: err.message });

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -689,3 +689,4 @@ __tests__/capa-implemented-mutations-behavioral-wave846.test.js
 __tests__/capa-reject-inprogress-behavioral-wave848.test.js
 __tests__/spasticity-injection-api-wave715.test.js
 __tests__/spasticity-injection-behavioral-wave715.test.js
+__tests__/quality-enhanced-branch-isolation-wave923.test.js


### PR DESCRIPTION
## Summary
- Close IDOR on `/api/v1/quality-enhanced` list and instance routes using `branchFilter` / `scopedById` and `assertBranchMatch` on path `:branchId` params (dashboard, NPS, risk matrix).
- Lists no longer honour spoofed `?branchId=`; foreign instance GET/PUT returns 404; foreign path branch returns 403.
- Add sprint-gated regression suite (8 assertions).

## Test plan
- [x] `npx jest __tests__/quality-enhanced-branch-isolation-wave923.test.js` — 8/8 pass locally
- [ ] CI sprint gate green


Made with [Cursor](https://cursor.com)