### PR TITLE
fix(W948): convert 67 sync callback save-hooks to async (Mongoose 9) — baseline 67→17

### DIFF
--- a/backend/__tests__/check-mongoose-hook-style-script.test.js
+++ b/backend/__tests__/check-mongoose-hook-style-script.test.js
@@ -250,8 +250,11 @@ describe('check-mongoose-hook-style — KNOWN_CALLBACK_HOOK_BASELINE structure',
     expect(KNOWN_CALLBACK_HOOK_BASELINE).toBeInstanceOf(Set);
   });
 
-  it('contains at least 50 entries (W494 baseline reality — was 99 at install)', () => {
-    expect(KNOWN_CALLBACK_HOOK_BASELINE.size).toBeGreaterThanOrEqual(50);
+  it('is non-empty (W494/W948 ratchet — 99 at install → 67 → 17 after W948)', () => {
+    // W948 converted the 50 bare-next() baseline files (+17 unbaselined) to async;
+    // the remaining entries are the harder next(arg) hooks awaiting manual
+    // throw-conversion. Lower bound is just "not accidentally wiped".
+    expect(KNOWN_CALLBACK_HOOK_BASELINE.size).toBeGreaterThanOrEqual(1);
   });
 
   it('every entry uses POSIX paths (no backslashes, no absolute paths)', () => {

--- a/backend/domains/ai-recommendations/models/ClinicalRiskScore.js
+++ b/backend/domains/ai-recommendations/models/ClinicalRiskScore.js
@@ -152,7 +152,7 @@ clinicalRiskScoreSchema.virtual('topFactors').get(function () {
 });
 
 // ── Pre-save: compute weighted scores & category scores ─────────────────────
-clinicalRiskScoreSchema.pre('save', function (next) {
+clinicalRiskScoreSchema.pre('save', async function () {
   if (this.factors && this.factors.length) {
     this.factors.forEach(f => {
       f.weightedScore = (f.weight || 1) * (f.score || 0);
@@ -171,7 +171,6 @@ clinicalRiskScoreSchema.pre('save', function (next) {
       }
     }
   }
-  next();
 });
 
 module.exports =

--- a/backend/domains/care-plans/models/UnifiedCarePlan.js
+++ b/backend/domains/care-plans/models/UnifiedCarePlan.js
@@ -292,13 +292,12 @@ unifiedCarePlanSchema.virtual('daysUntilReview').get(function () {
 
 // ─── Pre-save ───────────────────────────────────────────────────────────────
 
-unifiedCarePlanSchema.pre('save', function (next) {
+unifiedCarePlanSchema.pre('save', async function () {
   if (!this.planNumber && this.isNew) {
     const dateStr = new Date().toISOString().slice(0, 10).replace(/-/g, '');
     const random = Math.random().toString(36).substring(2, 6).toUpperCase();
     this.planNumber = `CP-${dateStr}-${random}`;
   }
-  next();
 });
 
 // ─── Static Methods ─────────────────────────────────────────────────────────

--- a/backend/domains/episodes/models/EpisodeOfCare.js
+++ b/backend/domains/episodes/models/EpisodeOfCare.js
@@ -396,7 +396,7 @@ episodeOfCareSchema.virtual('timelineEvents', {
 
 // ─── Pre-save Middleware ─────────────────────────────────────────────────────
 
-episodeOfCareSchema.pre('save', function (next) {
+episodeOfCareSchema.pre('save', async function () {
   // Auto-generate episode number
   if (!this.episodeNumber && this.isNew) {
     const dateStr = new Date().toISOString().slice(0, 10).replace(/-/g, '');
@@ -436,7 +436,6 @@ episodeOfCareSchema.pre('save', function (next) {
     ];
   }
 
-  next();
 });
 
 // ─── Instance Methods ───────────────────────────────────────────────────────

--- a/backend/domains/sessions/models/ClinicalSession.js
+++ b/backend/domains/sessions/models/ClinicalSession.js
@@ -303,7 +303,7 @@ clinicalSessionSchema.virtual('averageGoalProgress').get(function () {
 
 // ─── Pre-save ───────────────────────────────────────────────────────────────
 
-clinicalSessionSchema.pre('save', function (next) {
+clinicalSessionSchema.pre('save', async function () {
   if (!this.sessionNumber && this.isNew) {
     const dateStr = new Date().toISOString().slice(0, 10).replace(/-/g, '');
     const random = Math.random().toString(36).substring(2, 6).toUpperCase();
@@ -317,7 +317,6 @@ clinicalSessionSchema.pre('save', function (next) {
     );
   }
 
-  next();
 });
 
 // ─── Static Methods ─────────────────────────────────────────────────────────

--- a/backend/models/ADLAssessment.js
+++ b/backend/models/ADLAssessment.js
@@ -197,7 +197,7 @@ adlAssessmentSchema.index({ assessor: 1, assessmentDate: -1 });
 adlAssessmentSchema.index({ status: 1 });
 
 // ─── حساب الدرجات قبل الحفظ ───
-adlAssessmentSchema.pre('save', function (next) {
+adlAssessmentSchema.pre('save', async function () {
   const allSkillArrays = {
     cooking: this.cookingSkills,
     cleaning: this.cleaningSkills,
@@ -239,7 +239,6 @@ adlAssessmentSchema.pre('save', function (next) {
   else if (this.overallScore >= 25) this.independenceLevel = 'mostly_dependent';
   else this.independenceLevel = 'dependent';
 
-  next();
 });
 
 // ─── Virtuals ───

--- a/backend/models/Assessment.js
+++ b/backend/models/Assessment.js
@@ -347,7 +347,7 @@ programAssessmentSchema.statics.getDomainAnalysis = async function (beneficiaryI
 };
 
 // Pre-save middleware
-programAssessmentSchema.pre('save', function (next) {
+programAssessmentSchema.pre('save', async function () {
   this.updatedAt = new Date();
 
   // Auto-calculate weighted score
@@ -361,7 +361,6 @@ programAssessmentSchema.pre('save', function (next) {
     this.improvement = this.scoreChange > 0;
   }
 
-  next();
 });
 
 module.exports =

--- a/backend/models/Asset.js
+++ b/backend/models/Asset.js
@@ -81,9 +81,8 @@ assetSchema.index({ createdBy: 1, createdAt: -1 });
 assetSchema.index({ location: 1 });
 
 // Middleware to update updatedAt
-assetSchema.pre('save', function (next) {
+assetSchema.pre('save', async function () {
   this.updatedAt = Date.now();
-  next();
 });
 
 module.exports = mongoose.models.Asset || mongoose.model('Asset', assetSchema);

--- a/backend/models/AwarenessProgram.js
+++ b/backend/models/AwarenessProgram.js
@@ -253,7 +253,7 @@ awarenessProgramSchema.index({ status: 1, createdAt: -1 });
 awarenessProgramSchema.index({ coverageArea: 1, status: 1 });
 
 // ─── Pre-save: recalculate totals ────────────────────────────────────────────
-awarenessProgramSchema.pre('save', function (next) {
+awarenessProgramSchema.pre('save', async function () {
   if (this.workshops && this.workshops.length > 0) {
     this.totalWorkshopsCompleted = this.workshops.filter(w => w.status === 'completed').length;
     const ratedWorkshops = this.workshops.filter(w => w.satisfactionScore > 0);
@@ -262,7 +262,6 @@ awarenessProgramSchema.pre('save', function (next) {
         ratedWorkshops.reduce((sum, w) => sum + w.satisfactionScore, 0) / ratedWorkshops.length;
     }
   }
-  next();
 });
 
 module.exports =

--- a/backend/models/BeneficiaryManagement/AcademicRecord.js
+++ b/backend/models/BeneficiaryManagement/AcademicRecord.js
@@ -185,10 +185,9 @@ academicRecordSchema.index({ enrollmentDate: -1 });
 academicRecordSchema.index({ branchId: 1, enrollmentStatus: 1 });
 
 // Pre-save middleware
-academicRecordSchema.pre('save', function (next) {
+academicRecordSchema.pre('save', async function () {
   this.updatedAt = new Date();
   this.progressPercentage = (this.totalCreditsEarned / this.totalCreditsRequired) * 100;
-  next();
 });
 
 // Methods

--- a/backend/models/BeneficiaryManagement/Achievement.js
+++ b/backend/models/BeneficiaryManagement/Achievement.js
@@ -139,7 +139,7 @@ achievementSchema.index({ tags: 1 });
 achievementSchema.index({ branchId: 1, type: 1 });
 
 // Pre-save middleware
-achievementSchema.pre('save', function (next) {
+achievementSchema.pre('save', async function () {
   this.updatedAt = new Date();
 
   // Auto-assign points based on type if not specified
@@ -153,7 +153,6 @@ achievementSchema.pre('save', function (next) {
     this.pointsAwarded = pointMap[this.type] || 50;
   }
 
-  next();
 });
 
 // Methods

--- a/backend/models/BeneficiaryManagement/AttendanceRecord.js
+++ b/backend/models/BeneficiaryManagement/AttendanceRecord.js
@@ -121,9 +121,8 @@ attendanceRecordSchema.index({ 'consecutiveAbsences.count': 1 });
 attendanceRecordSchema.index({ branchId: 1, attendanceDate: -1 });
 
 // Pre-save middleware
-attendanceRecordSchema.pre('save', function (next) {
+attendanceRecordSchema.pre('save', async function () {
   this.updatedAt = new Date();
-  next();
 });
 
 // Methods

--- a/backend/models/BeneficiaryManagement/CounselingSession.js
+++ b/backend/models/BeneficiaryManagement/CounselingSession.js
@@ -212,7 +212,7 @@ counselingSessionSchema.index({ createdAt: -1 });
 counselingSessionSchema.index({ branchId: 1, sessionStatus: 1 });
 
 // Pre-save middleware
-counselingSessionSchema.pre('save', function (next) {
+counselingSessionSchema.pre('save', async function () {
   this.updatedAt = new Date();
 
   // Calculate actual duration if both times are present
@@ -220,7 +220,6 @@ counselingSessionSchema.pre('save', function (next) {
     this.actualDuration = (this.actualEndTime - this.actualStartTime) / (1000 * 60); // in minutes
   }
 
-  next();
 });
 
 // Methods

--- a/backend/models/BeneficiaryManagement/FinancialSupport.js
+++ b/backend/models/BeneficiaryManagement/FinancialSupport.js
@@ -239,7 +239,7 @@ financialSupportSchema.index({ approvalDate: -1 });
 financialSupportSchema.index({ branchId: 1, requestStatus: 1 });
 
 // Pre-save middleware
-financialSupportSchema.pre('save', function (next) {
+financialSupportSchema.pre('save', async function () {
   this.updatedAt = new Date();
 
   // Validate amount consistency
@@ -247,7 +247,6 @@ financialSupportSchema.pre('save', function (next) {
     throw new Error('Disbursed amount cannot exceed approved amount');
   }
 
-  next();
 });
 
 // Methods

--- a/backend/models/BeneficiaryManagement/Scholarship.js
+++ b/backend/models/BeneficiaryManagement/Scholarship.js
@@ -197,9 +197,8 @@ scholarshipSchema.index({ approvalDate: -1 });
 scholarshipSchema.index({ branchId: 1, applicationStatus: 1 });
 
 // Pre-save middleware
-scholarshipSchema.pre('save', function (next) {
+scholarshipSchema.pre('save', async function () {
   this.updatedAt = new Date();
-  next();
 });
 
 // Methods

--- a/backend/models/BeneficiaryManagement/SkillsDevelopment.js
+++ b/backend/models/BeneficiaryManagement/SkillsDevelopment.js
@@ -178,7 +178,7 @@ skillsDevelopmentSchema.index({ endorsementCount: -1 });
 // skillCategory: removed — index:true creates implicit index
 
 // Pre-save middleware
-skillsDevelopmentSchema.pre('save', function (next) {
+skillsDevelopmentSchema.pre('save', async function () {
   this.updatedAt = new Date();
 
   // Update endorsement count
@@ -186,7 +186,6 @@ skillsDevelopmentSchema.pre('save', function (next) {
     this.endorsementCount = this.endorsements.length;
   }
 
-  next();
 });
 
 // Methods

--- a/backend/models/BeneficiaryManagement/SupportPlan.js
+++ b/backend/models/BeneficiaryManagement/SupportPlan.js
@@ -185,9 +185,8 @@ supportPlanSchema.index({ 'reviewSchedule.nextReviewDate': 1 });
 supportPlanSchema.index({ coordinatorId: 1 });
 
 // Pre-save middleware
-supportPlanSchema.pre('save', function (next) {
+supportPlanSchema.pre('save', async function () {
   this.updatedAt = new Date();
-  next();
 });
 
 // Methods

--- a/backend/models/CashFlow.js
+++ b/backend/models/CashFlow.js
@@ -264,7 +264,7 @@ cashFlowSchema.index({ createdBy: 1 });
 cashFlowSchema.index({ 'period.startDate': 1, 'period.endDate': 1 });
 
 // ===== HOOKS =====
-cashFlowSchema.pre('save', function (next) {
+cashFlowSchema.pre('save', async function () {
   // ط­ط³ط§ط¨ ط§ظ„ط¥ط¬ظ…ط§ظ„ظٹط§طھ
   this.calculations.totalInflows = this.inflows.reduce((sum, inflow) => sum + inflow.amount, 0);
   this.calculations.totalOutflows = this.outflows.reduce((sum, outflow) => sum + outflow.amount, 0);
@@ -289,7 +289,6 @@ cashFlowSchema.pre('save', function (next) {
     this.reserves.adequacyRatio = (this.reserves.total / this.calculations.totalOutflows) * 100;
   }
 
-  next();
 });
 
 // ===== METHODS =====

--- a/backend/models/ComplaintEnhanced.js
+++ b/backend/models/ComplaintEnhanced.js
@@ -30,9 +30,8 @@ const complaintCategorySchema = new mongoose.Schema(
 );
 
 complaintCategorySchema.index({ branchId: 1, isActive: 1 });
-complaintCategorySchema.pre('save', function (next) {
+complaintCategorySchema.pre('save', async function () {
   if (!this.uuid) this.uuid = require('crypto').randomUUID();
-  next();
 });
 
 // ── Complaint SLA Config ──────────────────────────────────────────────────
@@ -63,9 +62,8 @@ const complaintSlaConfigSchema = new mongoose.Schema(
 );
 
 complaintSlaConfigSchema.index({ branchId: 1, priority: 1 }, { unique: true });
-complaintSlaConfigSchema.pre('save', function (next) {
+complaintSlaConfigSchema.pre('save', async function () {
   if (!this.uuid) this.uuid = require('crypto').randomUUID();
-  next();
 });
 
 // ── Complaint Workflow Step ───────────────────────────────────────────────
@@ -205,9 +203,8 @@ complaintV2Schema.virtual('slaProgress').get(function () {
 });
 
 // ── Pre-save: auto number & uuid ──────────────────────────────────────────
-complaintV2Schema.pre('save', function (next) {
+complaintV2Schema.pre('save', async function () {
   if (!this.uuid) this.uuid = require('crypto').randomUUID();
-  next();
 });
 
 // ── Static: generate complaint number ────────────────────────────────────
@@ -355,9 +352,8 @@ crmFeedbackSchema.index({ branchId: 1, type: 1 });
 crmFeedbackSchema.index({ branchId: 1, status: 1 });
 crmFeedbackSchema.index({ sentiment: 1 });
 
-crmFeedbackSchema.pre('save', function (next) {
+crmFeedbackSchema.pre('save', async function () {
   if (!this.uuid) this.uuid = require('crypto').randomUUID();
-  next();
 });
 
 // ── Exports ───────────────────────────────────────────────────────────────

--- a/backend/models/DisabilitySession.js
+++ b/backend/models/DisabilitySession.js
@@ -84,9 +84,8 @@ disabilitySessionSchema.index({ status: 1, date: -1 });
 disabilitySessionSchema.index({ participantId: 1, date: -1 });
 
 // Pre-save middleware
-disabilitySessionSchema.pre('save', function (next) {
+disabilitySessionSchema.pre('save', async function () {
   this.updatedAt = new Date();
-  next();
 });
 
 module.exports =

--- a/backend/models/EInvoice.js
+++ b/backend/models/EInvoice.js
@@ -69,7 +69,7 @@ const eInvoiceSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-eInvoiceSchema.pre('save', function (next) {
+eInvoiceSchema.pre('save', async function () {
   if (this.lineItems && this.lineItems.length > 0) {
     this.lineItems.forEach(item => {
       item.taxAmount = item.quantity * item.unitPrice * (item.taxRate / 100);
@@ -88,7 +88,6 @@ eInvoiceSchema.pre('save', function (next) {
     'totalDiscount',
     'totalAmount',
   ]);
-  next();
 });
 
 eInvoiceSchema.index({ status: 1, issueDate: -1 });

--- a/backend/models/EnterpriseRisk.js
+++ b/backend/models/EnterpriseRisk.js
@@ -127,9 +127,8 @@ const enterpriseRiskSchema = new mongoose.Schema(
 const PROB_MAP = { very_low: 1, low: 2, medium: 3, high: 4, very_high: 5 };
 const IMP_MAP = { very_low: 1, low: 2, medium: 3, high: 4, very_high: 5 };
 
-enterpriseRiskSchema.pre('save', function (next) {
+enterpriseRiskSchema.pre('save', async function () {
   this.riskScore = (PROB_MAP[this.probability] || 3) * (IMP_MAP[this.impact] || 3);
-  next();
 });
 
 const EnterpriseRisk =

--- a/backend/models/EventParticipation.js
+++ b/backend/models/EventParticipation.js
@@ -153,12 +153,11 @@ eventParticipationSchema.index({ beneficiary: 1, createdAt: -1 });
 eventParticipationSchema.index({ attendanceRate: -1 });
 
 // ─── Pre-save: recalculate attendance rate ───────────────────────────────────
-eventParticipationSchema.pre('save', function (next) {
+eventParticipationSchema.pre('save', async function () {
   const total = this.totalSessionsAttended + this.totalSessionsMissed;
   if (total > 0) {
     this.attendanceRate = Math.round((this.totalSessionsAttended / total) * 100);
   }
-  next();
 });
 
 module.exports =

--- a/backend/models/Exam.js
+++ b/backend/models/Exam.js
@@ -194,11 +194,10 @@ ExamSubmissionSchema.index({ exam: 1, student: 1 }, { unique: true });
 ExamSubmissionSchema.index({ student: 1, status: 1 });
 
 // Auto-calculate totalPoints
-ExamSchema.pre('save', function (next) {
+ExamSchema.pre('save', async function () {
   if (this.questions && this.questions.length > 0) {
     this.totalPoints = this.questions.reduce((sum, q) => sum + (q.points || 0), 0);
   }
-  next();
 });
 
 module.exports = {

--- a/backend/models/FamilyWellbeingSnapshot.js
+++ b/backend/models/FamilyWellbeingSnapshot.js
@@ -98,7 +98,7 @@ FamilyWellbeingSnapshotSchema.index({ beneficiaryId: 1, snapshotDate: -1 });
 FamilyWellbeingSnapshotSchema.index({ branchId: 1, band: 1, snapshotDate: -1 });
 
 // W467 Wave-18 — recompute composite + band + triggers from components
-FamilyWellbeingSnapshotSchema.pre('save', function (next) {
+FamilyWellbeingSnapshotSchema.pre('save', async function () {
   const lib = require('../intelligence/family-wbci.lib');
   const componentsObj = this.components ? this.components.toObject?.() || this.components : {};
   const result = lib.computeWBCI({
@@ -116,7 +116,6 @@ FamilyWellbeingSnapshotSchema.pre('save', function (next) {
   this.missingComponents = result.missingComponents ?? 5;
   this.triggeredActions = result.triggers || [];
 
-  next();
 });
 
 module.exports =

--- a/backend/models/FinancialNavigationPlan.js
+++ b/backend/models/FinancialNavigationPlan.js
@@ -103,7 +103,7 @@ FinancialNavigationPlanSchema.index({ branchId: 1, status: 1 });
 FinancialNavigationPlanSchema.index({ beneficiaryId: 1, status: 1 });
 
 // W469 Wave-18 — auto-compute financial stress + wellbeing + suggest programs
-FinancialNavigationPlanSchema.pre('save', function (next) {
+FinancialNavigationPlanSchema.pre('save', async function () {
   const navLib = require('../intelligence/benefits-navigator.lib');
   const wbciLib = require('../intelligence/family-wbci.lib');
 
@@ -150,7 +150,6 @@ FinancialNavigationPlanSchema.pre('save', function (next) {
     });
   }
 
-  next();
 });
 
 function _incomeBandMidpoint(band) {

--- a/backend/models/FinancialReport.js
+++ b/backend/models/FinancialReport.js
@@ -148,7 +148,7 @@ const financialReportSchema = new mongoose.Schema(
 financialReportSchema.index({ organizationId: 1, reportType: 1 });
 financialReportSchema.index({ 'period.endDate': -1 });
 
-financialReportSchema.pre('save', function (next) {
+financialReportSchema.pre('save', async function () {
   if (this.balanceSheet) {
     const assets = this.balanceSheet.assets;
     if (assets.current)
@@ -181,7 +181,6 @@ financialReportSchema.pre('save', function (next) {
     income.netIncome = income.incomeBeforeTax - (income.incomeTax || 0);
   }
 
-  next();
 });
 
 financialReportSchema.methods.validateEquation = function () {

--- a/backend/models/HR/TrainingPlan.js
+++ b/backend/models/HR/TrainingPlan.js
@@ -134,7 +134,7 @@ const trainingPlanSchema = new Schema(
 );
 
 // حساب الملخص تلقائياً
-trainingPlanSchema.pre('save', function (next) {
+trainingPlanSchema.pre('save', async function () {
   if (this.items && this.items.length > 0) {
     const items = this.items;
     this.summary.totalItems = items.length;
@@ -151,7 +151,6 @@ trainingPlanSchema.pre('save', function (next) {
       (this.summary.completedItems / this.summary.totalItems) * 100
     );
   }
-  next();
 });
 
 trainingPlanSchema.index({ year: 1, department: 1 });

--- a/backend/models/ImportExportJob.js
+++ b/backend/models/ImportExportJob.js
@@ -265,7 +265,7 @@ importExportJobSchema.virtual('successRate').get(function () {
 });
 
 // Pre-save: Generate jobId
-importExportJobSchema.pre('save', function (next) {
+importExportJobSchema.pre('save', async function () {
   if (!this.jobId) {
     const prefix = this.type === 'export' ? 'EXP' : 'IMP';
     const timestamp = Date.now().toString(36).toUpperCase();
@@ -278,7 +278,6 @@ importExportJobSchema.pre('save', function (next) {
     this.progress.percentage = Math.round((this.progress.processed / this.progress.total) * 100);
   }
 
-  next();
 });
 
 // Static: get module statistics

--- a/backend/models/ImportExportTemplate.js
+++ b/backend/models/ImportExportTemplate.js
@@ -137,7 +137,7 @@ importExportTemplateSchema.index({ isPublic: 1, isActive: 1 });
 importExportTemplateSchema.index({ createdBy: 1 });
 
 // Pre-save: Generate slug
-importExportTemplateSchema.pre('save', function (next) {
+importExportTemplateSchema.pre('save', async function () {
   if (!this.slug) {
     this.slug =
       this.name
@@ -147,7 +147,6 @@ importExportTemplateSchema.pre('save', function (next) {
       '-' +
       Date.now().toString(36);
   }
-  next();
 });
 
 // Static: Get templates for a module

--- a/backend/models/Incident.js
+++ b/backend/models/Incident.js
@@ -581,9 +581,8 @@ incidentSchema.methods.addAttachment = function (attachmentData) {
 };
 
 // تحديث الطوابع الزمنية
-incidentSchema.pre('save', function (next) {
+incidentSchema.pre('save', async function () {
   this.auditInfo.lastModifiedAt = new Date();
-  next();
 });
 
 const Incident = mongoose.models.Incident || mongoose.model('Incident', incidentSchema);

--- a/backend/models/IndependentLivingPlan.js
+++ b/backend/models/IndependentLivingPlan.js
@@ -289,7 +289,7 @@ independentLivingPlanSchema.index({ createdBy: 1 });
 independentLivingPlanSchema.index({ startDate: 1, endDate: 1 });
 
 // ─── حساب التقدم قبل الحفظ ───
-independentLivingPlanSchema.pre('save', function (next) {
+independentLivingPlanSchema.pre('save', async function () {
   if (this.goals && this.goals.length > 0) {
     // حساب تقدم الفئات
     const categoryGoals = {};
@@ -311,7 +311,6 @@ independentLivingPlanSchema.pre('save', function (next) {
     const totalProgress = this.goals.reduce((acc, g) => acc + (g.progressPercentage || 0), 0);
     this.overallProgress = Math.round(totalProgress / this.goals.length);
   }
-  next();
 });
 
 // ─── Virtuals ───

--- a/backend/models/IndependentLivingProgress.js
+++ b/backend/models/IndependentLivingProgress.js
@@ -260,7 +260,7 @@ independentLivingProgressSchema.index({ plan: 1, periodEnd: -1 });
 independentLivingProgressSchema.index({ status: 1 });
 
 // ─── حساب الاتجاه والنسب قبل الحفظ ───
-independentLivingProgressSchema.pre('save', function (next) {
+independentLivingProgressSchema.pre('save', async function () {
   // حساب نسبة الحضور
   if (this.sessionsScheduled > 0) {
     this.attendanceRate = Math.round((this.sessionsAttended / this.sessionsScheduled) * 100);
@@ -311,7 +311,6 @@ independentLivingProgressSchema.pre('save', function (next) {
   else if (this.overallScore >= 25) this.independenceLevel = 'mostly_dependent';
   else this.independenceLevel = 'dependent';
 
-  next();
 });
 
 // ─── Virtuals ───

--- a/backend/models/IntegrationAssessment.js
+++ b/backend/models/IntegrationAssessment.js
@@ -229,7 +229,7 @@ integrationAssessmentSchema.index({ overallIntegrationScore: -1 });
 integrationAssessmentSchema.index({ assessor: 1, assessmentDate: -1 });
 
 // ─── Pre-save: determine integration level ───────────────────────────────────
-integrationAssessmentSchema.pre('save', function (next) {
+integrationAssessmentSchema.pre('save', async function () {
   const score = this.overallIntegrationScore;
   if (score <= 20) this.integrationLevel = 'minimal';
   else if (score <= 40) this.integrationLevel = 'partial';
@@ -245,7 +245,6 @@ integrationAssessmentSchema.pre('save', function (next) {
     else this.trend = 'stable';
   }
 
-  next();
 });
 
 module.exports =

--- a/backend/models/LearningPath.js
+++ b/backend/models/LearningPath.js
@@ -32,9 +32,8 @@ const learningPathSchema = new mongoose.Schema(
 
 learningPathSchema.index({ branchId: 1, targetRole: 1, isActive: 1 });
 
-learningPathSchema.pre('save', function (next) {
+learningPathSchema.pre('save', async function () {
   if (!this.uuid) this.uuid = require('crypto').randomUUID();
-  next();
 });
 
 module.exports = mongoose.models.LearningPath || mongoose.model('LearningPath', learningPathSchema);

--- a/backend/models/Maintenance.js
+++ b/backend/models/Maintenance.js
@@ -121,9 +121,8 @@ maintenanceSchema.index({ createdBy: 1, createdAt: -1 });
 maintenanceSchema.index({ status: 1, priority: 1 });
 
 // Pre-save middleware
-maintenanceSchema.pre('save', function (next) {
+maintenanceSchema.pre('save', async function () {
   this.updatedAt = new Date();
-  next();
 });
 
 module.exports = mongoose.models.Maintenance || mongoose.model('Maintenance', maintenanceSchema);

--- a/backend/models/MaintenancePrediction.js
+++ b/backend/models/MaintenancePrediction.js
@@ -110,9 +110,8 @@ maintenancePredictionSchema.index({ status: 1, urgency: 1 });
 maintenancePredictionSchema.index({ predictionType: 1, status: 1 });
 
 // Pre-save middleware
-maintenancePredictionSchema.pre('save', function (next) {
+maintenancePredictionSchema.pre('save', async function () {
   this.updatedAt = new Date();
-  next();
 });
 
 module.exports =

--- a/backend/models/ModuleProgress.js
+++ b/backend/models/ModuleProgress.js
@@ -41,9 +41,8 @@ const moduleProgressSchema = new mongoose.Schema(
 moduleProgressSchema.index({ enrollmentId: 1, moduleId: 1 }, { unique: true });
 moduleProgressSchema.index({ branchId: 1, userId: 1, status: 1 });
 
-moduleProgressSchema.pre('save', function (next) {
+moduleProgressSchema.pre('save', async function () {
   if (!this.uuid) this.uuid = require('crypto').randomUUID();
-  next();
 });
 
 module.exports =

--- a/backend/models/PaymentVoucher.js
+++ b/backend/models/PaymentVoucher.js
@@ -117,7 +117,7 @@ paymentVoucherSchema.index({ type: 1, status: 1 });
 paymentVoucherSchema.index({ partyName: 1, date: -1 });
 paymentVoucherSchema.index({ organization: 1 });
 
-paymentVoucherSchema.pre('save', function (next) {
+paymentVoucherSchema.pre('save', async function () {
   if (this.isNew && !this.voucherNumber) {
     const prefix = this.type === 'receipt' ? 'RV' : 'PV';
     this.voucherNumber = `${prefix}-${Date.now()}`;
@@ -126,7 +126,6 @@ paymentVoucherSchema.pre('save', function (next) {
   // Money-Type Migration (audit #5) — dual-write integer-halalas siblings.
   // (Extends the existing callback-style hook in-style; no new hook added.)
   require('../intelligence/money.lib').deriveHalalas(this, ['amount', 'taxAmount', 'netAmount']);
-  next();
 });
 
 module.exports =

--- a/backend/models/PrescriptionValidation.js
+++ b/backend/models/PrescriptionValidation.js
@@ -44,9 +44,8 @@ const prescriptionValidationSchema = new mongoose.Schema(
 prescriptionValidationSchema.index({ branchId: 1, beneficiaryId: 1, status: 1 });
 prescriptionValidationSchema.index({ prescriptionId: 1 });
 
-prescriptionValidationSchema.pre('save', function (next) {
+prescriptionValidationSchema.pre('save', async function () {
   if (!this.uuid) this.uuid = require('crypto').randomUUID();
-  next();
 });
 
 module.exports =

--- a/backend/models/Product.js
+++ b/backend/models/Product.js
@@ -37,9 +37,8 @@ const productSchema = new mongoose.Schema({
 });
 
 // Update timestamp on save
-productSchema.pre('save', function (next) {
+productSchema.pre('save', async function () {
   this.updatedAt = Date.now();
-  next();
 });
 
 // ── Indexes ───────────────────────────────────────────────────────────────

--- a/backend/models/PublicBookingRequest.js
+++ b/backend/models/PublicBookingRequest.js
@@ -82,7 +82,7 @@ const schema = new mongoose.Schema(
 );
 
 // Auto-generate confirmation number (AW-YYYYMMDD-RRRRR) before validation.
-schema.pre('validate', function (next) {
+schema.pre('validate', async function () {
   if (!this.confirmationNumber) {
     const date = new Date();
     const y = date.getFullYear();
@@ -91,7 +91,6 @@ schema.pre('validate', function (next) {
     const rand = crypto.randomBytes(3).toString('hex').toUpperCase(); // 6 hex chars
     this.confirmationNumber = `AW-${y}${m}${d}-${rand}`;
   }
-  next();
 });
 
 schema.index({ createdAt: -1 });

--- a/backend/models/PublicJobApplication.js
+++ b/backend/models/PublicJobApplication.js
@@ -57,7 +57,7 @@ const schema = new mongoose.Schema(
   { timestamps: true }
 );
 
-schema.pre('validate', function (next) {
+schema.pre('validate', async function () {
   if (!this.referenceNumber) {
     const d = new Date();
     const y = d.getFullYear();
@@ -66,7 +66,6 @@ schema.pre('validate', function (next) {
     const rand = crypto.randomBytes(3).toString('hex').toUpperCase();
     this.referenceNumber = `AWHR-${y}${m}${day}-${rand}`;
   }
-  next();
 });
 
 schema.index({ createdAt: -1 });

--- a/backend/models/QuizAttempt.js
+++ b/backend/models/QuizAttempt.js
@@ -43,9 +43,8 @@ const quizAttemptSchema = new mongoose.Schema(
 quizAttemptSchema.index({ branchId: 1, userId: 1, quizId: 1 });
 quizAttemptSchema.index({ enrollmentId: 1, attemptNumber: 1 });
 
-quizAttemptSchema.pre('save', function (next) {
+quizAttemptSchema.pre('save', async function () {
   if (!this.uuid) this.uuid = require('crypto').randomUUID();
-  next();
 });
 
 module.exports = mongoose.models.QuizAttempt || mongoose.model('QuizAttempt', quizAttemptSchema);

--- a/backend/models/QuizQuestion.js
+++ b/backend/models/QuizQuestion.js
@@ -42,9 +42,8 @@ const quizQuestionSchema = new mongoose.Schema(
 quizQuestionSchema.index({ quizId: 1, orderIndex: 1 });
 quizQuestionSchema.index({ difficulty: 1 });
 
-quizQuestionSchema.pre('save', function (next) {
+quizQuestionSchema.pre('save', async function () {
   if (!this.uuid) this.uuid = require('crypto').randomUUID();
-  next();
 });
 
 module.exports = mongoose.models.QuizQuestion || mongoose.model('QuizQuestion', quizQuestionSchema);

--- a/backend/models/RehabPlanSuggestion.js
+++ b/backend/models/RehabPlanSuggestion.js
@@ -47,9 +47,8 @@ rehabPlanSuggestionSchema.index({ branchId: 1, beneficiaryId: 1, status: 1 });
 rehabPlanSuggestionSchema.index({ generationMethod: 1 });
 rehabPlanSuggestionSchema.index({ confidenceScore: -1 });
 
-rehabPlanSuggestionSchema.pre('save', function (next) {
+rehabPlanSuggestionSchema.pre('save', async function () {
   if (!this.uuid) this.uuid = require('crypto').randomUUID();
-  next();
 });
 
 module.exports =

--- a/backend/models/RiskAssessment.js
+++ b/backend/models/RiskAssessment.js
@@ -204,7 +204,7 @@ riskAssessmentSchema.virtual('riskLevel').get(function () {
 });
 
 // ===== HOOKS =====
-riskAssessmentSchema.pre('save', function (next) {
+riskAssessmentSchema.pre('save', async function () {
   // تحديد درجة الخطورة بناءً على الاحتمالية والتأثير
   const severity = this.riskScore;
   if (severity >= 0.75) {
@@ -217,7 +217,6 @@ riskAssessmentSchema.pre('save', function (next) {
     this.assessment.severity = 'low';
   }
 
-  next();
 });
 
 // ===== METHODS =====

--- a/backend/models/Schedule.js
+++ b/backend/models/Schedule.js
@@ -89,9 +89,8 @@ scheduleSchema.index({ status: 1, startDate: 1 });
 scheduleSchema.index({ createdBy: 1, createdAt: -1 });
 
 // Middleware to update updatedAt
-scheduleSchema.pre('save', function (next) {
+scheduleSchema.pre('save', async function () {
   this.updatedAt = Date.now();
-  next();
 });
 
 module.exports = mongoose.models.Schedule || mongoose.model('Schedule', scheduleSchema);

--- a/backend/models/SmartIRP.js
+++ b/backend/models/SmartIRP.js
@@ -593,9 +593,8 @@ smartIRPSchema.methods.scheduleNextReview = function () {
 };
 
 // Middleware to update timestamps
-smartIRPSchema.pre('save', function (next) {
+smartIRPSchema.pre('save', async function () {
   this.updatedAt = new Date();
-  next();
 });
 
 const SmartIRP = mongoose.models.SmartIRP || mongoose.model('SmartIRP', smartIRPSchema);

--- a/backend/models/SupportedHousing.js
+++ b/backend/models/SupportedHousing.js
@@ -304,7 +304,7 @@ supportedHousingSchema.index({ programType: 1, status: 1 });
 supportedHousingSchema.index({ 'housingUnit.status': 1 });
 
 // ─── حساب الجاهزية قبل الحفظ ───
-supportedHousingSchema.pre('save', function (next) {
+supportedHousingSchema.pre('save', async function () {
   // حساب درجة الجاهزية في آخر تقييم
   if (this.readinessAssessments && this.readinessAssessments.length > 0) {
     const latest = this.readinessAssessments[this.readinessAssessments.length - 1];
@@ -327,7 +327,6 @@ supportedHousingSchema.pre('save', function (next) {
     else if (latest.overallReadiness >= 40) latest.readinessLevel = 'preparing';
     else latest.readinessLevel = 'not_ready';
   }
-  next();
 });
 
 // ─── Virtuals ───

--- a/backend/models/TaxFiling.js
+++ b/backend/models/TaxFiling.js
@@ -89,7 +89,7 @@ const taxFilingSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-taxFilingSchema.pre('save', function (next) {
+taxFilingSchema.pre('save', async function () {
   // Money-Type Migration (audit #5) — dual-write integer-halalas siblings.
   require('../intelligence/money.lib').deriveHalalas(this, [
     'preparedAmount',
@@ -107,7 +107,6 @@ taxFilingSchema.pre('save', function (next) {
     this.filingNumber = `TF-${this.type}-${Date.now().toString(36).toUpperCase()}`;
   }
   this.differenceAmount = (this.assessedAmount || 0) - (this.submittedAmount || 0);
-  next();
 });
 
 taxFilingSchema.index({ organization: 1, type: 1, periodStart: 1 });
@@ -155,7 +154,7 @@ const taxPenaltySchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-taxPenaltySchema.pre('save', function (next) {
+taxPenaltySchema.pre('save', async function () {
   this.totalDue = (this.amount || 0) + (this.interestAmount || 0);
   // Money-Type Migration (audit #5) — dual-write integer-halalas siblings.
   require('../intelligence/money.lib').deriveHalalas(this, [
@@ -164,7 +163,6 @@ taxPenaltySchema.pre('save', function (next) {
     'totalDue',
     'paidAmount',
   ]);
-  next();
 });
 
 taxPenaltySchema.index({ organization: 1, filingId: 1 });

--- a/backend/models/TrainerEvaluation.js
+++ b/backend/models/TrainerEvaluation.js
@@ -39,9 +39,8 @@ const trainerEvaluationSchema = new mongoose.Schema(
 trainerEvaluationSchema.index({ enrollmentId: 1, trainerId: 1 }, { unique: true });
 trainerEvaluationSchema.index({ branchId: 1, trainerId: 1, courseId: 1 });
 
-trainerEvaluationSchema.pre('save', function (next) {
+trainerEvaluationSchema.pre('save', async function () {
   if (!this.uuid) this.uuid = require('crypto').randomUUID();
-  next();
 });
 
 module.exports =

--- a/backend/models/TrainingCompliance.js
+++ b/backend/models/TrainingCompliance.js
@@ -37,9 +37,8 @@ trainingComplianceSchema.index({ userId: 1, courseId: 1, year: 1 }, { unique: tr
 trainingComplianceSchema.index({ branchId: 1, status: 1, dueDate: 1 });
 trainingComplianceSchema.index({ userId: 1 });
 
-trainingComplianceSchema.pre('save', function (next) {
+trainingComplianceSchema.pre('save', async function () {
   if (!this.uuid) this.uuid = require('crypto').randomUUID();
-  next();
 });
 
 module.exports =

--- a/backend/models/WaitlistEntry.js
+++ b/backend/models/WaitlistEntry.js
@@ -278,14 +278,13 @@ waitlistEntrySchema.virtual('priorityScore').get(function () {
 });
 
 // ─── Middleware: تسجيل تاريخ تغيير الحالة ─────────────────────────────────────
-waitlistEntrySchema.pre('save', function (next) {
+waitlistEntrySchema.pre('save', async function () {
   if (this.isModified('status') && !this.isNew) {
     this.statusHistory.push({
       status: this.status,
       changedAt: new Date(),
     });
   }
-  next();
 });
 
 // ─── Methods ───────────────────────────────────────────────────────────────────

--- a/backend/models/WebhookDelivery.js
+++ b/backend/models/WebhookDelivery.js
@@ -116,9 +116,8 @@ webhookDeliverySchema.index(
 );
 
 // Pre-save middleware
-webhookDeliverySchema.pre('save', function (next) {
+webhookDeliverySchema.pre('save', async function () {
   this.updatedAt = new Date();
-  next();
 });
 
 module.exports =

--- a/backend/models/clinical-assessment/caregiver-burden-assessment.model.js
+++ b/backend/models/clinical-assessment/caregiver-burden-assessment.model.js
@@ -91,7 +91,7 @@ const CaregiverBurdenSchema = new Schema(
 CaregiverBurdenSchema.index({ beneficiary: 1, assessment_date: -1 });
 CaregiverBurdenSchema.index({ branch: 1, status: 1, createdAt: -1 });
 
-CaregiverBurdenSchema.pre('save', function (next) {
+CaregiverBurdenSchema.pre('save', async function () {
   if (typeof this.total_score === 'number' && !this.burden_level) {
     const s = this.total_score;
     if (s <= 20) {
@@ -108,7 +108,6 @@ CaregiverBurdenSchema.pre('save', function (next) {
       this.burden_level_ar = 'عبء شديد';
     }
   }
-  next();
 });
 
 CaregiverBurdenSchema.virtual('burden_summary').get(function () {

--- a/backend/models/clinical-assessment/mchat-assessment.model.js
+++ b/backend/models/clinical-assessment/mchat-assessment.model.js
@@ -84,7 +84,7 @@ MChatAssessmentSchema.index({ notes: 'text' });
 
 // ─── Pre-save Hook ────────────────────────────────────────────────────────────
 
-MChatAssessmentSchema.pre('save', function (next) {
+MChatAssessmentSchema.pre('save', async function () {
   if (typeof this.total_risk_score === 'number' && !this.risk_level) {
     if (this.total_risk_score <= 2) this.risk_level = 'low';
     else if (this.total_risk_score <= 7) this.risk_level = 'medium';
@@ -93,7 +93,6 @@ MChatAssessmentSchema.pre('save', function (next) {
   if (this.risk_level === 'low') this.risk_level_ar = 'منخفض';
   else if (this.risk_level === 'medium') this.risk_level_ar = 'متوسط';
   else if (this.risk_level === 'high') this.risk_level_ar = 'مرتفع';
-  next();
 });
 
 // ─── Virtuals ─────────────────────────────────────────────────────────────────

--- a/backend/models/clinical-assessment/quality-of-life-assessment.model.js
+++ b/backend/models/clinical-assessment/quality-of-life-assessment.model.js
@@ -85,7 +85,7 @@ QualityOfLifeSchema.index({ branch: 1, status: 1, createdAt: -1 });
 
 // ─── Pre-save Hook ────────────────────────────────────────────────────────────
 
-QualityOfLifeSchema.pre('save', function (next) {
+QualityOfLifeSchema.pre('save', async function () {
   if (typeof this.total_transformed_score === 'number' && !this.interpretation) {
     const s = this.total_transformed_score;
     if (s >= 80) this.interpretation = 'جودة حياة ممتازة';
@@ -94,7 +94,6 @@ QualityOfLifeSchema.pre('save', function (next) {
     else if (s >= 20) this.interpretation = 'جودة حياة منخفضة';
     else this.interpretation = 'جودة حياة متدنية جداً';
   }
-  next();
 });
 
 // ─── Virtuals ─────────────────────────────────────────────────────────────────

--- a/backend/models/clinical-assessment/srs2-assessment.model.js
+++ b/backend/models/clinical-assessment/srs2-assessment.model.js
@@ -81,7 +81,7 @@ SRS2AssessmentSchema.index({ notes: 'text' });
 
 // ─── Pre-save Hook ────────────────────────────────────────────────────────────
 
-SRS2AssessmentSchema.pre('save', function (next) {
+SRS2AssessmentSchema.pre('save', async function () {
   if (typeof this.total_t_score === 'number' && !this.severity_classification) {
     const t = this.total_t_score;
     if (t <= 59) {
@@ -98,7 +98,6 @@ SRS2AssessmentSchema.pre('save', function (next) {
       this.severity_classification_ar = 'شديد';
     }
   }
-  next();
 });
 
 // ─── Virtuals ─────────────────────────────────────────────────────────────────

--- a/backend/models/conversation.model.js
+++ b/backend/models/conversation.model.js
@@ -343,17 +343,15 @@ conversationSchema.statics.createGroupConversation = async function (
 };
 
 // Hook: قبل الحفظ
-conversationSchema.pre('save', function (next) {
+conversationSchema.pre('save', async function () {
   // تحديث عدد المشاركين النشطين
   this.stats.totalParticipants = this.participants.filter(p => p.isActive).length;
-  next();
 });
 
 // Hook: تنظيف المستخدمين الذين يكتبون (إزالة القديم)
-conversationSchema.pre('save', function (next) {
+conversationSchema.pre('save', async function () {
   const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
   this.typingUsers = this.typingUsers.filter(t => t.startedAt > fiveMinutesAgo);
-  next();
 });
 
 const Conversation =

--- a/backend/models/disability-assessment.model.js
+++ b/backend/models/disability-assessment.model.js
@@ -789,7 +789,7 @@ disabilityAssessmentSchema.statics.getRehabReadinessOverview = async function ()
 };
 
 // ── Pre-save: auto-calculate rehabilitation readiness level ──
-disabilityAssessmentSchema.pre('save', function (next) {
+disabilityAssessmentSchema.pre('save', async function () {
   const r = this.rehabilitation_readiness;
   if (r && r.motivation_score != null && r.cognitive_capacity != null) {
     const avg =
@@ -806,7 +806,6 @@ disabilityAssessmentSchema.pre('save', function (next) {
   }
 
   this.last_updated = new Date();
-  next();
 });
 
 module.exports =

--- a/backend/models/emr.model.js
+++ b/backend/models/emr.model.js
@@ -206,7 +206,7 @@ const VitalSignSchema = new Schema(
 VitalSignSchema.index({ beneficiary: 1, recordedAt: -1 });
 
 // Auto-calculate BMI
-VitalSignSchema.pre('save', function (next) {
+VitalSignSchema.pre('save', async function () {
   if (this.weight?.value && this.height) {
     const heightM = this.height / 100;
     this.bmi = Math.round((this.weight.value / (heightM * heightM)) * 10) / 10;
@@ -215,7 +215,6 @@ VitalSignSchema.pre('save', function (next) {
     this.glasgowComaScale.total =
       this.glasgowComaScale.eye + this.glasgowComaScale.verbal + this.glasgowComaScale.motor;
   }
-  next();
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/backend/models/pharmacy.model.js
+++ b/backend/models/pharmacy.model.js
@@ -197,14 +197,13 @@ prescriptionSchema.index({ beneficiary: 1, status: 1 });
 prescriptionSchema.index({ prescriber: 1, createdAt: -1 });
 prescriptionSchema.index({ status: 1, createdAt: -1 });
 
-prescriptionSchema.pre('save', function (next) {
+prescriptionSchema.pre('save', async function () {
   if (!this.prescriptionNumber) {
     this.prescriptionNumber = `RX-${Date.now()}-${Math.random().toString(36).substr(2, 5).toUpperCase()}`;
   }
   if (!this.validUntil) {
     this.validUntil = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
   }
-  next();
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -257,11 +256,10 @@ dispensingSchema.index({ prescription: 1 });
 dispensingSchema.index({ beneficiary: 1, createdAt: -1 });
 dispensingSchema.index({ pharmacist: 1, createdAt: -1 });
 
-dispensingSchema.pre('save', function (next) {
+dispensingSchema.pre('save', async function () {
   if (!this.dispensingNumber) {
     this.dispensingNumber = `DSP-${Date.now()}-${Math.random().toString(36).substr(2, 5).toUpperCase()}`;
   }
-  next();
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/backend/models/quality/Risk.model.js
+++ b/backend/models/quality/Risk.model.js
@@ -60,7 +60,7 @@ const riskSchema = new mongoose.Schema(
 );
 
 // حساب درجة المخاطرة تلقائياً
-riskSchema.pre('save', function (next) {
+riskSchema.pre('save', async function () {
   this.riskScore = this.likelihood * this.impact;
   const score = this.riskScore;
   if (score >= 17) this.riskLevel = 'critical';
@@ -71,7 +71,6 @@ riskSchema.pre('save', function (next) {
   if (this.residualLikelihood && this.residualImpact) {
     this.residualRiskScore = this.residualLikelihood * this.residualImpact;
   }
-  next();
 });
 
 riskSchema.index({ branchId: 1, riskLevel: 1, status: 1 });

--- a/backend/models/rehabilitation/Program.js
+++ b/backend/models/rehabilitation/Program.js
@@ -132,12 +132,11 @@ programSchema.virtual('type_label').get(function () {
 });
 
 // ── Pre-save ──────────────────────────────────────────────────────────────────
-programSchema.pre('save', function (next) {
+programSchema.pre('save', async function () {
   // تأكد من أن مدة البرامج المهنية لا تتجاوز 3 سنوات
   if (this.program_type === 'vocational') {
     this.max_duration_years = 3;
   }
-  next();
 });
 
 // ── Statics ───────────────────────────────────────────────────────────────────

--- a/backend/models/reports/ReportSchedule.js
+++ b/backend/models/reports/ReportSchedule.js
@@ -101,11 +101,10 @@ reportScheduleSchema.index({ template_id: 1 });
 reportScheduleSchema.index({ deleted_at: 1 });
 
 // حساب next_run_at تلقائياً قبل الحفظ
-reportScheduleSchema.pre('save', function (next) {
+reportScheduleSchema.pre('save', async function () {
   if (this.isModified('frequency') || this.isModified('time_of_day') || this.isNew) {
     this.next_run_at = this._computeNextRun();
   }
-  next();
 });
 
 reportScheduleSchema.methods._computeNextRun = function () {

--- a/backend/models/scheduling/WaitlistEntry.js
+++ b/backend/models/scheduling/WaitlistEntry.js
@@ -40,7 +40,7 @@ const waitlistEntrySchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-waitlistEntrySchema.pre('save', function (next) {
+waitlistEntrySchema.pre('save', async function () {
   // حساب أيام الانتظار
   this.waiting_days = Math.floor((Date.now() - this.registration_date) / (1000 * 60 * 60 * 24));
   // حساب نقاط الأولوية
@@ -57,7 +57,6 @@ waitlistEntrySchema.pre('save', function (next) {
   // إحالة طبية عاجلة
   if (this.urgent_medical_referral) score += 25;
   this.priority_score = score;
-  next();
 });
 
 waitlistEntrySchema.index({ branch_id: 1, service_type: 1, priority_score: -1 });

--- a/backend/privacy/data-subject-request.model.js
+++ b/backend/privacy/data-subject-request.model.js
@@ -55,11 +55,10 @@ const DsrSchema = new mongoose.Schema(
 );
 
 /** Auto-set slaDeadline if not provided. */
-DsrSchema.pre('validate', function (next) {
+DsrSchema.pre('validate', async function () {
   if (!this.slaDeadline) {
     this.slaDeadline = new Date(Date.now() + SLA_DAYS * 24 * 60 * 60 * 1000);
   }
-  next();
 });
 
 DsrSchema.methods.isOverdue = function (now = Date.now()) {

--- a/backend/scripts/check-mongoose-hook-style.js
+++ b/backend/scripts/check-mongoose-hook-style.js
@@ -82,90 +82,25 @@ const HOOK_RE =
 // entry from this Set, commit. Same wave pattern that drove W325c
 // phantom-ref baseline 58 → 0 across ~12 waves.
 const KNOWN_CALLBACK_HOOK_BASELINE = new Set([
-  'domains/care-plans/models/UnifiedCarePlan.js',
-  'domains/sessions/models/ClinicalSession.js',
-  'models/AccountingExpense.js',
-  'models/AiRecommendationBundle.js',
-  'models/Assessment.js',
-  'models/Asset.js',
-  'models/AwarenessProgram.js',
-  'models/BeneficiaryManagement/AcademicRecord.js',
-  'models/BeneficiaryManagement/Achievement.js',
-  'models/BeneficiaryManagement/AttendanceRecord.js',
-  'models/BeneficiaryManagement/CounselingSession.js',
-  'models/BeneficiaryManagement/FinancialSupport.js',
-  'models/BeneficiaryManagement/Scholarship.js',
-  'models/BeneficiaryManagement/SkillsDevelopment.js',
-  'models/BeneficiaryManagement/SupportPlan.js',
-  'models/BeneficiaryVoiceLog.js',
-  // W494 ratchet wave 3: 3 Cdss* + ClinicalRule + CpdRecord (-5)
-  // W494 ratchet wave 4: CommunityActivity + ComplianceMetric +
-  //   CourseEnrollment + CourseModule + CrisisIncident (-5)
-  'models/ComplaintEnhanced.js',
-  // W494 ratchet wave 1: Webhook + EmailPreference + CrmCampaign (-3)
-  // W494 ratchet wave 2: 5 Crm* models (CrmLead/Partner/Referral/Segment/Survey)
-  //   — all single uuid-fill hooks, trivial async conversion.
-  'models/CulturalProfile.js',
-  'models/DecisionRightsAssessment.js',
-  // W494 ratchet wave 4 (parallel agent): Delegation + DifferentialDiagnosis + DisabilityProgram
-  // (CrmCampaign + Webhook + EmailPreference removed — see W494 ratchet)
-  'models/DisabilitySession.js',
-  // W494 ratchet (mine, +2): DiscussionForum + DrugLibrary converted to async.
-  // W494 ratchet wave 6: ESignature + EStamp + ElearningCourse +
-  //   ElearningQuiz (-4) — auto-expiry + uuid-fill hooks.
-  'models/EmergencyPlan.js',
-  'models/EnterpriseRisk.js',
-  'models/EventParticipation.js',
-  'models/Exam.js',
-  'models/FamilyCounsellingSession.js',
-  'models/FinancialTransaction.js',
-  // (ForumReply removed — W494 ratchet wave 6 bonus)
-  'models/Goal.js',
-  'models/HikvisionRawEvent.js',
-  'models/ImportExportJob.js',
-  'models/ImportExportTemplate.js',
-  'models/Incident.js',
-  'models/InsuranceTariff.js',
-  'models/LearningPath.js',
-  // models/MDTCoordination.js — removed W629: unifiedRehabPlanSchema callback
-  // hook converted to async (ratchet-DOWN) so the sibling
-  // deriveBranchFromBeneficiary hook can be async on the same event.
-  'models/Maintenance.js',
-  'models/MaintenancePrediction.js',
-  'models/ModuleProgress.js',
-  'models/ParentChatbotSession.js',
-  'models/PaymentVoucher.js',
-  'models/PrescriptionValidation.js',
-  'models/Product.js',
-  'models/Productivity/UserPreferences.js',
-  'models/QuizAttempt.js',
-  'models/QuizQuestion.js',
-  'models/RehabPlanSuggestion.js',
-  'models/RiskAssessment.js',
-  'models/Schedule.js',
-  'models/SiblingAdjustmentRecord.js',
-  'models/SmartIRP.js',
-  'models/TaxFiling.js',
-  'models/TrainerEvaluation.js',
-  'models/TrainingCompliance.js',
-  'models/WaitlistEntry.js',
-  'models/WebhookDelivery.js',
-  'models/auditLog.model.js',
-  'models/clinical-assessment/caregiver-burden-assessment.model.js',
-  'models/clinical-assessment/mchat-assessment.model.js',
-  'models/clinical-assessment/quality-of-life-assessment.model.js',
-  'models/conversation.model.js',
-  'models/disability-assessment.model.js',
-  'models/emr.model.js',
-  // models/gratuity.model.js — removed: hook converted to async (W494/audit #5)
-  'models/pharmacy.model.js',
-  // W503: CapaItem converted to async style — unblocks auto-CAPA on major equity disparity.
-  'models/quality/Risk.model.js',
-  'models/rehabilitation/Program.js',
-  'models/reports/ReportSchedule.js',
-  'privacy/consent.model.js',
-  'privacy/data-subject-request.model.js',
-  'services/whatsapp/templateSync.service.js',
+  // W948 — remaining SYNC callback hooks with next(arg) bodies (need manual
+  // throw-conversion); the 50 bare-next baseline files were converted to async.
+  "models/AccountingExpense.js",
+  "models/AiRecommendationBundle.js",
+  "models/BeneficiaryVoiceLog.js",
+  "models/CulturalProfile.js",
+  "models/DecisionRightsAssessment.js",
+  "models/EmergencyPlan.js",
+  "models/FamilyCounsellingSession.js",
+  "models/FinancialTransaction.js",
+  "models/Goal.js",
+  "models/HikvisionRawEvent.js",
+  "models/InsuranceTariff.js",
+  "models/ParentChatbotSession.js",
+  "models/Productivity/UserPreferences.js",
+  "models/SiblingAdjustmentRecord.js",
+  "models/auditLog.model.js",
+  "privacy/consent.model.js",
+  "services/whatsapp/templateSync.service.js",
 ]);
 
 function listSchemaFiles(roots) {


### PR DESCRIPTION
## المشكلة (مؤكَّدة بإعادة إنتاج)
رفيق W946. الخطّافات المتزامنة `pre/post('save', function (next){…next()})` **تكسر أيضاً** في Mongoose 9.6.2 (next undefined → "next is not a function" على كل حفظ). كانت في قاعدة `KNOWN_CALLBACK_HOOK_BASELINE` (دَين متدرّج) لكنها تمنع الحفظ فعلاً.

## الحل
حُوّل **67 ملفاً** خطّافاتها تستخدم `next()`/`return next()` فقط → async نقي (50 من القاعدة + 17 فاتت نافذة البوابة). مُتحقَّق: الموديلات المحوّلة تصل لتحقّق الحقول بدل الكسر.
- القاعدة: **67 → 17** (المتبقّي خطّافات `next(arg)` تحتاج تحويل throw يدوياً — الأقواس المتداخلة غير آمنة للتحويل الآلي).
- البوابة خضراء + اختبارها الذاتي 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)