### PR TITLE
feat(quality): W976 wire incident→NCR producer + fix IncidentReport Mongoose-9 save hook

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1233,6 +1233,8 @@ on:
       - 'backend/__tests__/ai-analytics-branch-isolation-wave973.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/session-lifecycle-timeline-subscriber-wave974.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/incident-ncr-producer-wave976.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2449,6 +2451,8 @@ on:
       - 'backend/__tests__/ai-analytics-branch-isolation-wave973.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/session-lifecycle-timeline-subscriber-wave974.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/incident-ncr-producer-wave976.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/incident-ncr-producer-wave976.test.js
+++ b/backend/__tests__/incident-ncr-producer-wave976.test.js
@@ -1,0 +1,137 @@
+'use strict';
+
+/**
+ * W976 — incident → NCR producer.
+ *
+ * Closes finding #2 from the quality event-bus audit: the ncrAutoLinkPipeline
+ * subscribes to `quality.incident.reported` (auto-creates NCR + CAPA for serious
+ * incidents) but NOTHING emitted it, so the CBAHI safety automation was dead.
+ * Now that W974 unified the quality bus, an IncidentReport post('save') hook emits
+ * the event on the singleton bus where the pipeline listens.
+ *
+ * The producer emits for EVERY new incident; the pipeline SELF-FILTERS by severity
+ * (major/critical/sentinel) + dedups — so the clinical "which qualifies" decision
+ * stays in the pipeline, and the producer is safe + idempotent. ENV-GATED, default
+ * OFF (ENABLE_INCIDENT_NCR_AUTOLINK). Guarded so a bus error never breaks the save.
+ *
+ * Static guards + behavioral round-trip against MongoMemoryServer.
+ */
+
+const mongoose = require('mongoose');
+jest.unmock('mongoose');
+
+const fs = require('fs');
+const path = require('path');
+
+const MODEL_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'models', 'quality', 'IncidentReport.js'),
+  'utf8'
+);
+
+describe('W976 incident→NCR producer — source shape', () => {
+  it('env-gates on ENABLE_INCIDENT_NCR_AUTOLINK', () => {
+    expect(MODEL_SRC).toMatch(/process\.env\.ENABLE_INCIDENT_NCR_AUTOLINK\s*!==\s*'true'/);
+  });
+  it('emits quality.incident.reported from a post(save) hook', () => {
+    expect(MODEL_SRC).toMatch(/\.post\(\s*'save'/);
+    expect(MODEL_SRC).toMatch(/emit\(\s*'quality\.incident\.reported'/);
+  });
+  it('only fires on creation (captures wasNew in pre-save)', () => {
+    expect(MODEL_SRC).toMatch(/\$locals\.wasNew\s*=\s*this\.isNew/);
+    expect(MODEL_SRC).toMatch(/\$locals\.wasNew\)\s*return/);
+  });
+  it('emits on the singleton bus (unified, W974) via getDefault', () => {
+    expect(MODEL_SRC).toMatch(/require\(\s*'\.\.\/\.\.\/services\/quality\/qualityEventBus\.service'\s*\)/);
+    expect(MODEL_SRC).toMatch(/getDefault\(\)/);
+  });
+});
+
+describe('W976 incident→NCR producer — behavioral', () => {
+  let mongod;
+  let IncidentReport;
+  let busMod;
+  let original;
+  let isolated;
+  const PREV = process.env.ENABLE_INCIDENT_NCR_AUTOLINK;
+
+  beforeAll(async () => {
+    const { MongoMemoryServer } = require('mongodb-memory-server');
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+    IncidentReport = require('../models/quality/IncidentReport');
+    busMod = require('../services/quality/qualityEventBus.service');
+  }, 60000);
+
+  afterAll(async () => {
+    if (PREV === undefined) delete process.env.ENABLE_INCIDENT_NCR_AUTOLINK;
+    else process.env.ENABLE_INCIDENT_NCR_AUTOLINK = PREV;
+    await mongoose.disconnect();
+    if (mongod) await mongod.stop();
+  });
+
+  beforeEach(() => {
+    original = busMod.getDefault();
+    isolated = busMod.createQualityEventBus();
+    busMod._replaceDefault(isolated);
+  });
+  afterEach(() => {
+    busMod._replaceDefault(original);
+    delete process.env.ENABLE_INCIDENT_NCR_AUTOLINK;
+  });
+
+  function makeIncident(severity) {
+    return new IncidentReport({
+      title: 'Test incident',
+      description: 'desc',
+      incident_type: 'fall',
+      severity,
+      incident_date: new Date('2026-06-01'),
+      reported_by: new mongoose.Types.ObjectId(),
+      branch_id: new mongoose.Types.ObjectId(),
+    });
+  }
+
+  it('emits quality.incident.reported on creation when enabled', async () => {
+    process.env.ENABLE_INCIDENT_NCR_AUTOLINK = 'true';
+    const received = [];
+    busMod.getDefault().on('quality.incident.reported', p => received.push(p));
+
+    const doc = await makeIncident('major').save();
+    await busMod.getDefault().flush();
+
+    expect(received).toHaveLength(1);
+    expect(received[0].incidentId).toBe(String(doc._id));
+    expect(received[0].severity).toBe('major');
+    expect(received[0].branchId).toBe(String(doc.branch_id));
+    expect(received[0].title).toBe('Test incident');
+  });
+
+  it('does NOT emit when the flag is off (inert default)', async () => {
+    delete process.env.ENABLE_INCIDENT_NCR_AUTOLINK;
+    const received = [];
+    busMod.getDefault().on('quality.incident.reported', p => received.push(p));
+    await makeIncident('critical').save();
+    await busMod.getDefault().flush();
+    expect(received).toHaveLength(0);
+  });
+
+  it('does NOT re-emit on a non-creation save (update)', async () => {
+    process.env.ENABLE_INCIDENT_NCR_AUTOLINK = 'true';
+    const doc = await makeIncident('sentinel').save();
+    await busMod.getDefault().flush();
+
+    const received = [];
+    busMod.getDefault().on('quality.incident.reported', p => received.push(p));
+    doc.status = 'under_investigation';
+    await doc.save();
+    await busMod.getDefault().flush();
+    expect(received).toHaveLength(0); // only creation emits
+  });
+
+  it('a save still succeeds even though the producer is best-effort', async () => {
+    process.env.ENABLE_INCIDENT_NCR_AUTOLINK = 'true';
+    const doc = await makeIncident('minor').save(); // minor → pipeline would skip, producer still emits
+    expect(doc._id).toBeDefined();
+    expect(doc.incident_number).toMatch(/^INC-/);
+  });
+});

--- a/backend/models/quality/IncidentReport.js
+++ b/backend/models/quality/IncidentReport.js
@@ -94,13 +94,45 @@ const incidentReportSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-incidentReportSchema.pre('save', async function (next) {
+// W976 — async-no-next form. Mongoose 9 does NOT pass `next` to an async hook, so
+// the prior `async function (next) { … next(); }` threw "next is not a function" on
+// EVERY save (the documented Mongoose-9 hazard; see feedback_mongoose_9_pre_save_callback_silent_break).
+// Completing via promise resolution is the canonical Mongoose-9 form.
+incidentReportSchema.pre('save', async function () {
+  this.$locals.wasNew = this.isNew; // capture for the post-save NCR producer
   if (!this.incident_number) {
     const year = new Date().getFullYear();
     const count = await mongoose.model('IncidentReport').countDocuments();
     this.incident_number = `INC-${year}-${String(count + 1).padStart(5, '0')}`;
   }
-  next();
+});
+
+// W976 — producer for the NCR auto-link pipeline (services/quality/ncrAutoLinkPipeline).
+// On a NEW incident, emit `quality.incident.reported` on the unified quality bus
+// (the singleton, W974) so the pipeline can auto-create an NCR + CAPA. The pipeline
+// SELF-FILTERS by severity (major/critical/sentinel) and dedups by incidentId, so the
+// "which incidents qualify" decision lives there, not here, and emitting is idempotent.
+// ENV-GATED, default OFF (ENABLE_INCIDENT_NCR_AUTOLINK=true) — ships inert; auto-creating
+// corrective-action records is a behaviour an operator opts into. Fully guarded: a bus
+// or emit error must NEVER break the incident save.
+incidentReportSchema.post('save', async function (doc) {
+  if (process.env.ENABLE_INCIDENT_NCR_AUTOLINK !== 'true') return;
+  if (!doc || !doc.$locals || !doc.$locals.wasNew) return; // creation only
+  try {
+    const { getDefault } = require('../../services/quality/qualityEventBus.service');
+    const bus = getDefault();
+    if (bus && typeof bus.emit === 'function') {
+      await bus.emit('quality.incident.reported', {
+        incidentId: String(doc._id),
+        severity: doc.severity ? String(doc.severity).toLowerCase() : null,
+        title: doc.title || null,
+        branchId: doc.branch_id ? String(doc.branch_id) : null,
+        reportedBy: doc.reported_by ? String(doc.reported_by) : null,
+      });
+    }
+  } catch (_) {
+    /* best-effort producer — never break the incident save */
+  }
 });
 
 incidentReportSchema.index({ incident_type: 1, severity: 1, incident_date: -1 });

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -727,3 +727,4 @@ __tests__/appointments-core-linkage-wave970.test.js
 __tests__/care-plan-workers-bootstrap-wave973.test.js
 __tests__/quality-bus-unification-wave974.test.js
 __tests__/model-event-bridge-global-plugin-wave974.test.js
+__tests__/incident-ncr-producer-wave976.test.js


### PR DESCRIPTION
## What

Closes finding #2 from the quality event-bus audit (unblocked by W974 unification): the `ncrAutoLinkPipeline` subscribes to `quality.incident.reported` (auto-creates an NCR + CAPA for serious incidents — a CBAHI safety automation) but **nothing emitted it**, so the pipeline was dead.

## Two changes in `models/quality/IncidentReport.js`

**1. Producer** — an **env-gated** async `post('save')` hook emits `quality.incident.reported` on the unified bus (`getDefault`, W974) on incident **creation**. The pipeline self-filters by severity (`major`/`critical`/`sentinel`) + dedups, so the clinical decision stays in the pipeline and emitting is idempotent. **Default OFF** (`ENABLE_INCIDENT_NCR_AUTOLINK=true`) — ships inert. Guarded: a bus error never breaks the save.

**2. Prerequisite fix** — the existing `pre('save', async function (next) { … next(); })` **throws "next is not a function" on every save under Mongoose 9.6.2** (M9 doesn't pass `next` to async hooks — the documented hazard). Converted to async-no-next. Required for saves to succeed (proved by an isolated repro) and a real fix in its own right.

> ⚠️ **Follow-up finding:** **53 other models** share the broken `async function (next){…next()}` pattern and throw on `.save()` under Mongoose 9.6.2 — a likely contributor to several "data not saved" reports. Documented separately; **not swept here** (large + overlaps the active data-not-saved work). Beneficiary.js is already migrated (async-no-next), which is why high-traffic saves work.

## Tests (8)

Static (env-gate, post-save emit, creation-only via `$locals.wasNew`, getDefault) + behavioral round-trip on MongoMemoryServer (emits on create when enabled with correct payload; inert when off; no re-emit on update; save still succeeds). hook-style gate green, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)