### PR TITLE
feat(core): W974 resurrect the modelEventBridge (env-gated pre-compile global plugin)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1227,6 +1227,8 @@ on:
       - 'backend/__tests__/care-plan-workers-bootstrap-wave973.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/quality-bus-unification-wave974.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/model-event-bridge-global-plugin-wave974.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2437,6 +2439,8 @@ on:
       - 'backend/__tests__/care-plan-workers-bootstrap-wave973.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/quality-bus-unification-wave974.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/model-event-bridge-global-plugin-wave974.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/model-event-bridge-global-plugin-wave974.test.js
+++ b/backend/__tests__/model-event-bridge-global-plugin-wave974.test.js
@@ -1,0 +1,195 @@
+'use strict';
+
+/**
+ * model-event-bridge-global-plugin-wave974.test.js — W974.
+ *
+ * Resurrects the modelEventBridge. The W394 `wireModelEventBridge` attached
+ * schema.post('save') hooks at STARTUP — after app.js had already compiled the
+ * models — so they NEVER FIRED (Mongoose bakes middleware in at compile time;
+ * hooks added afterwards are ignored). All 16 LIVE-registry producers were dead.
+ *
+ * The fix is a GLOBAL mongoose plugin registered (env-gated) BEFORE any model
+ * compiles; at save-time it dispatches by `this.constructor.modelName`. This
+ * test proves the mechanism end-to-end against a real in-memory Mongo using
+ * synthetic models compiled UNDER THE REAL MODEL NAMES, exercising every
+ * trigger kind (create-only / status-flip / status-flip-any / predicate) and
+ * asserting the canonical event publishes with the mapped payload — plus the
+ * env gate and the fast-skip for unmapped models.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mockPublish = jest.fn().mockResolvedValue(undefined);
+jest.mock('../integration/systemIntegrationBus', () => ({
+  integrationBus: { publish: (...a) => mockPublish(...a) },
+}));
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let Employee, Invoice, Beneficiary, ClinicalSession, RiskSnapshot, Unmapped;
+
+function published(eventType) {
+  return mockPublish.mock.calls.find(c => c[1] === eventType);
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w974-bridge' } });
+  await mongoose.connect(mongod.getUri());
+
+  // Enable + register the GLOBAL plugin BEFORE compiling any model.
+  process.env.ENABLE_MODEL_EVENT_BRIDGE = 'true';
+  const { registerModelEventBridgePlugin } = require('../integration/modelEventBridge');
+  const res = registerModelEventBridgePlugin();
+  expect(res.registered).toBe(true);
+
+  // Synthetic schemas compiled UNDER THE REAL MAPPED NAMES (the plugin keys on
+  // modelName). Fields cover what each mapping's payload() reads.
+  Employee = mongoose.model(
+    'Employee',
+    new mongoose.Schema({
+      fullName: String,
+      department: String,
+      position: String,
+      contractType: String,
+      status: { type: String, default: 'active' },
+      terminationReason: String,
+      baseSalary: Number,
+    })
+  );
+  Invoice = mongoose.model(
+    'Invoice',
+    new mongoose.Schema({
+      beneficiaryId: mongoose.Schema.Types.ObjectId,
+      amount: Number,
+      currency: String,
+    })
+  );
+  Beneficiary = mongoose.model(
+    'Beneficiary',
+    new mongoose.Schema({
+      fullNameArabic: String,
+      status: { type: String, default: 'active' },
+      statusReason: String,
+      createdBy: String,
+    })
+  );
+  ClinicalSession = mongoose.model(
+    'ClinicalSession',
+    new mongoose.Schema({
+      beneficiaryId: mongoose.Schema.Types.ObjectId,
+      therapistId: mongoose.Schema.Types.ObjectId,
+      type: String,
+      duration: Number,
+      status: { type: String, default: 'scheduled' },
+    })
+  );
+  RiskSnapshot = mongoose.model(
+    'RiskSnapshot',
+    new mongoose.Schema({
+      beneficiaryId: mongoose.Schema.Types.ObjectId,
+      overallTier: String,
+      tierDelta: String,
+      reason: String,
+      explanation: String,
+    })
+  );
+  Unmapped = mongoose.model('SomethingUnmapped', new mongoose.Schema({ x: String }));
+});
+
+afterEach(() => mockPublish.mockClear());
+
+afterAll(async () => {
+  delete process.env.ENABLE_MODEL_EVENT_BRIDGE;
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+describe('W974 — global plugin fires the previously-dead producers', () => {
+  it('create-only: Employee.create → hr.employee.hired', async () => {
+    const e = await Employee.create({ fullName: 'سالم', department: 'HR', position: 'Officer' });
+    await new Promise(r => setImmediate(r));
+    const call = published('employee.hired');
+    expect(call).toBeTruthy();
+    expect(call[0]).toBe('hr');
+    expect(call[2].employeeId).toBe(String(e._id));
+    expect(call[2].name).toBe('سالم');
+  });
+
+  it('create-only: Invoice.create → finance.invoice.created', async () => {
+    const inv = await Invoice.create({ amount: 500, currency: 'SAR' });
+    await new Promise(r => setImmediate(r));
+    const call = published('invoice.created');
+    expect(call).toBeTruthy();
+    expect(call[0]).toBe('finance');
+    expect(call[2].amount).toBe(500);
+  });
+
+  it('status-flip: ClinicalSession status→completed → medical.therapy.session_completed', async () => {
+    const s = await ClinicalSession.create({ type: 'PT' });
+    await new Promise(r => setImmediate(r));
+    mockPublish.mockClear();
+    const loaded = await ClinicalSession.findById(s._id);
+    loaded.status = 'completed';
+    await loaded.save();
+    await new Promise(r => setImmediate(r));
+    expect(published('therapy.session_completed')).toBeTruthy();
+  });
+
+  it('status-flip: Employee status→terminated → hr.employee.terminated (not on create)', async () => {
+    const e = await Employee.create({ fullName: 'منى', status: 'active' });
+    await new Promise(r => setImmediate(r));
+    expect(published('employee.terminated')).toBeFalsy(); // create must not flip
+    mockPublish.mockClear();
+    const loaded = await Employee.findById(e._id);
+    loaded.status = 'terminated';
+    await loaded.save();
+    await new Promise(r => setImmediate(r));
+    expect(published('employee.terminated')).toBeTruthy();
+  });
+
+  it('status-flip-any: Beneficiary status change → beneficiary.status_changed with oldStatus', async () => {
+    const b = await Beneficiary.create({ fullNameArabic: 'سارة', status: 'active' });
+    await new Promise(r => setImmediate(r));
+    mockPublish.mockClear();
+    const loaded = await Beneficiary.findById(b._id);
+    loaded.status = 'discharged';
+    await loaded.save();
+    await new Promise(r => setImmediate(r));
+    const call = published('beneficiary.status_changed');
+    expect(call).toBeTruthy();
+    expect(call[2].oldStatus).toBe('active');
+    expect(call[2].newStatus).toBe('discharged');
+  });
+
+  it('predicate: RiskSnapshot emits only on tier escalation', async () => {
+    await RiskSnapshot.create({ overallTier: 'low', tierDelta: 'unchanged' });
+    await new Promise(r => setImmediate(r));
+    expect(published('risk.alert_raised')).toBeFalsy(); // predicate gates it out
+    mockPublish.mockClear();
+    await RiskSnapshot.create({ overallTier: 'critical', tierDelta: 'escalated' });
+    await new Promise(r => setImmediate(r));
+    expect(published('risk.alert_raised')).toBeTruthy();
+  });
+
+  it('unmapped model save publishes nothing (fast-skip)', async () => {
+    await Unmapped.create({ x: '1' });
+    await new Promise(r => setImmediate(r));
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+});
+
+describe('W974 — env gate', () => {
+  it('registerModelEventBridgePlugin is a no-op when ENABLE_MODEL_EVENT_BRIDGE is unset', () => {
+    jest.resetModules();
+    const saved = process.env.ENABLE_MODEL_EVENT_BRIDGE;
+    delete process.env.ENABLE_MODEL_EVENT_BRIDGE;
+    const fresh = require('../integration/modelEventBridge');
+    const res = fresh.registerModelEventBridgePlugin();
+    expect(res.registered).toBe(false);
+    expect(res.reason).toMatch(/not enabled/);
+    if (saved !== undefined) process.env.ENABLE_MODEL_EVENT_BRIDGE = saved;
+  });
+});

--- a/backend/app.js
+++ b/backend/app.js
@@ -29,6 +29,18 @@ const express = require('express');
 const mongoose = require('mongoose');
 const logger = require('./utils/logger');
 
+// W974 — register the model-event-bridge GLOBAL plugin here, BEFORE any route/
+// domain require below compiles a model. A mongoose global plugin only applies
+// to schemas constructed AFTER it is registered, and Mongoose bakes middleware
+// into a model at compile time — so the old startup-time `wireModelEventBridge`
+// (which attaches hooks after compilation) never fired. Env-gated
+// (ENABLE_MODEL_EVENT_BRIDGE=true, default OFF) → no-op unless an owner enables.
+try {
+  require('./integration/modelEventBridge').registerModelEventBridgePlugin();
+} catch (err) {
+  logger.warn?.(`[ModelEventBridge] plugin registration skipped: ${err.message}`);
+}
+
 const {
   errorHandler,
   notFoundHandler,

--- a/backend/integration/modelEventBridge.js
+++ b/backend/integration/modelEventBridge.js
@@ -508,4 +508,135 @@ function wireModelEventBridge(integrationBus) {
   return { wiredCount: wired, skippedMappings: skipped };
 }
 
-module.exports = { wireModelEventBridge, MAPPINGS };
+// ═══════════════════════════════════════════════════════════════════════════
+//  W974 — GLOBAL PRE-COMPILE PLUGIN (the resurrection)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// `wireModelEventBridge` (above) attaches schema.post('save') hooks AT STARTUP,
+// i.e. AFTER the models were already compiled by app.js's route/domain requires.
+// Mongoose compiles a schema's middleware into the model at `mongoose.model()`
+// time; hooks added to the schema afterwards NEVER FIRE. Verified empirically:
+// every one of the 16 mappings was producing nothing in production.
+//
+// The fix: register a GLOBAL plugin via `mongoose.plugin()` BEFORE any model
+// compiles (app.js, right after `require('mongoose')`). A global plugin runs
+// against every schema at construction time — pre-compile — so its hooks DO
+// fire. The plugin attaches ONE generic set of hooks to every schema; at
+// save-time the hook looks up `this.constructor.modelName` in the mapping
+// registry and dispatches only for mapped models (a cheap Map.get for the rest).
+//
+// Env-gated (`ENABLE_MODEL_EVENT_BRIDGE=true`, default OFF) so the deployed
+// behaviour is unchanged until an owner activates it. integrationBus is
+// lazy-resolved at fire-time, decoupling registration from bus init.
+
+const MAPPINGS_BY_MODEL = (() => {
+  const m = new Map();
+  for (const mapping of MAPPINGS) {
+    if (!m.has(mapping.modelName)) m.set(mapping.modelName, []);
+    m.get(mapping.modelName).push(mapping);
+  }
+  return m;
+})();
+
+function _evalAndPublish(doc, self, mapping, bus) {
+  const { domain, eventType, trigger, flipField, flipTo, payload, predicate } = mapping;
+  try {
+    if (trigger === 'create-only' && !self.$__wasNew) return;
+
+    if (trigger === 'status-flip') {
+      const previous = self[`$__previous_${flipField || 'status'}`];
+      const current = doc[flipField || 'status'];
+      if (current === previous) return;
+      if (Array.isArray(flipTo) && !flipTo.includes(current)) return;
+    }
+
+    if (trigger === 'status-flip-any') {
+      const previous = self[`$__previous_${flipField || 'status'}`];
+      const current = doc[flipField || 'status'];
+      if (current === previous) return;
+      doc.$__previousStatus = previous;
+    }
+
+    if (typeof predicate === 'function' && !predicate(doc)) return;
+
+    const eventPayload = payload(doc);
+    Promise.resolve()
+      .then(() => bus.publish(domain, eventType, eventPayload))
+      .catch(err =>
+        logger.error(`[ModelEventBridge] forward failed for ${domain}.${eventType}: ${err.message}`)
+      );
+  } catch (err) {
+    logger.error(`[ModelEventBridge] hook error in ${eventType}: ${err.message}`);
+  }
+}
+
+/**
+ * Global mongoose plugin — attached to EVERY schema (pre-compile). Generic
+ * hooks that dispatch only for models present in MAPPINGS_BY_MODEL.
+ */
+function bridgeGlobalPlugin(schema) {
+  schema.pre('save', function () {
+    this.$__wasNew = this.isNew;
+  });
+
+  // Capture the persisted value of every flip-field this model's mappings watch,
+  // so a status flip is detectable in post('save'). modelName is known here.
+  schema.post('init', function () {
+    const ms = MAPPINGS_BY_MODEL.get(this.constructor && this.constructor.modelName);
+    if (!ms) return;
+    for (const m of ms) {
+      if (m.trigger === 'status-flip' || m.trigger === 'status-flip-any') {
+        const f = m.flipField || 'status';
+        this[`$__previous_${f}`] = this[f];
+      }
+    }
+  });
+
+  schema.post('save', function (doc) {
+    const name = this.constructor && this.constructor.modelName;
+    const ms = name && MAPPINGS_BY_MODEL.get(name);
+    if (!ms) return; // fast skip for the vast majority of (unmapped) models
+    let bus;
+    try {
+      bus = require('./systemIntegrationBus').integrationBus;
+    } catch (_) {
+      return; // bus not loadable (e.g. some unit-test contexts)
+    }
+    if (!bus || typeof bus.publish !== 'function') return;
+    for (const mapping of ms) _evalAndPublish(doc, this, mapping, bus);
+  });
+}
+
+const PLUGIN_FLAG = Symbol.for('w974.modelEventBridge.globalPluginRegistered');
+
+/**
+ * Register the global bridge plugin. MUST be called before any model compiles
+ * (app.js, right after the mongoose require). Idempotent + env-gated.
+ *
+ * @returns {{registered: boolean, reason?: string, mappingCount?: number}}
+ */
+function registerModelEventBridgePlugin() {
+  if (process.env.ENABLE_MODEL_EVENT_BRIDGE !== 'true') {
+    return { registered: false, reason: 'ENABLE_MODEL_EVENT_BRIDGE not enabled' };
+  }
+  const mongoose = require('mongoose');
+  if (mongoose[PLUGIN_FLAG]) {
+    return { registered: false, reason: 'already registered' };
+  }
+  mongoose.plugin(bridgeGlobalPlugin);
+  mongoose[PLUGIN_FLAG] = true;
+  logger.info(
+    `[ModelEventBridge] global pre-compile plugin registered — ${MAPPINGS.length} mappings live ` +
+      `across ${MAPPINGS_BY_MODEL.size} models`
+  );
+  return { registered: true, mappingCount: MAPPINGS.length, modelCount: MAPPINGS_BY_MODEL.size };
+}
+
+module.exports = {
+  wireModelEventBridge,
+  MAPPINGS,
+  // W974 — global pre-compile plugin (the working mechanism)
+  bridgeGlobalPlugin,
+  registerModelEventBridgePlugin,
+  MAPPINGS_BY_MODEL,
+};

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -723,3 +723,4 @@ __tests__/purchase-order-create-branch-wave933.test.js
 __tests__/appointments-core-linkage-wave970.test.js
 __tests__/care-plan-workers-bootstrap-wave973.test.js
 __tests__/quality-bus-unification-wave974.test.js
