### PR TITLE
fix(models): W978 migrate 53 models off the Mongoose-9 async-save-hook throw

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1243,6 +1243,8 @@ on:
       - 'backend/__tests__/screening-core-linkage-wave980.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/auth-alias-user-id-wave947.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/no-async-next-save-hooks-wave978.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2469,6 +2471,8 @@ on:
       - 'backend/__tests__/screening-core-linkage-wave980.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/auth-alias-user-id-wave947.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/no-async-next-save-hooks-wave978.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/no-async-next-save-hooks-wave978.test.js
+++ b/backend/__tests__/no-async-next-save-hooks-wave978.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+/**
+ * W978 — Mongoose-9 async save-hook migration guard + smoke.
+ *
+ * Under Mongoose 9, an async `pre/post('save', async function (next) { … next(); })`
+ * hook does NOT receive `next` — calling it throws "next is not a function" on
+ * EVERY .save() (proven by isolated repro; documented in
+ * feedback_mongoose_9_pre_save_callback_silent_break). 53 models shipped with this
+ * broken pattern (high-traffic ones like Beneficiary were already migrated); W978
+ * converted all 53 to async-no-next.
+ *
+ * (1) DRIFT GUARD — no model may re-introduce an async `save` hook that declares
+ *     `next`. Baseline is EMPTY (all cleared) → any new one fails CI.
+ * (2) SMOKE — a sample of converted models saves on MongoMemoryServer WITHOUT
+ *     throwing "next is not a function" (a validation error is fine — it proves the
+ *     hook ran to completion past where next() used to throw).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MODELS_DIR = path.resolve(__dirname, '..', 'models');
+const BROKEN_SAVE_HOOK = /\.(pre|post)\(\s*['"]save['"]\s*,\s*async function \(\s*next\s*\)/;
+
+function walk(dir, acc) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.name === 'node_modules' || e.name === '_archived' || e.name === '__tests__') continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, acc);
+    else if (e.name.endsWith('.js')) acc.push(p);
+  }
+  return acc;
+}
+
+describe('W978 — no async save hook declares next (Mongoose-9 throw class)', () => {
+  it('zero models use `async function (next)` for a save hook', () => {
+    const offenders = walk(MODELS_DIR, []).filter(f =>
+      BROKEN_SAVE_HOOK.test(fs.readFileSync(f, 'utf8'))
+    );
+    expect(offenders.map(f => path.relative(MODELS_DIR, f))).toEqual([]);
+  });
+});
+
+describe('W978 — converted models save without the Mongoose-9 hook error', () => {
+  const mongoose = require('mongoose');
+  jest.unmock('mongoose');
+  let mongod;
+
+  // A varied sample of the 53 converted models (different domains).
+  const SAMPLES = [
+    'Budget',
+    'Cheque',
+    'communication/Announcement',
+    'reports/ReportJob',
+    'laundry.model',
+  ];
+
+  beforeAll(async () => {
+    const { MongoMemoryServer } = require('mongodb-memory-server');
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+  }, 60000);
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    if (mongod) await mongod.stop();
+  });
+
+  it.each(SAMPLES)('%s: .save() never throws "next is not a function"', async rel => {
+    const Model = require(`../models/${rel}`);
+    let err = null;
+    try {
+      await new Model({}).save(); // empty doc → may fail validation, that's OK
+    } catch (e) {
+      err = e;
+    }
+    // The pre-save hook must have run past where next() used to throw. A
+    // ValidationError (missing required fields) is the expected, acceptable outcome.
+    if (err) {
+      expect(err.message).not.toMatch(/next is not a function/i);
+    }
+  });
+});

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -732,3 +732,4 @@ __tests__/safety-core-linkage-wave977.test.js
 __tests__/waitlist-core-linkage-wave979.test.js
 __tests__/screening-core-linkage-wave980.test.js
 __tests__/auth-alias-user-id-wave947.test.js
+__tests__/no-async-next-save-hooks-wave978.test.js


### PR DESCRIPTION
## What

Under **Mongoose 9.6.2**, `pre/post('save', async function (next) { … next(); })` does **not** receive `next` — calling it throws **"next is not a function" on every `.save()`** (proven by isolated repro; documented hazard). **53 models** shipped with this exact pattern, so any flow saving one failed at the model layer — a likely contributor to several "data not saved" reports. (Beneficiary & other high-traffic models were already migrated, which is why core saves work; these 53 are the cold long tail.)

## How

All 53 had a single trailing `next();` (no `next(err)` / conditional `return next()`), so the migration is one uniform mechanical transform — `async function (next) {` → `async function () {`, drop the trailing `next();` (promise-resolution completion, the canonical M9 form). Applied via a brace-scoped transform touching **only** `async function (next)` save hooks (never sync-callback hooks).

## Verification

All 53 `require()` cleanly · `check:hook-style` green (67 callback baseline unchanged) · eslint exit 0 on all 53 · diff is purely signature + `next()` removal (64 ins / 128 del).

## Guard + smoke (6 tests)

1. **Drift guard** — zero models declare `async function (next)` for a save hook (baseline empty → any regression fails CI).
2. **Behavioral smoke** — a varied sample (Budget / Cheque / Announcement / ReportJob / laundry) `.save()`s on MongoMemoryServer **without** throwing "next is not a function".

> Covers **save** hooks only; async `validate`/`remove` hooks with `next` (if any) are the same hazard and a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)