### PR TITLE
feat(quality): W941 deliver quality.audit.* notifications via a one-way bus bridge

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1208,6 +1208,8 @@ on:
       - 'backend/__tests__/goal-created-timeline-subscriber-wave939.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/complaints-normalize-bridge-reconcile-wave940.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/quality-audit-notify-wave941.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2399,6 +2401,8 @@ on:
       - 'backend/__tests__/goal-created-timeline-subscriber-wave939.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/complaints-normalize-bridge-reconcile-wave940.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/quality-audit-notify-wave941.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/quality-audit-notify-wave941.test.js
+++ b/backend/__tests__/quality-audit-notify-wave941.test.js
@@ -1,0 +1,163 @@
+'use strict';
+
+/**
+ * W941 — quality.audit.* notification delivery.
+ *
+ * Closes a two-bus disconnect in the quality subsystem: the auditScheduler emits
+ * quality.audit.scheduled/nc_recorded/closed on `qualityEventBus.getDefault()`
+ * (the SINGLETON), but the email notification router subscribes to the FRESH bus
+ * created inside qualityComplianceBootstrap. So those audit events never reached
+ * the router → no policy-based email, no matter the policies (the W349/W387
+ * silent-no-op class). The bootstrap now installs a one-way `quality.audit.*`
+ * bridge (singleton → router bus); this wave adds the 3 policies + templates.
+ *
+ * Coverage:
+ *   1. static — bootstrap installs the narrow, audit-only, one-way bridge.
+ *   2. policy — resolvePolicies() returns a dedicated policy for each audit event.
+ *   3. template — render() produces a real subject/body for each (not generic).
+ *   4. INTEGRATION (the W387 lesson) — emit quality.audit.closed on bus A, prove
+ *      it reaches a router on bus B THROUGH the bridge and gets dispatched.
+ *
+ * Pure JS — real event bus + real router with fake logModel/channel; no DB.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { resolvePolicies } = require('../config/notification-policies.registry');
+const { render } = require('../services/quality/notifications/templates');
+const { createQualityEventBus } = require('../services/quality/qualityEventBus.service');
+const {
+  createNotificationRouter,
+} = require('../services/quality/notifications/notificationRouter.service');
+
+const BOOT_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'startup', 'qualityComplianceBootstrap.js'),
+  'utf8'
+);
+
+describe('W941 audit-event bridge — bootstrap source', () => {
+  it('imports getDefault as the singleton handle', () => {
+    expect(BOOT_SRC).toMatch(/getDefault:\s*getQualityBusDefault/);
+  });
+  it('forwards ONLY quality.audit.* (narrow, not a wildcard re-broadcast)', () => {
+    expect(BOOT_SRC).toMatch(/\.on\(\s*'quality\.audit\.\*'/);
+    expect(BOOT_SRC).not.toMatch(/getQualityBusDefault\(\)[\s\S]{0,200}\.on\(\s*'\*'/);
+  });
+  it('guards against a self-emit loop (singleton !== bus)', () => {
+    expect(BOOT_SRC).toMatch(/singleton\s*!==\s*bus/);
+  });
+  it('detaches the bridge on shutdown', () => {
+    expect(BOOT_SRC).toMatch(/_auditBridgeUnsub\?\.\(\)/);
+  });
+});
+
+describe('W941 audit notification policies', () => {
+  it.each([
+    ['quality.audit.scheduled', 'audit.scheduled'],
+    ['quality.audit.nc_recorded', 'audit.nc_recorded'],
+    ['quality.audit.closed', 'audit.closed'],
+  ])('resolves a dedicated policy for %s', (eventName, policyId) => {
+    const ids = resolvePolicies(eventName).map(p => p.id);
+    expect(ids).toContain(policyId);
+  });
+
+  it('routes audit NCs to quality_manager + compliance_officer over email', () => {
+    const p = resolvePolicies('quality.audit.nc_recorded').find(x => x.id === 'audit.nc_recorded');
+    expect(p.recipients.roles).toEqual(
+      expect.arrayContaining(['quality_manager', 'compliance_officer'])
+    );
+    expect(p.channels).toContain('email');
+  });
+});
+
+describe('W941 audit templates render real content', () => {
+  it('audit.closed surfaces the audit number + outcome', () => {
+    const r = render('audit.closed', {
+      auditNumber: 'IA-2026-014',
+      occurrenceId: 'occ1',
+      outcome: 'major_nc',
+      findingsCount: 3,
+    });
+    expect(r.subject).toContain('IA-2026-014');
+    expect(r.body).toMatch(/عدم مطابقة كبرى/);
+    expect(r.body).toContain('3');
+  });
+  it('audit.nc_recorded distinguishes major vs minor', () => {
+    expect(render('audit.nc_recorded', { type: 'major_nc' }).subject).toMatch(/كبرى/);
+    expect(render('audit.nc_recorded', { type: 'minor_nc' }).subject).toMatch(/صغرى/);
+  });
+  it('audit.scheduled is NOT the generic fallback', () => {
+    const r = render('audit.scheduled', { occurrenceId: 'o', riskLevel: 'high' });
+    expect(r.subject).not.toMatch(/^🔔 quality\.audit\.scheduled/);
+    expect(r.subject).toMatch(/تدقيق داخلي مجدول/);
+  });
+});
+
+describe('W941 INTEGRATION — audit event crosses the bridge and is dispatched', () => {
+  it('quality.audit.closed on the singleton bus reaches a router on a different bus', async () => {
+    const singletonBus = createQualityEventBus(); // stands in for getDefault()
+    const routerBus = createQualityEventBus(); // stands in for the bootstrap bus
+
+    const created = [];
+    const logModel = {
+      findOne: () => ({ lean: async () => null }), // never dedup
+      create: async doc => {
+        created.push(doc);
+        return doc;
+      },
+    };
+
+    const router = createNotificationRouter({
+      bus: routerBus,
+      logModel,
+      channels: { email: { send: async () => ({ success: true }) } },
+      resolveRoleRecipients: async () => [
+        { userId: 'u1', email: 'qm@example.com', label: 'QM' },
+      ],
+    });
+    router.start();
+
+    // The exact bridge the bootstrap installs.
+    const unsub = singletonBus.on('quality.audit.*', (payload, name) =>
+      routerBus.emit(name, payload)
+    );
+
+    await singletonBus.emit('quality.audit.closed', {
+      occurrenceId: 'occ-1',
+      auditNumber: 'IA-2026-099',
+      outcome: 'minor_nc',
+      findingsCount: 2,
+    });
+    await singletonBus.flush();
+    await routerBus.flush();
+
+    const emailRow = created.find(c => c.policyId === 'audit.closed' && c.channel === 'email');
+    expect(emailRow).toBeTruthy();
+    expect(emailRow.status).toBe('sent');
+    expect(emailRow.recipient.email).toBe('qm@example.com');
+    expect(emailRow.subject).toContain('IA-2026-099');
+
+    unsub();
+    router.stop();
+  });
+
+  it('without the bridge the same event is NOT delivered (proves the bridge is load-bearing)', async () => {
+    const singletonBus = createQualityEventBus();
+    const routerBus = createQualityEventBus();
+    const created = [];
+    const router = createNotificationRouter({
+      bus: routerBus,
+      logModel: { findOne: () => ({ lean: async () => null }), create: async d => created.push(d) },
+      channels: { email: { send: async () => ({ success: true }) } },
+      resolveRoleRecipients: async () => [{ userId: 'u1', email: 'qm@example.com' }],
+    });
+    router.start();
+    // NO bridge installed.
+    await singletonBus.emit('quality.audit.closed', { auditNumber: 'X' });
+    await singletonBus.flush();
+    await routerBus.flush();
+    expect(created.find(c => c.policyId === 'audit.closed')).toBeFalsy();
+    router.stop();
+  });
+});

--- a/backend/config/notification-policies.registry.js
+++ b/backend/config/notification-policies.registry.js
@@ -197,6 +197,38 @@ const NOTIFICATION_POLICIES = Object.freeze([
     dedupWindowMs: ONE_HOUR,
   },
 
+  // ── Internal Audit (W941) ─────────────────────────────────────
+  // The auditScheduler emits these on qualityEventBus.getDefault(); the
+  // bootstrap installs a one-way `quality.audit.*` bridge to the router's bus
+  // (see qualityComplianceBootstrap "audit-event bridge") so they reach here.
+  {
+    id: 'audit.scheduled',
+    pattern: 'quality.audit.scheduled',
+    recipients: { roles: ['quality_manager'] },
+    channels: ['email'],
+    priority: 'normal',
+    template: 'audit.scheduled',
+    dedupWindowMs: ONE_DAY,
+  },
+  {
+    id: 'audit.nc_recorded',
+    pattern: 'quality.audit.nc_recorded',
+    recipients: { roles: ['quality_manager', 'compliance_officer'] },
+    channels: ['email'],
+    priority: 'high',
+    template: 'audit.nc_recorded',
+    dedupWindowMs: ONE_HOUR,
+  },
+  {
+    id: 'audit.closed',
+    pattern: 'quality.audit.closed',
+    recipients: { roles: ['quality_manager', 'compliance_officer'] },
+    channels: ['email'],
+    priority: 'normal',
+    template: 'audit.closed',
+    dedupWindowMs: ONE_HOUR,
+  },
+
   // ── Catch-all for observability ───────────────────────────────
   {
     id: 'audit.all',

--- a/backend/services/quality/notifications/templates.js
+++ b/backend/services/quality/notifications/templates.js
@@ -218,6 +218,44 @@ ${p.nextReviewScheduledFor ? `• المراجعة التالية: ${when(p.next
 `,
   }),
 
+  // ── Internal Audit (W941) ───────────────────────────────────────
+  'audit.scheduled': p => ({
+    subject: `📋 تدقيق داخلي مجدول`,
+    body: `تم جدولة تدقيق داخلي جديد.
+
+• معرّف التدقيق: ${p.occurrenceId || '—'}
+• التاريخ المخطط: ${p.plannedFor ? when(p.plannedFor) : '—'}
+• مستوى المخاطرة: ${p.riskLevel || '—'}
+
+يرجى الاستعداد وتجهيز الأدلة المطلوبة.
+`,
+  }),
+
+  'audit.nc_recorded': p => ({
+    subject: `⚠️ عدم مطابقة في تدقيق داخلي: ${p.type === 'major_nc' ? 'كبرى' : 'صغرى'}`,
+    body: `سُجّلت حالة عدم مطابقة أثناء تدقيق داخلي.
+
+• معرّف التدقيق: ${p.occurrenceId || '—'}
+• النوع: ${p.type === 'major_nc' ? 'عدم مطابقة كبرى' : p.type === 'minor_nc' ? 'عدم مطابقة صغرى' : p.type || '—'}
+• البند المرجعي: ${p.clauseRef || '—'}
+
+يلزم فتح إجراء تصحيحي (CAPA) ومتابعة المعالجة.
+`,
+  }),
+
+  'audit.closed': p => ({
+    subject: `✅ أُغلق تدقيق داخلي ${p.auditNumber || ''} — ${p.outcome === 'conform' ? 'مطابق' : p.outcome === 'major_nc' ? 'عدم مطابقة كبرى' : p.outcome === 'minor_nc' ? 'عدم مطابقة صغرى' : p.outcome || ''}`,
+    body: `أُغلق تدقيق داخلي.
+
+• رقم التدقيق: ${p.auditNumber || '—'}
+• معرّف التدقيق: ${p.occurrenceId || '—'}
+• النتيجة: ${p.outcome === 'conform' ? 'مطابق' : p.outcome === 'major_nc' ? 'عدم مطابقة كبرى' : p.outcome === 'minor_nc' ? 'عدم مطابقة صغرى' : p.outcome || '—'}
+• عدد الملاحظات: ${p.findingsCount ?? 0}
+
+يمكن الاطلاع على التقرير الكامل عبر لوحة الجودة.
+`,
+  }),
+
   // ── Generic fallback ────────────────────────────────────────────
   generic: (p, eventName) => ({
     subject: `🔔 ${eventName || 'حدث جودة'}`,

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -710,3 +710,4 @@ __tests__/icf-assessment-create-assessor-wave930.test.js
 __tests__/branch-scope-user-enrich-wave930.test.js
 __tests__/form-save-bridge-complaints-groups-wave930.test.js
 __tests__/reporting-webhooks-wiring-wave933.test.js
+__tests__/quality-audit-notify-wave941.test.js

--- a/backend/startup/qualityComplianceBootstrap.js
+++ b/backend/startup/qualityComplianceBootstrap.js
@@ -62,7 +62,10 @@ const {
 const {
   createComplianceCalendarAlertSweeper,
 } = require('../services/quality/complianceCalendarAlertSweeper.service');
-const { createQualityEventBus } = require('../services/quality/qualityEventBus.service');
+const {
+  createQualityEventBus,
+  getDefault: getQualityBusDefault,
+} = require('../services/quality/qualityEventBus.service');
 const { createCapaAgingScheduler } = require('../services/quality/capaAgingScheduler.service');
 const {
   createRiskReassessmentScheduler,
@@ -230,6 +233,7 @@ function bootstrapQualityCompliance({
   // NotificationLog or emailService are unavailable, we skip
   // quietly rather than blocking bootstrap.
   let notificationRouter = null;
+  let _auditBridgeUnsub = null;
   try {
     const NotificationLog = require('../models/quality/NotificationLog.model');
     notificationRouter = createNotificationRouter({
@@ -298,6 +302,32 @@ function bootstrapQualityCompliance({
     if (notificationRouter) {
       try {
         notificationRouter.start();
+        // ── W941 — audit-event bridge ───────────────────────────────
+        // The auditScheduler (and other lazy quality services) emit on
+        // qualityEventBus.getDefault() — the SINGLETON — while this router
+        // subscribes to `bus`, the fresh instance created above. That two-bus
+        // split left quality.audit.scheduled/nc_recorded/closed with NO email
+        // path (the W349/W387 silent-no-op class). We forward ONLY
+        // `quality.audit.*` one-way from the singleton to the router's bus: the
+        // narrowest fix that delivers audit notifications WITHOUT disturbing
+        // phase29-subscribers (which stay on getDefault) or activating unrelated
+        // cross-bus flows. The `singleton !== bus` guard prevents a self-emit
+        // loop in the (future) case the two buses are unified.
+        try {
+          const singleton = getQualityBusDefault();
+          if (singleton && singleton !== bus && typeof singleton.on === 'function') {
+            _auditBridgeUnsub = singleton.on('quality.audit.*', (payload, name) => {
+              try {
+                bus.emit(name, payload);
+              } catch (e) {
+                logger.warn(`[QMS] audit-event bridge emit failed: ${e.message}`);
+              }
+            });
+            logger.info('[QMS] W941 audit-event bridge installed (getDefault → router bus)');
+          }
+        } catch (bridgeErr) {
+          logger.warn(`[QMS] audit-event bridge install failed: ${bridgeErr.message}`);
+        }
       } catch (err) {
         logger.warn(`[QMS] notification router failed to start: ${err.message}`);
       }
@@ -346,6 +376,11 @@ function bootstrapQualityCompliance({
     }
     try {
       notificationRouter?.stop();
+    } catch {
+      /* ignore */
+    }
+    try {
+      _auditBridgeUnsub?.(); // W941 — detach the audit-event bridge
     } catch {
       /* ignore */
     }


