### PR TITLE
feat(screenings): W980 wire vision/hearing screenings into the unified-core timeline

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1239,6 +1239,8 @@ on:
       - 'backend/__tests__/safety-core-linkage-wave977.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/waitlist-core-linkage-wave979.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/screening-core-linkage-wave980.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2461,6 +2463,8 @@ on:
       - 'backend/__tests__/safety-core-linkage-wave977.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/waitlist-core-linkage-wave979.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/screening-core-linkage-wave980.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/ddd-event-contracts-wave374.test.js
+++ b/backend/__tests__/ddd-event-contracts-wave374.test.js
@@ -64,6 +64,7 @@ const EXPECTED_DOMAIN_GROUPS = Object.freeze([
   'appointments', // W970 — appointment booking/cancellation/no-show → core timeline
   'safety', // W977 — seizure / safeguarding / restraint → core timeline
   'waitlist', // W979 — waitlist added / booked (admission) → core timeline
+  'screenings', // W980 — vision / hearing screening finalized → core timeline
 ]);
 
 // Allowed `eventType` prefixes. Most match W354 TIER domain names; a few are
@@ -102,6 +103,7 @@ const ALLOWED_EVENT_PREFIXES = Object.freeze(
     'safeguarding', // W977
     'restraint', // W977
     'waitlist', // W979
+    'screening', // W980
   ])
 );
 
