### PR TITLE
chore(drift-guards): W972 ratchet-down dormant baseline — reporting webhookHandler now wired

### DIFF
--- a/backend/__tests__/check-dormant-modules-script.test.js
+++ b/backend/__tests__/check-dormant-modules-script.test.js
@@ -249,7 +249,7 @@ describe('check-dormant-modules — baseline + skip structures', () => {
     expect(KNOWN_DORMANT_BASELINE).toBeInstanceOf(Set);
   });
 
-  it('baseline holds 11 entries (W825 wired hr-webhooks; W527 held 7)', () => {
+  it('baseline holds 10 entries (W933/W941 wired reporting webhookHandler; W825 hr-webhooks)', () => {
     // When a module is wired-up or deleted, drop it here AND from the
     // baseline in the same commit. Bumping this number without a
     // corresponding source change should fail the CLI contract below.
@@ -257,7 +257,8 @@ describe('check-dormant-modules — baseline + skip structures', () => {
     // W526: 6 dead flat documentXService.js duplicates deleted → 28→22.
     // W527: 10 bulk-import orphans deleted → 22→12 (5 CLI_TOOL + 7 held).
     // W825: hr-webhooks.routes.js mounted via hr.registry → 12→11.
-    expect(KNOWN_DORMANT_BASELINE.size).toBe(11);
+    // W933/W941: reporting/webhookHandler.js wired via reports-webhooks self-init → 11→10.
+    expect(KNOWN_DORMANT_BASELINE.size).toBe(10);
   });
 
   it('every baseline entry uses POSIX paths (no backslashes, no absolute paths)', () => {

--- a/backend/scripts/check-dormant-modules.js
+++ b/backend/scripts/check-dormant-modules.js
@@ -167,7 +167,9 @@ const KNOWN_DORMANT_BASELINE = new Set([
   'services/gpsSecurityService.js', // entangled w/ W440 security drift-guard (verifyAPIKey timing-safe)
   'services/isolationForest.service.js', // deliberate Phase16-18 ship — anomaly ML; wire OR delete
   'services/rehabilitation/RehabService.js', // deliberate module add; rehab system is fragmented (future ADR)
-  'services/reporting/webhookHandler.js', // Phase10 "delivered/read receipts end-to-end" — wire-up likely missed
+  // services/reporting/webhookHandler.js — RATCHETED-DOWN 2026-06-05 (W933/W941):
+  //   wired via routes/reports-webhooks.routes.js self-init when ENABLE_REPORT_WEBHOOKS=true
+  //   (real WebhookHandler bound to ReportDelivery). No longer dormant.
 ]);
 
 function walk(rootAbs, accept) {


### PR DESCRIPTION
## What

W933/W941 wired `services/reporting/webhookHandler.js` (real `WebhookHandler` bound to `ReportDelivery`, activated via `routes/reports-webhooks.routes.js` self-init when `ENABLE_REPORT_WEBHOOKS=true`), so it's no longer dormant. The `check:dormant-modules` scanner correctly flagged it as a **stale baseline entry** (exit 1).

Per the **W325c ratchet-down discipline** (remove from baseline in the same spirit as the fix), this drops it from `KNOWN_DORMANT_BASELINE` and updates the self-test count `11 → 10`.

## Result

- Scanner now exits 0: `Dormant: 10, baseline: 10, no stale entries`.
- Self-test: **37/37** pass.
- Bonus signal: confirms the parallel agent's W946–W970 introduced **no new dormant** routes/services.

Tiny, mechanical, no runtime change (+6/-3). No new test file → no sprint-tests/yml change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)