### PR TITLE
fix(security): W924 morning-health-check branch isolation

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1171,6 +1171,8 @@ on:
       - 'backend/__tests__/subsidies-routes-branch-isolation-wave922.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/quality-enhanced-branch-isolation-wave923.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/morning-health-check-branch-isolation-wave924.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2325,6 +2327,8 @@ on:
       - 'backend/__tests__/subsidies-routes-branch-isolation-wave922.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/quality-enhanced-branch-isolation-wave923.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/morning-health-check-branch-isolation-wave924.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/morning-health-check-branch-isolation-wave924.test.js
+++ b/backend/__tests__/morning-health-check-branch-isolation-wave924.test.js
@@ -1,0 +1,137 @@
+'use strict';
+
+/**
+ * morning-health-check-branch-isolation-wave924.test.js — W924.
+ * PHI morning checks; pre-W924 requireBranchAccess was missing and instance
+ * routes used bare findById (bodyScopedBeneficiaryGuard inert).
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(60000);
+
+const mongoose = require('mongoose');
+const express = require('express');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const mockAuthState = { user: null };
+jest.mock('../middleware/auth', () => ({
+  authenticateToken: (req, _res, next) => {
+    req.user = mockAuthState.user;
+    next();
+  },
+  requireRole: roles => (req, res, next) => {
+    const role = req.user && req.user.role;
+    if (!Array.isArray(roles) || roles.includes(role)) return next();
+    return res.status(403).json({ success: false, message: 'الدور غير مصرّح' });
+  },
+}));
+
+let mongod;
+let MorningHealthCheck;
+let Beneficiary;
+
+const BRANCH_A = new mongoose.Types.ObjectId();
+const BRANCH_B = new mongoose.Types.ObjectId();
+const BENE_A = new mongoose.Types.ObjectId();
+const BENE_B = new mongoose.Types.ObjectId();
+const today = new Date();
+
+const nurseA = {
+  id: String(new mongoose.Types.ObjectId()),
+  role: 'nurse',
+  name: 'الممرض',
+  branchId: String(BRANCH_A),
+};
+
+let app;
+
+function buildApp() {
+  const expressApp = express();
+  expressApp.use(express.json());
+  expressApp.use('/api/v1/morning-health-check', require('../routes/morning-health-check.routes'));
+  return expressApp;
+}
+
+function startOfDay(d) {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+async function seedCheck(branchId, beneficiaryId = BENE_A) {
+  return MorningHealthCheck.create({
+    beneficiaryId,
+    branchId,
+    date: startOfDay(today),
+    decision: 'allow',
+    checkTime: new Date(),
+  });
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w924-mhc' } });
+  await mongoose.connect(mongod.getUri());
+  require('../config/mongoose.plugins');
+  MorningHealthCheck = require('../models/MorningHealthCheck');
+  Beneficiary = require('../models/Beneficiary');
+  await Beneficiary.collection.insertOne({ _id: BENE_A, branchId: BRANCH_A });
+  await Beneficiary.collection.insertOne({ _id: BENE_B, branchId: BRANCH_B });
+  app = buildApp();
+});
+
+beforeEach(() => {
+  mockAuthState.user = nurseA;
+});
+
+afterEach(async () => {
+  await MorningHealthCheck.deleteMany({});
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+describe('W924 — POST stamps caller branch', () => {
+  it('POST / upserts with branchId from caller scope (201)', async () => {
+    const res = await request(app)
+      .post('/api/v1/morning-health-check')
+      .send({ beneficiaryId: String(BENE_A), decision: 'allow' });
+    expect(res.status).toBe(201);
+    expect(String(res.body.data.branchId)).toBe(String(BRANCH_A));
+  });
+});
+
+describe('W924 — instance IDOR regression', () => {
+  it('GET /:id returns 404 for foreign-branch row', async () => {
+    const row = await seedCheck(BRANCH_B, BENE_B);
+    const res = await request(app).get(`/api/v1/morning-health-check/${row._id}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('PATCH /:id returns 404 for foreign-branch row', async () => {
+    const row = await seedCheck(BRANCH_B, BENE_B);
+    const res = await request(app)
+      .patch(`/api/v1/morning-health-check/${row._id}`)
+      .send({ reason: 'x' });
+    expect(res.status).toBe(404);
+  });
+
+  it('DELETE /:id returns 404 for foreign-branch row', async () => {
+    const row = await seedCheck(BRANCH_B, BENE_B);
+    const res = await request(app).delete(`/api/v1/morning-health-check/${row._id}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('W924 — GET /today branch-scoped', () => {
+  it('only returns caller-branch checks', async () => {
+    await seedCheck(BRANCH_A, BENE_A);
+    await seedCheck(BRANCH_B, BENE_B);
+    const res = await request(app).get('/api/v1/morning-health-check/today');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(String(res.body.items[0].branchId)).toBe(String(BRANCH_A));
+  });
+});

--- a/backend/routes/morning-health-check.routes.js
+++ b/backend/routes/morning-health-check.routes.js
@@ -23,10 +23,20 @@ const { authenticateToken, requireRole } = require('../middleware/auth');
 const MorningHealthCheck = require('../models/MorningHealthCheck');
 const Beneficiary = require('../models/Beneficiary');
 const safeError = require('../utils/safeError');
-const { bodyScopedBeneficiaryGuard } = require('../middleware/assertBranchMatch');
+const {
+  bodyScopedBeneficiaryGuard,
+  enforceBeneficiaryBranch,
+} = require('../middleware/assertBranchMatch');
+const { requireBranchAccess, branchFilter } = require('../middleware/branchScope.middleware');
 
 router.use(authenticateToken);
+// W924 — populate req.branchScope before bodyScopedBeneficiaryGuard (W441 was inert without it).
+router.use(requireBranchAccess);
 router.use(bodyScopedBeneficiaryGuard); // W441: enforce branch on req.body.beneficiaryId
+
+function scopedById(req, id) {
+  return { _id: id, ...branchFilter(req) };
+}
 
 const READ_ROLES = [
   'admin',
@@ -79,10 +89,7 @@ async function hydrate(items) {
 router.get('/today', requireRole(READ_ROLES), async (req, res) => {
   try {
     const d = req.query.date ? new Date(req.query.date) : new Date();
-    const filter = { date: { $gte: startOfDay(d), $lte: endOfDay(d) } };
-    if (req.query.branchId && mongoose.isValidObjectId(req.query.branchId)) {
-      filter.branchId = req.query.branchId;
-    }
+    const filter = { date: { $gte: startOfDay(d), $lte: endOfDay(d) }, ...branchFilter(req) };
     if (req.query.decision && DECISIONS.includes(String(req.query.decision))) {
       filter.decision = String(req.query.decision);
     }
@@ -104,8 +111,9 @@ router.get('/today', requireRole(READ_ROLES), async (req, res) => {
 // ── GET / ──────────────────────────────────────────────────────────────
 router.get('/', requireRole(READ_ROLES), async (req, res) => {
   try {
-    const filter = {};
+    const filter = { ...branchFilter(req) };
     if (req.query.beneficiaryId && mongoose.isValidObjectId(req.query.beneficiaryId)) {
+      await enforceBeneficiaryBranch(req, req.query.beneficiaryId);
       filter.beneficiaryId = req.query.beneficiaryId;
     }
     if (req.query.decision && DECISIONS.includes(String(req.query.decision))) {
@@ -146,7 +154,7 @@ router.get('/:id', requireRole(READ_ROLES), async (req, res) => {
     if (!mongoose.isValidObjectId(req.params.id)) {
       return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
     }
-    const row = await MorningHealthCheck.findById(req.params.id).lean();
+    const row = await MorningHealthCheck.findOne(scopedById(req, req.params.id)).lean();
     if (!row) return res.status(404).json({ success: false, message: 'السجل غير موجود' });
     const [hydrated] = await hydrate([row]);
     res.json({ success: true, data: hydrated });
@@ -180,8 +188,10 @@ router.post('/', requireRole(WRITE_ROLES), async (req, res) => {
       reason: body.reason || '',
       nurseId: req.user?.id || null,
       nurseName: req.user?.name || body.nurseName || '',
+      branchId:
+        req.branchScope?.branchId ||
+        (body.branchId && mongoose.isValidObjectId(body.branchId) ? body.branchId : null),
     };
-    if (body.branchId && mongoose.isValidObjectId(body.branchId)) update.branchId = body.branchId;
     if (typeof body.temperatureC === 'number') update.temperatureC = body.temperatureC;
     if (body.mood) update.mood = body.mood;
     if (body.symptoms && typeof body.symptoms === 'object') update.symptoms = body.symptoms;
@@ -213,7 +223,7 @@ router.patch('/:id', requireRole(WRITE_ROLES), async (req, res) => {
     if (body.decision === 'send_home' && !String(body.reason || '').trim()) {
       return res.status(400).json({ success: false, message: 'السبب مطلوب' });
     }
-    const row = await MorningHealthCheck.findByIdAndUpdate(req.params.id, body, {
+    const row = await MorningHealthCheck.findOneAndUpdate(scopedById(req, req.params.id), body, {
       returnDocument: 'after',
       runValidators: true,
     });
@@ -230,8 +240,8 @@ router.post('/:id/notify-parent', requireRole(WRITE_ROLES), async (req, res) => 
     if (!mongoose.isValidObjectId(req.params.id)) {
       return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
     }
-    const row = await MorningHealthCheck.findByIdAndUpdate(
-      req.params.id,
+    const row = await MorningHealthCheck.findOneAndUpdate(
+      scopedById(req, req.params.id),
       { parentNotified: true, parentNotifiedAt: new Date() },
       { returnDocument: 'after' }
     );
@@ -248,7 +258,7 @@ router.delete('/:id', requireRole(WRITE_ROLES), async (req, res) => {
     if (!mongoose.isValidObjectId(req.params.id)) {
       return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
     }
-    const row = await MorningHealthCheck.findByIdAndDelete(req.params.id);
+    const row = await MorningHealthCheck.findOneAndDelete(scopedById(req, req.params.id));
     if (!row) return res.status(404).json({ success: false, message: 'السجل غير موجود' });
     res.json({ success: true, message: 'تم الحذف' });
   } catch (err) {

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -690,3 +690,4 @@ __tests__/capa-reject-inprogress-behavioral-wave848.test.js
 __tests__/spasticity-injection-api-wave715.test.js
 __tests__/spasticity-injection-behavioral-wave715.test.js
 __tests__/quality-enhanced-branch-isolation-wave923.test.js
+__tests__/morning-health-check-branch-isolation-wave924.test.js


### PR DESCRIPTION
## Summary
- Mount \equireBranchAccess\ on morning-health-check so \odyScopedBeneficiaryGuard\ (W441) is no longer inert on PHI write paths.
- Branch-scope \GET /today\, \GET /\, and all instance routes (\GET/PATCH/DELETE /:id\, \POST /:id/notify-parent\) via \ranchFilter\ / \scopedById\.
- Stamp \ranchId\ from caller scope on POST upsert (same pattern as W869 MAR / W879 toileting).
- Sprint regression suite: 5 assertions.

## Test plan
- [x] \
px jest __tests__/morning-health-check-branch-isolation-wave924.test.js\ — 5/5 pass locally
- [ ] CI sprint gate green


Made with [Cursor](https://cursor.com)