@@ -148,6 +150,7 @@ describe('W374 DDD event-contracts drift guard', () => {
         appointments: 'APPOINTMENT_EVENTS', // W970
         safety: 'SAFETY_EVENTS', // W977
         waitlist: 'WAITLIST_EVENTS', // W979
+        screenings: 'SCREENING_EVENTS', // W980
       };
       for (const [group, exportName] of Object.entries(groupExportMap)) {
         expect(contracts[exportName]).toBe(contracts.DDD_CONTRACTS[group]);

--- a/backend/__tests__/screening-core-linkage-wave980.test.js
+++ b/backend/__tests__/screening-core-linkage-wave980.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+/**
+ * screening-core-linkage-wave980.test.js — W980.
+ *
+ * Wires finalized vision/hearing screenings into the unified-core timeline,
+ * flagging outcome='refer' (needs ophthalmology/optometry or audiology/ENT) as a
+ * warning. Producers: native VisionScreening/HearingScreening post-save hooks
+ * (fire when status reaches 'finalized', once). RUNTIME end-to-end against a real
+ * in-memory Mongo + the real integration bus + real subscribers.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let VisionScreening, HearingScreening, CareTimeline;
+
+async function waitForTimeline(query, { timeout = 4000, interval = 25 } = {}) {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const row = await CareTimeline.findOne(query);
+    if (row) return row;
+    if (Date.now() - start > timeout) return null;
+    await new Promise(r => setTimeout(r, interval));
+  }
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w980-screen' } });
+  await mongoose.connect(mongod.getUri());
+
+  VisionScreening = require('../models/VisionScreening');
+  HearingScreening = require('../models/HearingScreening');
+  ({ CareTimeline } = require('../domains/timeline/models/CareTimeline'));
+  require('../models/Beneficiary');
+
+  const { integrationBus } = require('../integration/systemIntegrationBus');
+  const { initializeDDDSubscribers } = require('../integration/dddCrossModuleSubscribers');
+  initializeDDDSubscribers(integrationBus);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+afterEach(async () => {
+  await Promise.all([
+    VisionScreening.deleteMany({}),
+    HearingScreening.deleteMany({}),
+    CareTimeline.deleteMany({}),
+  ]);
+});
+
+const finalizeFields = () => ({ screenedBy: new mongoose.Types.ObjectId(), screenedAt: new Date() });
+
+describe('W980 — screenings reach the unified-core timeline', () => {
+  it('a draft vision screening produces no row; finalizing it lands screening_completed', async () => {
+    const beneficiaryId = new mongoose.Types.ObjectId();
+    const v = await VisionScreening.create({
+      beneficiaryId,
+      date: new Date(),
+      screeningMethod: 'snellen_chart',
+      outcome: 'pass',
+      status: 'draft',
+    });
+    await new Promise(r => setTimeout(r, 150));
+    expect(await CareTimeline.countDocuments({ beneficiaryId })).toBe(0);
+
+    const loaded = await VisionScreening.findById(v._id);
+    loaded.status = 'finalized';
+    Object.assign(loaded, finalizeFields());
+    await loaded.save();
+
+    const tl = await waitForTimeline({ beneficiaryId, eventType: 'screening_completed' });
+    expect(tl).toBeTruthy();
+    expect(tl.severity).toBe('info');
+  });
+
+  it('a vision screening finalized with outcome=refer lands a WARNING row', async () => {
+    const beneficiaryId = new mongoose.Types.ObjectId();
+    await VisionScreening.create({
+      beneficiaryId,
+      date: new Date(),
+      screeningMethod: 'lea_symbols',
+      outcome: 'refer',
+      referralReason: 'reduced acuity both eyes',
+      referralTo: 'ophthalmology',
+      status: 'finalized',
+      ...finalizeFields(),
+    });
+    const tl = await waitForTimeline({ beneficiaryId, eventType: 'screening_completed' });
+    expect(tl).toBeTruthy();
+    expect(tl.severity).toBe('warning');
+    expect(tl.metadata.outcome).toBe('refer');
+  });
+
+  it('a finalized hearing screening lands screening_completed', async () => {
+    const beneficiaryId = new mongoose.Types.ObjectId();
+    await HearingScreening.create({
+      beneficiaryId,
+      date: new Date(),
+      screeningMethod: 'oae',
+      outcome: 'pass',
+      status: 'finalized',
+      ...finalizeFields(),
+    });
+    const tl = await waitForTimeline({ beneficiaryId, eventType: 'screening_completed' });
+    expect(tl).toBeTruthy();
+    expect(tl.category).toBe('clinical');
+  });
+});

--- a/backend/domains/timeline/models/CareTimeline.js
+++ b/backend/domains/timeline/models/CareTimeline.js
@@ -39,6 +39,7 @@ const careTimelineSchema = new mongoose.Schema(
         'readmission',
         // Clinical
         'assessment_completed',
+        'screening_completed', // W980 — vision/hearing screening finalized
         'assessment_scheduled',
         'reassessment_due',
         'care_plan_created',

--- a/backend/events/contracts/dddEventContracts.js
+++ b/backend/events/contracts/dddEventContracts.js
@@ -616,6 +616,49 @@ const WAITLIST_EVENTS = {
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
+//  Screening Events — أحداث الفحوصات (W980)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// A finalized vision/hearing screening surfaces on the timeline; outcome='refer'
+// is the high-value signal (needs ophthalmology/optometry or audiology/ENT).
+// Producers: native VisionScreening/HearingScreening post-save hooks.
+
+const SCREENING_EVENTS = {
+  VISION_COMPLETED: {
+    domain: 'screenings',
+    eventType: 'screening.vision_completed',
+    version: 1,
+    description: 'تم إنهاء فحص بصر — Vision screening finalized',
+    payload: {
+      screeningId: 'string',
+      beneficiaryId: 'string',
+      outcome: 'string',
+      referralTo: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.REALTIME, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards', 'notification'],
+  },
+
+  HEARING_COMPLETED: {
+    domain: 'screenings',
+    eventType: 'screening.hearing_completed',
+    version: 1,
+    description: 'تم إنهاء فحص سمع — Hearing screening finalized',
+    payload: {
+      screeningId: 'string',
+      beneficiaryId: 'string',
+      outcome: 'string',
+      lossType: 'string',
+      severity: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.REALTIME, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards', 'notification'],
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
 //  Aggregated Contracts Registry
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -632,6 +675,7 @@ const DDD_CONTRACTS = {
   appointments: APPOINTMENT_EVENTS,
   safety: SAFETY_EVENTS,
   waitlist: WAITLIST_EVENTS,
+  screenings: SCREENING_EVENTS,
 };
 
 /**
@@ -661,6 +705,7 @@ module.exports = {
   APPOINTMENT_EVENTS,
   SAFETY_EVENTS,
   WAITLIST_EVENTS,
+  SCREENING_EVENTS,
   DDD_CONTRACTS,
   getDDDContractStats,
 };

--- a/backend/integration/dddCrossModuleSubscribers.js
+++ b/backend/integration/dddCrossModuleSubscribers.js
@@ -896,6 +896,66 @@ function initializeDDDSubscribers(integrationBus, _moduleConnector) {
     },
   });
 
+  // ─── Screenings → Timeline: Vision finalized (W980) ───────────────
+  subscribers.push({
+    name: 'screenings:vision → timeline:record',
+    pattern: 'screenings.screening.vision_completed',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          const refer = event.payload.outcome === 'refer';
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'screening_completed',
+            category: 'clinical',
+            severity: refer ? 'warning' : 'info',
+            title: refer
+              ? `Vision screening → REFER (${event.payload.referralTo || 'ophthalmology'})`
+              : `Vision screening finalized (${event.payload.outcome || ''})`.trim(),
+            title_ar: refer
+              ? `فحص بصر → إحالة (${event.payload.referralTo || 'عيون'})`
+              : `إنهاء فحص بصر (${event.payload.outcome || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Vision-screening timeline failed: ${err.message}`);
+      }
+    },
+  });
+
+  // ─── Screenings → Timeline: Hearing finalized (W980) ──────────────
+  subscribers.push({
+    name: 'screenings:hearing → timeline:record',
+    pattern: 'screenings.screening.hearing_completed',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          const refer = event.payload.outcome === 'refer';
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'screening_completed',
+            category: 'clinical',
+            severity: refer ? 'warning' : 'info',
+            title: refer
+              ? 'Hearing screening → REFER (audiology/ENT)'
+              : `Hearing screening finalized (${event.payload.outcome || ''})`.trim(),
+            title_ar: refer
+              ? 'فحص سمع → إحالة (سمعيات/أنف وأذن)'
+              : `إنهاء فحص سمع (${event.payload.outcome || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Hearing-screening timeline failed: ${err.message}`);
+      }
+    },
+  });
+
   // ── Register all subscribers ───────────────────────────────────────
   let registered = 0;
   for (const sub of subscribers) {

--- a/backend/models/HearingScreening.js
+++ b/backend/models/HearingScreening.js
@@ -235,6 +235,34 @@ HearingScreeningSchema.virtual('isBilateral').get(function () {
 HearingScreeningSchema.set('toJSON', { virtuals: true });
 HearingScreeningSchema.set('toObject', { virtuals: true });
 
+// W980 — surface a finalized hearing screening on the unified-core timeline,
+// flagging outcome='refer' (needs audiology/ENT) as a warning. Fires when status
+// reaches 'finalized' (created-as-finalized OR draft→finalized, once). Native
+// pre-compile hooks per the proven W970 pattern; guarded, fire-and-forget.
+// Consumed by dddCrossModuleSubscribers.js.
+HearingScreeningSchema.post('init', function () {
+  this.$__prevStatus = this.status;
+});
+HearingScreeningSchema.post('save', function (doc) {
+  try {
+    if (doc.status !== 'finalized' || this.$__prevStatus === 'finalized') return;
+    const { integrationBus } = require('../integration/systemIntegrationBus');
+    if (!integrationBus || typeof integrationBus.publish !== 'function') return;
+    if (!doc.beneficiaryId) return;
+    Promise.resolve(
+      integrationBus.publish('screenings', 'screening.hearing_completed', {
+        screeningId: String(doc._id),
+        beneficiaryId: String(doc.beneficiaryId),
+        outcome: doc.outcome || '',
+        lossType: doc.lossType || '',
+        severity: doc.severity || '',
+      })
+    ).catch(() => {});
+  } catch (_) {
+    /* bus not wired — never block persistence */
+  }
+});
+
 module.exports =
   mongoose.models.HearingScreening || mongoose.model('HearingScreening', HearingScreeningSchema);
 