### PR DESCRIPTION
## What

Quality managers were **never emailed** when an internal audit was scheduled, recorded a non-conformity, or closed — even though the audit events fire and the notification router exists.

**Root cause (a two-bus disconnect):** the auditScheduler (and other lazy quality services) emit on `qualityEventBus.getDefault()` — the **singleton** — while the email notification router subscribes to the **fresh** bus created inside `qualityComplianceBootstrap`. So `quality.audit.scheduled/nc_recorded/closed` never reached the router. This is the W349/W387 silent-no-op class: the event fired, but to a bus with no email subscriber. (Adding a policy alone — the obvious fix — would have done nothing.)

## How — the narrowest safe fix

The full bus unification has a startup-ordering hazard (could orphan `phase29-subscribers`' auto-CAPA) and overlaps active core event-wiring work. So instead, the bootstrap installs a **one-way `quality.audit.*` bridge** from the singleton to the router's bus, right after the router starts:

- **audit-only + one-directional** → `phase29-subscribers` (auto-CAPA, on `getDefault`) are untouched, no regression;
- **no unrelated cross-bus flows** are activated;
- a `singleton !== bus` guard prevents a self-emit loop;
- detached on shutdown.

Plus the 3 missing policies (`audit.scheduled` → quality_manager; `audit.nc_recorded` + `audit.closed` → quality_manager + compliance_officer) and their Arabic email templates, matching the existing management-review pattern.

## Tests (13)

- **static** — the bridge is narrow (`quality.audit.*`, not `*`), one-way, loop-guarded, detached on shutdown;
- **policy** — `resolvePolicies()` returns a dedicated policy for each of the 3 events;
- **template** — `render()` produces real (non-generic) Arabic subject/body;
- **INTEGRATION (W387 lesson)** — emit `quality.audit.closed` on bus A, prove it crosses the bridge to a router on bus B and is dispatched (NotificationLog row, status `sent`, correct recipient + subject), **plus a negative control** proving the bridge is load-bearing.

`phase29-subscribers` suite stays green. Pure-JS tests (real bus + router, fake logModel/channel), no DB.

## Gates

`check:routes-load` ✓ · `check:sprint-paths` ✓ · bootstrap loads clean · W941 collision-free (pushed with `CHECK_WAVE_SKIP=1` only for pre-existing squash-merge wave-dupes on main). Additive: +276 / -1.

> Note: this is the targeted fix. The deeper two-bus unification (so fmea/coq/calibration notifications also reach the router) is documented as a follow-up — it needs the startup-ordering analysis + coordination with the in-flight core event-wiring work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)