### PR TITLE
feat(care-plan): W973 schedule the dormant care-plan background workers

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1223,6 +1223,8 @@ on:
       - 'backend/__tests__/care-plan-completed-timeline-subscriber-wave947.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/appointments-core-linkage-wave970.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/care-plan-workers-bootstrap-wave973.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2429,6 +2431,8 @@ on:
       - 'backend/__tests__/care-plan-completed-timeline-subscriber-wave947.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/appointments-core-linkage-wave970.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/care-plan-workers-bootstrap-wave973.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/care-plan-workers-bootstrap-wave973.test.js
+++ b/backend/__tests__/care-plan-workers-bootstrap-wave973.test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+/**
+ * W973 drift guard — carePlanWorkersBootstrap.
+ *
+ * Schedules the dormant care-plan background workers (overdue-review scanner W50
+ * + family-retry worker W45). Both expose runOnce() and explicitly leave
+ * scheduling to the caller; nothing did, so they were dead (W225 pattern).
+ *
+ * Locks: env-gated default OFF; throws without logger/app; graceful skip when
+ * the engine didn't mount (app._carePlanWorkers absent); schedules both workers
+ * when enabled; each scheduled tick invokes the worker's runOnce; wired into
+ * app.js; carePlanningBootstrap exposes the workers.
+ *
+ * node-cron is mocked so no real timers leak.
+ */
+
+jest.mock('node-cron', () => ({ schedule: jest.fn(() => ({ stop() {} })) }));
+const cron = require('node-cron');
+
+const fs = require('fs');
+const path = require('path');
+const { wireCarePlanWorkers } = require('../startup/carePlanWorkersBootstrap');
+
+const SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'startup', 'carePlanWorkersBootstrap.js'),
+  'utf8'
+);
+const APP_SRC = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+const CPB_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'startup', 'carePlanningBootstrap.js'),
+  'utf8'
+);
+
+const silent = { info() {}, warn() {}, error() {} };
+
+afterEach(() => {
+  delete process.env.ENABLE_CARE_PLAN_WORKERS;
+  cron.schedule.mockClear();
+});
+
+describe('W973 carePlanWorkersBootstrap — source shape', () => {
+  it('env-gates on ENABLE_CARE_PLAN_WORKERS', () => {
+    expect(SRC).toMatch(/process\.env\.ENABLE_CARE_PLAN_WORKERS\s*!==\s*'true'/);
+  });
+  it('invokes runOnce on both workers', () => {
+    expect(SRC).toMatch(/workers\.overdueReview[\s\S]{0,80}\.runOnce\(/);
+    expect(SRC).toMatch(/workers\.familyRetry[\s\S]{0,80}\.runOnce\(/);
+  });
+  it('loads node-cron via loadOptional', () => {
+    expect(SRC).toMatch(/loadOptional\(\s*'node-cron'\s*\)/);
+  });
+  it('guards each tick (a worker throw never escapes)', () => {
+    expect(SRC).toMatch(/catch \(err\)/);
+  });
+  it('exports wireCarePlanWorkers', () => {
+    expect(SRC).toMatch(/module\.exports\s*=\s*\{\s*wireCarePlanWorkers\s*\}/);
+  });
+});
+
+describe('W973 — wiring', () => {
+  it('app.js wires wireCarePlanWorkers after carePlanning', () => {
+    expect(APP_SRC).toMatch(
+      /carePlanWorkersBootstrap'\)\.wireCarePlanWorkers\(app,\s*\{\s*logger\s*\}\)/
+    );
+    // ordering: carePlanning mount precedes the worker scheduler
+    expect(APP_SRC.indexOf('wireCarePlanning(app')).toBeLessThan(
+      APP_SRC.indexOf('wireCarePlanWorkers(app')
+    );
+  });
+  it('carePlanningBootstrap exposes app._carePlanWorkers', () => {
+    expect(CPB_SRC).toMatch(/app\._carePlanWorkers\s*=\s*careplan\.workers/);
+  });
+});
+
+describe('W973 — behavior', () => {
+  it('throws without logger', () => {
+    expect(() => wireCarePlanWorkers({}, {})).toThrow(/app \+ logger required/);
+  });
+
+  it('is inert when the flag is unset (no cron scheduled)', () => {
+    const res = wireCarePlanWorkers({ _carePlanWorkers: {} }, { logger: silent });
+    expect(res).toEqual({ started: false });
+    expect(cron.schedule).not.toHaveBeenCalled();
+  });
+
+  it('skips gracefully when the engine did not mount (no app._carePlanWorkers)', () => {
+    process.env.ENABLE_CARE_PLAN_WORKERS = 'true';
+    const res = wireCarePlanWorkers({}, { logger: silent });
+    expect(res).toEqual({ started: false });
+    expect(cron.schedule).not.toHaveBeenCalled();
+  });
+
+  it('schedules both workers when enabled, and each tick calls runOnce', async () => {
+    process.env.ENABLE_CARE_PLAN_WORKERS = 'true';
+    const overdueReview = { runOnce: jest.fn(async () => ({ scanned: 1, overdue: 0 })) };
+    const familyRetry = { runOnce: jest.fn(async () => ({ retried: 0 })) };
+    const app = { _carePlanWorkers: { overdueReview, familyRetry } };
+
+    const res = wireCarePlanWorkers(app, { logger: silent });
+    expect(res.started).toBe(true);
+    expect(res.scheduled).toEqual(expect.arrayContaining(['overdueReview', 'familyRetry']));
+    expect(cron.schedule).toHaveBeenCalledTimes(2);
+
+    // Invoke each registered cron callback → proves the wiring calls runOnce.
+    for (const call of cron.schedule.mock.calls) {
+      const tick = call[1];
+      await tick();
+    }
+    expect(overdueReview.runOnce).toHaveBeenCalledTimes(1);
+    expect(familyRetry.runOnce).toHaveBeenCalledTimes(1);
+  });
+
+  it('a worker throw inside a tick is swallowed (never rejects)', async () => {
+    process.env.ENABLE_CARE_PLAN_WORKERS = 'true';
+    const overdueReview = {
+      runOnce: jest.fn(async () => {
+        throw new Error('boom');
+      }),
+    };
+    const app = { _carePlanWorkers: { overdueReview } };
+    wireCarePlanWorkers(app, { logger: silent });
+    const tick = cron.schedule.mock.calls[0][1];
+    await expect(tick()).resolves.toBeUndefined();
+  });
+});

--- a/backend/app.js
+++ b/backend/app.js
@@ -2302,6 +2302,12 @@ try {
 // Identical behaviour: same bootstrapCarePlanning() call, same dep-loading order,
 // same /api/v1/care-plans mount, same 7 app._carePlanXxx references.
 require('./startup/carePlanningBootstrap').wireCarePlanning(app, { logger });
+// W973 — schedule the dormant care-plan background workers (overdue-review
+// scanner W50 + family-retry worker W45). They expose runOnce() and explicitly
+// leave scheduling to the caller; nothing did, so they were dead. Env-gated,
+// default OFF (ENABLE_CARE_PLAN_WORKERS=true). Runs after carePlanning so
+// app._carePlanWorkers is populated.
+require('./startup/carePlanWorkersBootstrap').wireCarePlanWorkers(app, { logger });
 
 // ─── Therapist Portal ─────────────────────────────────────────────────────────
 try {

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -721,3 +721,4 @@ __tests__/vehicle-create-branch-hook-wave933.test.js
 __tests__/employee-create-route-hook-wave933.test.js
 __tests__/purchase-order-create-branch-wave933.test.js
 __tests__/appointments-core-linkage-wave970.test.js
+__tests__/care-plan-workers-bootstrap-wave973.test.js

--- a/backend/startup/carePlanWorkersBootstrap.js
+++ b/backend/startup/carePlanWorkersBootstrap.js
@@ -1,0 +1,115 @@
+'use strict';
+
+/**
+ * carePlanWorkersBootstrap.js — W973.
+ *
+ * Schedules the DORMANT care-plan background workers built by
+ * `intelligence/care-plan-bootstrap.js::bootstrapCarePlanning()`:
+ *
+ *   • overdueReview (Wave 50) — scans for care-plan reviews past their due
+ *     date and notifies the responsible audience via the wired notifier.
+ *   • familyRetry (Wave 45) — retries failed family-notification attempts with
+ *     exponential backoff (inert unless a family channel is wired, but the
+ *     scan is harmless and completes the wiring for when one is).
+ *
+ * Both workers expose a `runOnce({ now })` contract and DELIBERATELY do not
+ * spawn their own interval — their own doc-comments say "caller (cron /
+ * job-queue) invokes runOnce". Nothing ever did, so they were dead (W225
+ * dormant-capability pattern). carePlanningBootstrap now exposes them on
+ * `app._carePlanWorkers`; this is the missing scheduler.
+ *
+ * GATED OFF BY DEFAULT (ENABLE_CARE_PLAN_WORKERS=true). Ships inert — nothing
+ * runs until an operator opts in. Fully guarded: a worker throw is caught
+ * per-tick and never breaks boot or the other worker.
+ *
+ * Env:
+ *   ENABLE_CARE_PLAN_WORKERS         — 'true' to schedule (default: OFF)
+ *   CARE_PLAN_OVERDUE_REVIEW_CRON    — cron expr (default = daily 07:00 Asia/Riyadh)
+ *   CARE_PLAN_FAMILY_RETRY_CRON      — cron expr (default = every 15 minutes)
+ */
+
+function loadOptional(modulePath) {
+  try {
+    return require(modulePath);
+  } catch {
+    return null;
+  }
+}
+
+function wireCarePlanWorkers(app, deps = {}) {
+  const { logger } = deps;
+  if (!app || !logger) {
+    throw new Error('carePlanWorkersBootstrap.wireCarePlanWorkers: app + logger required');
+  }
+
+  if (process.env.ENABLE_CARE_PLAN_WORKERS !== 'true') {
+    logger.info(
+      '[startup] care-plan workers disabled (set ENABLE_CARE_PLAN_WORKERS=true to schedule overdue-review + family-retry)'
+    );
+    return { started: false };
+  }
+
+  const workers = app._carePlanWorkers;
+  if (!workers) {
+    // Care-planning engine didn't mount (no CarePlanVersion / governance) —
+    // nothing to schedule. Degrade quietly; the engine logs its own skip.
+    logger.warn('[startup] care-plan workers not available (engine not mounted); scheduler skipped');
+    return { started: false };
+  }
+
+  const cron = loadOptional('node-cron');
+  if (!cron) {
+    logger.warn('[startup] node-cron not available; care-plan workers not scheduled');
+    return { started: false };
+  }
+
+  const TZ = { timezone: 'Asia/Riyadh' };
+  const overdueCron = process.env.CARE_PLAN_OVERDUE_REVIEW_CRON || '0 7 * * *';
+  const familyCron = process.env.CARE_PLAN_FAMILY_RETRY_CRON || '*/15 * * * *';
+  const scheduled = [];
+
+  // overdue-review scanner — daily.
+  if (workers.overdueReview && typeof workers.overdueReview.runOnce === 'function') {
+    cron.schedule(
+      overdueCron,
+      async () => {
+        try {
+          const res = await workers.overdueReview.runOnce({ now: new Date() });
+          logger.info(
+            `[care-plan] overdue-review scan: scanned=${(res && res.scanned) ?? '?'} overdue=${(res && res.overdue) ?? '?'}`
+          );
+        } catch (err) {
+          logger.error('[care-plan] overdue-review scan failed', { error: err && err.message });
+        }
+      },
+      TZ
+    );
+    scheduled.push('overdueReview');
+  }
+
+  // family-retry worker — every 15 min (its own backoff decides eligibility).
+  if (workers.familyRetry && typeof workers.familyRetry.runOnce === 'function') {
+    cron.schedule(
+      familyCron,
+      async () => {
+        try {
+          const res = await workers.familyRetry.runOnce({ now: new Date() });
+          logger.info(
+            `[care-plan] family-retry: retried=${(res && res.retried) ?? '?'} succeeded=${(res && res.succeeded) ?? '?'} failed=${(res && res.failed) ?? '?'}`
+          );
+        } catch (err) {
+          logger.error('[care-plan] family-retry failed', { error: err && err.message });
+        }
+      },
+      TZ
+    );
+    scheduled.push('familyRetry');
+  }
+
+  logger.info(
+    `[startup] W973 care-plan workers scheduled (${scheduled.join(', ') || 'none'}; overdue '${overdueCron}', family '${familyCron}' Asia/Riyadh)`
+  );
+  return { started: scheduled.length > 0, scheduled };
+}
+
+module.exports = { wireCarePlanWorkers };

--- a/backend/startup/carePlanningBootstrap.js
+++ b/backend/startup/carePlanningBootstrap.js
@@ -145,6 +145,11 @@ function wireCarePlanning(app, deps = {}) {
         app._carePlanRoleViews = careplan.roleViews;
         app._carePlanGroupService = careplan.groupPlan;
         app._carePlanProgramsLibrary = careplan.programsLibrary;
+        // W973 — expose the background workers (overdue-review scanner W50 +
+        // family-retry worker W45). bootstrapCarePlanning builds them with a
+        // `runOnce()` contract and explicitly leaves scheduling to the caller;
+        // startup/carePlanWorkersBootstrap.js consumes this (env-gated, default OFF).
+        app._carePlanWorkers = careplan.workers;
 
         logger.info(
           '[CarePlan] ✓ Engine mounted at /api/v1/care-plans (Waves 41–48: 24 endpoints, ' +


### PR DESCRIPTION
## What

`bootstrapCarePlanning()` builds two background workers — the **overdue-review scanner** (Wave 50) and the **family-retry worker** (Wave 45) — each with a `runOnce()` contract whose own doc-comments say *"caller (cron/job-queue) invokes runOnce"*. But the caller (`carePlanningBootstrap`) never captured `careplan.workers` and nothing scheduled them, so both were **dead** (W225 dormant-capability pattern): overdue care-plan reviews were never swept + notified, and failed family notifications were never retried.

## How

- `carePlanningBootstrap` now exposes `app._carePlanWorkers = careplan.workers`.
- New `startup/carePlanWorkersBootstrap.js` schedules `overdueReview` (daily) + `familyRetry` (every 15 min) via `runOnce()` on node-cron (Asia/Riyadh).
- `app.js` wires it right after carePlanning so `app._carePlanWorkers` is populated.

## Safety

- **Env-gated, default OFF** (`ENABLE_CARE_PLAN_WORKERS=true`) — ships inert.
- **Fully guarded**: graceful skip if the engine didn't mount (no `app._carePlanWorkers`) or node-cron is absent; a worker throw inside a tick is caught and never escapes boot or the other worker.
- `overdueReview` notifies via the already-wired `unifiedNotifier`; `familyRetry` stays inert unless a family channel is later wired (its scan is harmless). Cadence overridable via `CARE_PLAN_OVERDUE_REVIEW_CRON` / `CARE_PLAN_FAMILY_RETRY_CRON`.

## Tests (12)

env-gated inert default; throws without app+logger; graceful no-workers skip; schedules both when enabled; **each tick invokes `runOnce`**; a tick throw is swallowed; wired into app.js (after carePlanning); workers exposed. node-cron mocked so no real timers leak. Enumerated in `sprint-tests.txt`.

## Gates

`check:routes-load` ✓ · `check:sprint-paths` ✓ · care-plan engine still loads · W973 collision-free (`CHECK_WAVE_SKIP=1` only for pre-existing squash-merge wave-dupes on main). Additive: +257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)