--- a/backend/models/VisionScreening.js
+++ b/backend/models/VisionScreening.js
@@ -240,6 +240,33 @@ VisionScreeningSchema.virtual('cviSignCount').get(function () {
 VisionScreeningSchema.set('toJSON', { virtuals: true });
 VisionScreeningSchema.set('toObject', { virtuals: true });
 
+// W980 — surface a finalized vision screening on the unified-core timeline,
+// flagging outcome='refer' (needs ophthalmology/optometry) as a warning. Fires
+// when status reaches 'finalized' (created-as-finalized OR draft→finalized,
+// once). Native pre-compile hooks per the proven W970 pattern; guarded,
+// fire-and-forget. Consumed by dddCrossModuleSubscribers.js.
+VisionScreeningSchema.post('init', function () {
+  this.$__prevStatus = this.status;
+});
+VisionScreeningSchema.post('save', function (doc) {
+  try {
+    if (doc.status !== 'finalized' || this.$__prevStatus === 'finalized') return;
+    const { integrationBus } = require('../integration/systemIntegrationBus');
+    if (!integrationBus || typeof integrationBus.publish !== 'function') return;
+    if (!doc.beneficiaryId) return;
+    Promise.resolve(
+      integrationBus.publish('screenings', 'screening.vision_completed', {
+        screeningId: String(doc._id),
+        beneficiaryId: String(doc.beneficiaryId),
+        outcome: doc.outcome || '',
+        referralTo: doc.referralTo || '',
+      })
+    ).catch(() => {});
+  } catch (_) {
+    /* bus not wired — never block persistence */
+  }
+});
+
 module.exports =
   mongoose.models.VisionScreening || mongoose.model('VisionScreening', VisionScreeningSchema);
 

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -730,3 +730,4 @@ __tests__/model-event-bridge-global-plugin-wave974.test.js
 __tests__/incident-ncr-producer-wave976.test.js
 __tests__/safety-core-linkage-wave977.test.js
 __tests__/waitlist-core-linkage-wave979.test.js
+__tests__/screening-core-linkage-wave980.test.js


### PR DESCRIPTION
Tier-1 ledger item: finalized vision/hearing screening → timeline; outcome='refer' flagged as WARNING (ophthalmology/optometry or audiology/ENT). Native pre-compile model hooks (W970 pattern) + SCREENING_EVENTS contracts + W374 + screening_completed enum + 2 subscribers. Verified end-to-end (wave980, 3 tests); W389/W374/W375 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)