### PR TITLE
feat(waitlist): W979 wire the waitlist journey into the unified-core timeline

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1237,6 +1237,8 @@ on:
       - 'backend/__tests__/incident-ncr-producer-wave976.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/safety-core-linkage-wave977.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/waitlist-core-linkage-wave979.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2457,6 +2459,8 @@ on:
       - 'backend/__tests__/incident-ncr-producer-wave976.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/safety-core-linkage-wave977.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/waitlist-core-linkage-wave979.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/ddd-event-contracts-wave374.test.js
+++ b/backend/__tests__/ddd-event-contracts-wave374.test.js
@@ -63,6 +63,7 @@ const EXPECTED_DOMAIN_GROUPS = Object.freeze([
   'ai-recommendations',
   'appointments', // W970 — appointment booking/cancellation/no-show → core timeline
   'safety', // W977 — seizure / safeguarding / restraint → core timeline
+  'waitlist', // W979 — waitlist added / booked (admission) → core timeline
 ]);
 
 // Allowed `eventType` prefixes. Most match W354 TIER domain names; a few are
@@ -100,6 +101,7 @@ const ALLOWED_EVENT_PREFIXES = Object.freeze(
     'seizure', // W977
     'safeguarding', // W977
     'restraint', // W977
+    'waitlist', // W979
   ])
 );
 
