### PR TITLE
fix(security): W925 telehealth-v2 TherapySession branch isolation

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1348,6 +1348,8 @@ on:
       - 'backend/__tests__/alert-engine-model-availability-wave1149.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/staff-certification-rules-wave1151.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/telehealth-v2-branch-isolation-wave925.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2679,6 +2681,8 @@ on:
       - 'backend/__tests__/alert-engine-model-availability-wave1149.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/staff-certification-rules-wave1151.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/telehealth-v2-branch-isolation-wave925.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/telehealth-v2-branch-isolation-wave925.test.js
+++ b/backend/__tests__/telehealth-v2-branch-isolation-wave925.test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+/**
+ * telehealth-v2-branch-isolation-wave925.test.js — W925.
+ * TherapySession video layer had no requireBranchAccess; bare findById let
+ * restricted users probe foreign-branch sessions (PHI + room URLs).
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(60000);
+
+const mongoose = require('mongoose');
+const express = require('express');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const mockAuthState = { user: null };
+jest.mock('../middleware/auth', () => ({
+  authenticateToken: (req, _res, next) => {
+    req.user = mockAuthState.user;
+    next();
+  },
+}));
+
+let mongod;
+let TherapySession;
+let Employee;
+
+const BRANCH_A = new mongoose.Types.ObjectId();
+const BRANCH_B = new mongoose.Types.ObjectId();
+const BENE_A = new mongoose.Types.ObjectId();
+const EMP_A = new mongoose.Types.ObjectId();
+const EMP_B = new mongoose.Types.ObjectId();
+
+const managerA = {
+  id: String(new mongoose.Types.ObjectId()),
+  role: 'manager',
+  branchId: String(BRANCH_A),
+};
+
+const therapistA = {
+  id: String(new mongoose.Types.ObjectId()),
+  role: 'therapist',
+  email: 'therapist-a@test.com',
+  branchId: String(BRANCH_A),
+};
+
+let app;
+
+function buildApp() {
+  const expressApp = express();
+  expressApp.use(express.json());
+  expressApp.use('/api/v1/telehealth-v2', require('../routes/telehealth-v2.routes'));
+  return expressApp;
+}
+
+function futureDate() {
+  const d = new Date();
+  d.setDate(d.getDate() + 7);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+async function seedSession(branchId, therapistId, overrides = {}) {
+  return TherapySession.create({
+    branchId,
+    beneficiary: BENE_A,
+    therapist: therapistId,
+    date: futureDate(),
+    status: 'SCHEDULED',
+    telehealth: { enabled: true, roomUrl: 'https://meet.jit.si/alawael-test' },
+    ...overrides,
+  });
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w925-telehealth-v2' } });
+  await mongoose.connect(mongod.getUri());
+  require('../config/mongoose.plugins');
+  TherapySession = require('../models/TherapySession');
+  Employee = require('../models/HR/Employee');
+  await Employee.collection.insertMany([
+    { _id: EMP_A, email: 'therapist-a@test.com', branchId: BRANCH_A, firstName_ar: 'معالج أ' },
+    { _id: EMP_B, email: 'therapist-b@test.com', branchId: BRANCH_B, firstName_ar: 'معالج ب' },
+  ]);
+  app = buildApp();
+});
+
+beforeEach(() => {
+  mockAuthState.user = managerA;
+});
+
+afterEach(async () => {
+  await TherapySession.deleteMany({});
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+describe('W925 — instance IDOR regression', () => {
+  it('GET /sessions/:id returns 404 for foreign-branch session', async () => {
+    const foreign = await seedSession(BRANCH_B, EMP_B);
+    const res = await request(app).get(`/api/v1/telehealth-v2/sessions/${foreign._id}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /sessions/:id/join returns 404 for foreign-branch session', async () => {
+    const foreign = await seedSession(BRANCH_B, EMP_B);
+    const res = await request(app).post(`/api/v1/telehealth-v2/sessions/${foreign._id}/join`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('W925 — GET /my/upcoming branch-scoped', () => {
+  it('therapist only sees in-scope telehealth sessions', async () => {
+    mockAuthState.user = therapistA;
+    await seedSession(BRANCH_A, EMP_A);
+    await seedSession(BRANCH_B, EMP_B);
+    const res = await request(app).get('/api/v1/telehealth-v2/my/upcoming');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(String(res.body.items[0].branchId)).toBe(String(BRANCH_A));
+  });
+});

--- a/backend/routes/telehealth-v2.routes.js
+++ b/backend/routes/telehealth-v2.routes.js
@@ -28,6 +28,7 @@ const router = express.Router();
 const mongoose = require('mongoose');
 const crypto = require('crypto');
 const { authenticateToken } = require('../middleware/auth');
+const { requireBranchAccess, branchFilter } = require('../middleware/branchScope.middleware');
 const safeError = require('../utils/safeError');
 const logger = require('../utils/logger');
 
@@ -37,6 +38,11 @@ const Guardian = require('../models/Guardian');
 const Beneficiary = require('../models/Beneficiary');
 
 router.use(authenticateToken);
+router.use(requireBranchAccess);
+
+function scopedSessionById(req, id) {
+  return { _id: id, ...branchFilter(req) };
+}
 
 const HQ = ['admin', 'superadmin', 'super_admin'];
 const THERAPIST_ROLES = ['therapist', 'specialist', 'clinical_supervisor'];
@@ -82,7 +88,7 @@ router.post('/sessions/:id/create-room', async (req, res) => {
   try {
     if (!mongoose.isValidObjectId(req.params.id))
       return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
-    const session = await TherapySession.findById(req.params.id);
+    const session = await TherapySession.findOne(scopedSessionById(req, req.params.id));
     if (!session) return res.status(404).json({ success: false, message: 'الجلسة غير موجودة' });
 
     const who = await resolveRole(req, session);
@@ -133,7 +139,7 @@ router.post('/sessions/:id/join', async (req, res) => {
   try {
     if (!mongoose.isValidObjectId(req.params.id))
       return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
-    const session = await TherapySession.findById(req.params.id);
+    const session = await TherapySession.findOne(scopedSessionById(req, req.params.id));
     if (!session) return res.status(404).json({ success: false, message: 'غير موجود' });
 
     const who = await resolveRole(req, session);
@@ -175,7 +181,7 @@ router.post('/sessions/:id/end', async (req, res) => {
   try {
     if (!mongoose.isValidObjectId(req.params.id))
       return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
-    const session = await TherapySession.findById(req.params.id);
+    const session = await TherapySession.findOne(scopedSessionById(req, req.params.id));
     if (!session) return res.status(404).json({ success: false, message: 'غير موجود' });
 
     const who = await resolveRole(req, session);
@@ -218,7 +224,7 @@ router.get('/sessions/:id', async (req, res) => {
   try {
     if (!mongoose.isValidObjectId(req.params.id))
       return res.status(400).json({ success: false, message: 'معرّف غير صالح' });
-    const session = await TherapySession.findById(req.params.id)
+    const session = await TherapySession.findOne(scopedSessionById(req, req.params.id))
       .populate('beneficiary', 'firstName lastName firstName_ar lastName_ar beneficiaryNumber')
       .populate('therapist', 'firstName lastName firstName_ar lastName_ar fullName')
       .lean();
@@ -256,6 +262,7 @@ router.get('/my/upcoming', async (req, res) => {
     const now = new Date();
     now.setHours(0, 0, 0, 0);
     const filter = {
+      ...branchFilter(req),
       'telehealth.enabled': true,
       date: { $gte: now },
       status: { $in: ['SCHEDULED', 'CONFIRMED', 'IN_PROGRESS'] },
@@ -279,7 +286,9 @@ router.get('/my/upcoming', async (req, res) => {
       .populate('therapist', 'firstName lastName firstName_ar lastName_ar')
       .sort({ date: 1, startTime: 1 })
       .limit(50)
-      .select('title sessionType date startTime endTime status telehealth beneficiary therapist')
+      .select(
+        'title sessionType date startTime endTime status telehealth beneficiary therapist branchId'
+      )
       .lean();
     res.json({ success: true, items });
   } catch (err) {

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -793,3 +793,4 @@ __tests__/budget-overrun-rule-wave1141.test.js
 __tests__/model-event-bridge-mapping-models-exist-wave1148.test.js
 __tests__/alert-engine-model-availability-wave1149.test.js
 __tests__/staff-certification-rules-wave1151.test.js
+__tests__/telehealth-v2-branch-isolation-wave925.test.js


### PR DESCRIPTION
## Summary
- Mount \equireBranchAccess\ on telehealth-v2 (Jitsi layer over TherapySession).
- Replace bare \indById\ with \scopedSessionById\ on create-room/join/end/get session — foreign branch → 404 (no PHI/room URL leak).
- Branch-filter \GET /my/upcoming\ via \ranchFilter(req)\; expose \ranchId\ in list projection.
- HQ admin roles still cross-branch via empty \ranchFilter\.
- Sprint regression: 3 assertions.

## Test plan
- [x] \
px jest __tests__/telehealth-v2-branch-isolation-wave925.test.js\ — 3/3 pass locally
- [ ] CI sprint gate green


Made with [Cursor](https://cursor.com)