+__tests__/model-event-bridge-global-plugin-wave974.test.js


### PR DESCRIPTION
## What
Resurrects the **modelEventBridge** — 16 LIVE-registry event producers (hr/finance/medical/beneficiary/attendance/notification) that were **runtime-dead**. Env-gated (`ENABLE_MODEL_EVENT_BRIDGE=true`, default OFF) so deployed behaviour is unchanged until an owner flips it.

## Why
`wireModelEventBridge` attaches `schema.post('save')` hooks at **startup — after app.js already compiled the models**. Mongoose bakes a schema's middleware into the model at `mongoose.model()` time, so hooks added afterwards **never fire**. Verified empirically: every one of the 16 mappings (employee.hired, invoice.created, payment.received, beneficiary.registered/status_changed, therapy.session_completed, risk.alert_raised, …) produced **nothing** in production. The static guards (W382/W392) only ever read the `MAPPINGS` array — they never ran a save, so they missed it (the W349 lesson).

## How
A **global mongoose plugin** registered via `mongoose.plugin()` in `app.js` right after the mongoose require — **before** the route/domain requires compile any model. A global plugin runs against every schema at construction (pre-compile), so its hooks fire. One generic pre-save / post-init / post-save set is attached to every schema; at save-time the post-save hook looks up `this.constructor.modelName` in a `Map` and dispatches only for mapped models (cheap miss for the rest). `integrationBus` is lazy-resolved at fire-time.

## Safety
- **Env-gated OFF** by default → inert on deploy.
- **Downstream audited**: the 16 events feed `crossModuleSubscribers.js`, whose handlers invoke `notification.send` via a `moduleConnector.hasService(...)` guard or re-publish KPI/audit/sync events — none directly create a Mongoose doc with a risky shape (unlike the W970 CareTimeline class), all try/catch wrapped.

## Verification
`model-event-bridge-global-plugin-wave974` (8 tests, real in-memory Mongo): synthetic models under the real mapped names exercise **every trigger kind** — create-only, status-flip, status-flip-any, predicate — + fast-skip for unmapped + env-gate no-op. W404/W392/W389/hook-style/routes-load guards green (`MAPPINGS` unchanged).

## Activation prerequisite (follow-up, NOT in this PR)
A quick behavioural pass over the deeper subscriber chains (e.g. `dashboard.kpi.update → KPISnapshot`, which had the W970 shape bug) before flipping the flag in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