@@ -145,6 +147,7 @@ describe('W374 DDD event-contracts drift guard', () => {
         'ai-recommendations': 'AI_RECOMMENDATION_EVENTS',
         appointments: 'APPOINTMENT_EVENTS', // W970
         safety: 'SAFETY_EVENTS', // W977
+        waitlist: 'WAITLIST_EVENTS', // W979
       };
       for (const [group, exportName] of Object.entries(groupExportMap)) {
         expect(contracts[exportName]).toBe(contracts.DDD_CONTRACTS[group]);

--- a/backend/__tests__/waitlist-core-linkage-wave979.test.js
+++ b/backend/__tests__/waitlist-core-linkage-wave979.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+/**
+ * waitlist-core-linkage-wave979.test.js — W979.
+ *
+ * Wires the waitlist journey into the unified-core timeline:
+ *   - Waitlist.create()          → waitlist.waitlist.added  → 'waitlisted' row
+ *   - status → 'BOOKED'          → waitlist.waitlist.booked → 'waitlist_booked'
+ *     row (admission into active care — the high-value moment)
+ *
+ * Producer: native pre-compile post-save hooks in models/Waitlist.js. RUNTIME
+ * end-to-end against a real in-memory Mongo + the real integration bus + real
+ * subscribers (the W349 lesson — assert the row actually persists).
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let Waitlist, CareTimeline;
+
+async function waitForTimeline(query, { timeout = 4000, interval = 25 } = {}) {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const row = await CareTimeline.findOne(query);
+    if (row) return row;
+    if (Date.now() - start > timeout) return null;
+    await new Promise(r => setTimeout(r, interval));
+  }
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w978-waitlist' } });
+  await mongoose.connect(mongod.getUri());
+
+  Waitlist = require('../models/Waitlist');
+  ({ CareTimeline } = require('../domains/timeline/models/CareTimeline'));
+  require('../models/Beneficiary');
+
+  const { integrationBus } = require('../integration/systemIntegrationBus');
+  const { initializeDDDSubscribers } = require('../integration/dddCrossModuleSubscribers');
+  initializeDDDSubscribers(integrationBus);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+afterEach(async () => {
+  await Promise.all([Waitlist.deleteMany({}), CareTimeline.deleteMany({})]);
+});
+
+function newEntry(extra = {}) {
+  return Waitlist.create({
+    beneficiary: new mongoose.Types.ObjectId(),
+    department: 'SPEECH',
+    priority: 'HIGH',
+    ...extra,
+  });
+}
+
+describe('W979 — waitlist journey reaches the unified-core timeline', () => {
+  it('adding to the waitlist lands a "waitlisted" row', async () => {
+    const e = await newEntry();
+    const tl = await waitForTimeline({ beneficiaryId: e.beneficiary, eventType: 'waitlisted' });
+    expect(tl).toBeTruthy();
+    expect(tl.category).toBe('administrative');
+    expect(tl.metadata.department).toBe('SPEECH');
+  });
+
+  it('booking from the waitlist lands a "waitlist_booked" (admission) row, once', async () => {
+    const e = await newEntry();
+    await waitForTimeline({ beneficiaryId: e.beneficiary, eventType: 'waitlisted' });
+
+    const loaded = await Waitlist.findById(e._id);
+    loaded.status = 'BOOKED';
+    await loaded.save();
+
+    const tl = await waitForTimeline({
+      beneficiaryId: e.beneficiary,
+      eventType: 'waitlist_booked',
+    });
+    expect(tl).toBeTruthy();
+    expect(tl.severity).toBe('success');
+
+    // booked fires once; waitlisted did not re-fire on the update
+    expect(
+      await CareTimeline.countDocuments({ beneficiaryId: e.beneficiary, eventType: 'waitlisted' })
+    ).toBe(1);
+  });
+
+  it('an OFFERED transition does not produce a booked row', async () => {
+    const e = await newEntry();
+    await waitForTimeline({ beneficiaryId: e.beneficiary, eventType: 'waitlisted' });
+    const loaded = await Waitlist.findById(e._id);
+    loaded.status = 'OFFERED';
+    await loaded.save();
+    await new Promise(r => setTimeout(r, 200));
+    expect(
+      await CareTimeline.countDocuments({
+        beneficiaryId: e.beneficiary,
+        eventType: 'waitlist_booked',
+      })
+    ).toBe(0);
+  });
+});

--- a/backend/domains/timeline/models/CareTimeline.js
+++ b/backend/domains/timeline/models/CareTimeline.js
@@ -31,6 +31,8 @@ const careTimelineSchema = new mongoose.Schema(
       enum: [
         // Lifecycle
         'registration',
+        'waitlisted', // W979
+        'waitlist_booked', // W979 — booked from the waitlist (admission)
         'admission',
         'discharge',
         'transfer',

--- a/backend/events/contracts/dddEventContracts.js
+++ b/backend/events/contracts/dddEventContracts.js
@@ -574,6 +574,48 @@ const SAFETY_EVENTS = {
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
+//  Waitlist Events — أحداث قائمة الانتظار (W979)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// The start of a beneficiary's care journey: added to the waitlist, then —
+// the high-value moment — BOOKED into active care (admission). Producer:
+// native Waitlist post-save hooks. Consumers: CareTimeline subscribers.
+
+const WAITLIST_EVENTS = {
+  ADDED: {
+    domain: 'waitlist',
+    eventType: 'waitlist.added',
+    version: 1,
+    description: 'تمت إضافة المستفيد لقائمة الانتظار — Beneficiary waitlisted',
+    payload: {
+      waitlistId: 'string',
+      beneficiaryId: 'string',
+      department: 'string',
+      priority: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards'],
+  },
+
+  BOOKED: {
+    domain: 'waitlist',
+    eventType: 'waitlist.booked',
+    version: 1,
+    description: 'تم حجز/قبول مستفيد من قائمة الانتظار — Waitlist entry booked (admission)',
+    payload: {
+      waitlistId: 'string',
+      beneficiaryId: 'string',
+      department: 'string',
+      priority: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.REALTIME, DELIVERY.LOCAL],
+    priority: PRIORITY.HIGH,
+    consumers: ['timeline', 'dashboards', 'notification'],
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
 //  Aggregated Contracts Registry
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -589,6 +631,7 @@ const DDD_CONTRACTS = {
   'ai-recommendations': AI_RECOMMENDATION_EVENTS,
   appointments: APPOINTMENT_EVENTS,
   safety: SAFETY_EVENTS,
+  waitlist: WAITLIST_EVENTS,
 };
 
 /**
@@ -617,6 +660,7 @@ module.exports = {
   AI_RECOMMENDATION_EVENTS,
   APPOINTMENT_EVENTS,
   SAFETY_EVENTS,
+  WAITLIST_EVENTS,
   DDD_CONTRACTS,
   getDDDContractStats,
 };

--- a/backend/integration/dddCrossModuleSubscribers.js
+++ b/backend/integration/dddCrossModuleSubscribers.js
@@ -846,6 +846,56 @@ function initializeDDDSubscribers(integrationBus, _moduleConnector) {
     },
   });
 
+  // ─── Waitlist → Timeline: Added (W979) ────────────────────────────
+  subscribers.push({
+    name: 'waitlist:added → timeline:record',
+    pattern: 'waitlist.waitlist.added',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'waitlisted',
+            category: 'administrative',
+            severity: 'info',
+            title: `Added to waitlist (${event.payload.department || ''})`.trim(),
+            title_ar: `إضافة لقائمة الانتظار (${event.payload.department || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Waitlist-added timeline failed: ${err.message}`);
+      }
+    },
+  });
+
+  // ─── Waitlist → Timeline: Booked = admission (W979) ───────────────
+  subscribers.push({
+    name: 'waitlist:booked → timeline:record',
+    pattern: 'waitlist.waitlist.booked',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'waitlist_booked',
+            category: 'administrative',
+            severity: 'success',
+            title: `Booked from waitlist — admission (${event.payload.department || ''})`.trim(),
+            title_ar: `حجز/قبول من قائمة الانتظار (${event.payload.department || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Waitlist-booked timeline failed: ${err.message}`);
+      }
+    },
+  });
+
   // ── Register all subscribers ───────────────────────────────────────
   let registered = 0;
   for (const sub of subscribers) {

--- a/backend/models/Waitlist.js
+++ b/backend/models/Waitlist.js
@@ -30,4 +30,38 @@ waitlistSchema.index({ department: 1 });
 waitlistSchema.index({ priority: 1 });
 waitlistSchema.index({ status: 1, department: 1 });
 waitlistSchema.index({ createdAt: -1 });
+
+// W979 — surface the waitlist journey on the unified-core timeline: a new
+// waitlist entry (`waitlist.added`) and — the high-value moment — the entry
+// being BOOKED (`waitlist.booked` = admission into active care). Native
+// pre-compile hooks (schema middleware added after mongoose.model() never
+// fires); 0-arg pre + function(doc) post per the proven W970 pattern; guarded,
+// fire-and-forget. Consumed by dddCrossModuleSubscribers.js.
+waitlistSchema.pre('save', function () {
+  this.$__wasNew = this.isNew;
+});
+waitlistSchema.post('init', function () {
+  this.$__prevStatus = this.status;
+});
+waitlistSchema.post('save', function (doc) {
+  try {
+    const { integrationBus } = require('../integration/systemIntegrationBus');
+    if (!integrationBus || typeof integrationBus.publish !== 'function') return;
+    if (!doc.beneficiary) return;
+    const base = {
+      waitlistId: String(doc._id),
+      beneficiaryId: String(doc.beneficiary),
+      department: doc.department || '',
+      priority: doc.priority || '',
+    };
+    if (this.$__wasNew) {
+      Promise.resolve(integrationBus.publish('waitlist', 'waitlist.added', base)).catch(() => {});
+    } else if (doc.status === 'BOOKED' && this.$__prevStatus !== 'BOOKED') {
+      Promise.resolve(integrationBus.publish('waitlist', 'waitlist.booked', base)).catch(() => {});
+    }
+  } catch (_) {
+    /* bus not wired — never block persistence */
+  }
+});
+
 module.exports = mongoose.models.Waitlist || mongoose.model('Waitlist', waitlistSchema);

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -729,3 +729,4 @@ __tests__/quality-bus-unification-wave974.test.js
 __tests__/model-event-bridge-global-plugin-wave974.test.js
 __tests__/incident-ncr-producer-wave976.test.js
 __tests__/safety-core-linkage-wave977.test.js
+__tests__/waitlist-core-linkage-wave979.test.js


### PR DESCRIPTION
Tier-1 ledger item: waitlist add → 'waitlisted' row; status→BOOKED → 'waitlist_booked' (admission). Native pre-compile model hooks (W970 pattern) + WAITLIST_EVENTS contracts + W374 + 2 enum values + 2 subscribers. Verified end-to-end (wave979, 3 tests); W389/W374/W375 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)