### PR TITLE
feat(quality): W974 unify the quality event bus (root-cause fix for the two-bus disconnect)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1225,6 +1225,8 @@ on:
       - 'backend/__tests__/appointments-core-linkage-wave970.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/care-plan-workers-bootstrap-wave973.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/quality-bus-unification-wave974.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2433,6 +2435,8 @@ on:
       - 'backend/__tests__/appointments-core-linkage-wave970.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/care-plan-workers-bootstrap-wave973.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/quality-bus-unification-wave974.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/quality-bus-unification-wave974.test.js
+++ b/backend/__tests__/quality-bus-unification-wave974.test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+/**
+ * W974 — quality event-bus unification.
+ *
+ * Root-cause fix for the two-bus disconnect (W941 was a quality.audit.*-only
+ * stopgap bridge): qualityComplianceBootstrap now uses the SINGLETON bus
+ * (qualityEventBus.getDefault()) instead of a fresh createQualityEventBus(),
+ * so the lazy quality services (auditScheduler/fmea/coq/calibration/...) and
+ * phase29-subscribers (server.js) — which all use getDefault() — share ONE bus
+ * with the notification router + ncrPipeline. Order-independent (no re-seat).
+ *
+ * Coverage:
+ *   1. static — bootstrap binds `bus` to getDefault(), no longer createQualityEventBus.
+ *   2. INTEGRATION — a producer emitting on getDefault() reaches a router
+ *      subscribed via getDefault() (audit policy fires WITHOUT any bridge);
+ *      a previously-orphaned lazy event (fmea.*) now reaches the router (console
+ *      catch-all only — no surprise email); a coexisting phase29-style subscriber
+ *      still receives its event (auto-CAPA path intact); no double-dispatch.
+ *
+ * Uses _replaceDefault to install an isolated singleton for the test, restored after.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const busMod = require('../services/quality/qualityEventBus.service');
+const {
+  createNotificationRouter,
+} = require('../services/quality/notifications/notificationRouter.service');
+
+const BOOT_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'startup', 'qualityComplianceBootstrap.js'),
+  'utf8'
+);
+
+describe('W974 unification — bootstrap source', () => {
+  it('binds the bus to the singleton getDefault()', () => {
+    expect(BOOT_SRC).toMatch(/const bus = getQualityBusDefault\(\)/);
+  });
+  it('no longer creates a fresh bus via createQualityEventBus', () => {
+    expect(BOOT_SRC).not.toMatch(/createQualityEventBus/);
+  });
+});
+
+describe('W974 unification — integration on the singleton bus', () => {
+  let original;
+  let isolated;
+
+  beforeEach(() => {
+    original = busMod.getDefault();
+    isolated = busMod.createQualityEventBus();
+    busMod._replaceDefault(isolated); // getDefault() now returns `isolated`
+  });
+  afterEach(() => {
+    busMod._replaceDefault(original);
+  });
+
+  function buildRouterOnDefault(created) {
+    const logModel = {
+      findOne: () => ({ lean: async () => null }),
+      create: async doc => {
+        created.push(doc);
+        return doc;
+      },
+    };
+    const router = createNotificationRouter({
+      bus: busMod.getDefault(), // the bootstrap now does exactly this
+      logModel,
+      channels: { email: { send: async () => ({ success: true }) } },
+      resolveRoleRecipients: async () => [{ userId: 'u1', email: 'qm@example.com' }],
+    });
+    router.start();
+    return router;
+  }
+
+  it('audit.closed emitted on getDefault() reaches the router — no bridge needed', async () => {
+    const created = [];
+    const router = buildRouterOnDefault(created);
+
+    // A producer (auditScheduler-style) emits on the SAME getDefault() singleton.
+    await busMod.getDefault().emit('quality.audit.closed', {
+      occurrenceId: 'o1',
+      auditNumber: 'IA-974',
+      outcome: 'minor_nc',
+      findingsCount: 1,
+    });
+    await busMod.getDefault().flush();
+
+    const emailRow = created.find(c => c.policyId === 'audit.closed' && c.channel === 'email');
+    expect(emailRow).toBeTruthy();
+    expect(emailRow.subject).toContain('IA-974');
+    // exactly one email row for this policy → no double-dispatch
+    expect(created.filter(c => c.policyId === 'audit.closed' && c.channel === 'email').length).toBe(1);
+    router.stop();
+  });
+
+  it('a previously-orphaned lazy event (fmea.*) now reaches the router — console only, no email', async () => {
+    const created = [];
+    const router = buildRouterOnDefault(created);
+
+    await busMod.getDefault().emit('quality.fmea.high_priority_detected', { fmeaId: 'f1' });
+    await busMod.getDefault().flush();
+
+    // reaches the router via the '*' catch-all (console), NOT any email policy
+    expect(created.some(c => c.policyId === 'audit.all' && c.channel === 'console')).toBe(true);
+    expect(created.some(c => c.channel === 'email')).toBe(false); // no surprise email
+    router.stop();
+  });
+
+  it('a coexisting phase29-style subscriber on getDefault() still receives its event', async () => {
+    const created = [];
+    const router = buildRouterOnDefault(created);
+    const phase29 = [];
+    const unsub = busMod.getDefault().on('quality.audit.nc_recorded', payload => {
+      phase29.push(payload); // stands in for the auto-CAPA subscriber
+    });
+
+    await busMod.getDefault().emit('quality.audit.nc_recorded', { occurrenceId: 'o2', type: 'major_nc' });
+    await busMod.getDefault().flush();
+
+    // both the router (email policy) AND the phase29 subscriber fired
+    expect(phase29).toHaveLength(1);
+    expect(phase29[0].type).toBe('major_nc');
+    expect(created.some(c => c.policyId === 'audit.nc_recorded')).toBe(true);
+
+    unsub();
+    router.stop();
+  });
+});

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -722,3 +722,4 @@ __tests__/employee-create-route-hook-wave933.test.js
 __tests__/purchase-order-create-branch-wave933.test.js
 __tests__/appointments-core-linkage-wave970.test.js
 __tests__/care-plan-workers-bootstrap-wave973.test.js
+__tests__/quality-bus-unification-wave974.test.js

--- a/backend/startup/qualityComplianceBootstrap.js
+++ b/backend/startup/qualityComplianceBootstrap.js
@@ -62,10 +62,7 @@ const {
 const {
   createComplianceCalendarAlertSweeper,
 } = require('../services/quality/complianceCalendarAlertSweeper.service');
-const {
-  createQualityEventBus,
-  getDefault: getQualityBusDefault,
-} = require('../services/quality/qualityEventBus.service');
+const { getDefault: getQualityBusDefault } = require('../services/quality/qualityEventBus.service');
 const { createCapaAgingScheduler } = require('../services/quality/capaAgingScheduler.service');
 const {
   createRiskReassessmentScheduler,
@@ -105,7 +102,22 @@ function bootstrapQualityCompliance({
   //       service below. If the caller injected a dispatcher, we
   //       wrap it so both the external sink and in-process
   //       subscribers receive events.
-  const bus = createQualityEventBus({ logger });
+  //
+  // W974 — use the SINGLETON bus (getDefault). The lazy quality services
+  // (auditScheduler / fmea / coq / calibration / changeControl /
+  // controlledDocument / inspectionSubmission / paretoA3 / capa-producers) set
+  // their dispatcher to qualityEventBus.getDefault(), and phase29-subscribers
+  // (server.js) subscribe to getDefault(). This bootstrap previously created a
+  // FRESH bus, so the notification router + ncrPipeline lived on a DIFFERENT bus
+  // than those producers/subscribers → their events never reached the router
+  // (the W349/W387 silent-no-op class; W941 bridged quality.audit.* as a stopgap).
+  // Using getDefault() unifies everything onto one bus. This is ORDER-INDEPENDENT
+  // (getDefault always returns the same singleton; no re-seat, so no startup-
+  // ordering hazard that could orphan phase29's auto-CAPA). The W941 bridge below
+  // self-disables under unification via its `singleton !== bus` guard.
+  const bus = getQualityBusDefault();
+  if (logger && bus && bus.logger === console) bus.logger = logger; // preserve structured logging
+
   const combinedDispatcher = dispatcher
     ? {
         async emit(name, payload) {


### PR DESCRIPTION
## What

Root-cause fix for the quality two-bus disconnect (W941 was an audit-only stopgap bridge; see `docs/architecture/QUALITY_EVENT_BUS_FINDINGS_2026-06-05.md`).

`qualityComplianceBootstrap` created a **fresh** `createQualityEventBus()` for the notification router + ncrPipeline, while the lazy quality services (auditScheduler / fmea / coq / calibration / changeControl / controlledDocument / inspectionSubmission / paretoA3 / capa-producers) dispatch on `qualityEventBus.getDefault()` (the singleton) and phase29-subscribers (server.js) subscribe on `getDefault()` too. **Two buses** → the router never heard the lazy services' events (the W349/W387 silent-no-op class).

## How

The bootstrap now binds `bus` to **`getDefault()`** — one bus for every producer, subscriber, the router, and ncrPipeline. This is **order-independent** (getDefault always returns the same singleton; no `_replaceDefault` re-seat, so no startup-ordering hazard that could orphan phase29's auto-CAPA). The W941 bridge **self-disables** under unification via its existing `singleton !== bus` guard.

## Blast radius — verified SAFE

The newly-connected lazy events (`quality.calibration.*`/`fmea.*`/`coq.*`/`doc.*`/`change.*`/`inspection.*`/`corrective_action_required`) match **no email policy** — they hit only the `*` console catch-all. **No surprise emails, no state mutation**; phase29 (already on the singleton) + ncrPipeline are unaffected; the router's NotificationLog dedup guards duplicates.

## Tests (5) + regression

Static (bus bound to `getDefault`, `createQualityEventBus` gone) + integration on the singleton: `audit.closed` emitted on `getDefault()` reaches the router with **no bridge** (one email row, no double-dispatch); a previously-orphaned `fmea.*` event now reaches the router via console catch-all (**no email**); a coexisting phase29-style subscriber still receives its event (**auto-CAPA path intact**). Regression sweep `quality-audit-notify-w941 + phase29-subscribers + notification-router + this = 45/45`. eslint clean, routes-load clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)