### PR TITLE
fix(W949): convert final 16 next(arg) callback hooks to async — broken-hook class → 0

### DIFF
--- a/backend/models/AccountingExpense.js
+++ b/backend/models/AccountingExpense.js
@@ -185,12 +185,12 @@ accountingExpenseSchema.methods.reject = function (userId, reason) {
 };
 
 // Pre-save middleware للتحقق
-accountingExpenseSchema.pre('save', function (next) {
+accountingExpenseSchema.pre('save', async function () {
   // Money-Type Migration (audit #5) — dual-write integer-halalas siblings.
   require('../intelligence/money.lib').deriveHalalas(this, ['amount']);
   // التحقق من وجود سبب الرفض عند الرفض
   if (this.status === 'rejected' && !this.rejectionReason) {
-    return next(new Error('يجب تحديد سبب الرفض'));
+    throw new Error('يجب تحديد سبب الرفض');
   }
 
   // تحديث updatedBy
@@ -198,7 +198,7 @@ accountingExpenseSchema.pre('save', function (next) {
     this.updatedBy = this.createdBy; // يمكن تحسينه للحصول على المستخدم الحالي
   }
 
-  next();
+  
 });
 
 // Static method للحصول على إحصائيات المصروفات

--- a/backend/models/AiRecommendationBundle.js
+++ b/backend/models/AiRecommendationBundle.js
@@ -144,15 +144,15 @@ aiRecommendationBundleSchema.post('init', function (doc) {
 // Idempotent: re-saving without a status change is a no-op (no history entry).
 // New docs go straight to the default state without triggering validation
 // (creation flow is separate from transition flow).
-aiRecommendationBundleSchema.pre('save', function (next) {
+aiRecommendationBundleSchema.pre('save', async function () {
   // New doc — no transition to validate. History will be seeded by the
   // service layer's createDraft() if needed (e.g. DRAFT→DISCARDED on low
   // confidence happens in service code, not in the pre-save hook).
   if (this.isNew) {
     this.$__originalStatus = this.status;
-    return next();
+    return;
   }
-  if (!this.isModified('status')) return next();
+  if (!this.isModified('status')) return;
 
   const fromStatus = this.$__originalStatus;
   const toStatus = this.status;
@@ -162,7 +162,7 @@ aiRecommendationBundleSchema.pre('save', function (next) {
   // tests). Defer to the lib in that case via a permissive path.
   if (!fromStatus) {
     this.$__originalStatus = toStatus;
-    return next();
+    return;
   }
 
   const result = lib.validateTransition({
@@ -179,7 +179,7 @@ aiRecommendationBundleSchema.pre('save', function (next) {
     err.code = result.code;
     err.fromStatus = fromStatus;
     err.toStatus = toStatus;
-    return next(err);
+    throw err;
   }
 
   // Append to history (append-only audit per W325 P2 / W325 P3 pattern)
@@ -200,7 +200,7 @@ aiRecommendationBundleSchema.pre('save', function (next) {
   this.$__transitionNotes = undefined;
   this.$__transitionMfaTier = undefined;
 
-  next();
+  
 });
 
 module.exports =

--- a/backend/models/BeneficiaryVoiceLog.js
+++ b/backend/models/BeneficiaryVoiceLog.js
@@ -143,18 +143,16 @@ BeneficiaryVoiceLogSchema.index({ beneficiaryId: 1, entryKind: 1, capturedAt: -1
 BeneficiaryVoiceLogSchema.index({ branchId: 1, entryKind: 1, capturedAt: -1 });
 
 // W460 Wave-18 invariants
-BeneficiaryVoiceLogSchema.pre('save', function (next) {
+BeneficiaryVoiceLogSchema.pre('save', async function () {
   // Anti-substitution doctrine: proxy + capacityGrade='absent' is the
   // ONLY case where we tolerate no content beyond proxy interpretation.
   // Other proxy entries MUST document why direct capture was infeasible.
   if (this.captureModality === 'proxy' && this.capacityGrade !== 'absent') {
     if (!this.supportArrangement || this.supportArrangement.trim().length < 10) {
-      return next(
-        new Error(
+      throw new Error(
           'BeneficiaryVoiceLog: proxy capture requires supportArrangement (≥10 chars) ' +
             'documenting why direct capture from beneficiary was infeasible'
-        )
-      );
+        );
     }
   }
 
@@ -163,9 +161,7 @@ BeneficiaryVoiceLogSchema.pre('save', function (next) {
     (this.entryKind === 'daily_rating' || this.entryKind === 'session_rating') &&
     (this.content?.ratingValue == null || this.content?.ratingScale == null)
   ) {
-    return next(
-      new Error(`BeneficiaryVoiceLog: ${this.entryKind} requires content.ratingValue + ratingScale`)
-    );
+    throw new Error(`BeneficiaryVoiceLog: ${this.entryKind} requires content.ratingValue + ratingScale`);
   }
 
   // AAC entries must have aacSymbols populated
@@ -173,10 +169,10 @@ BeneficiaryVoiceLogSchema.pre('save', function (next) {
     this.captureModality === 'aac' &&
     (!this.content?.aacSymbols || this.content.aacSymbols.length === 0)
   ) {
-    return next(new Error('BeneficiaryVoiceLog: aac capture requires content.aacSymbols[]'));
+    throw new Error('BeneficiaryVoiceLog: aac capture requires content.aacSymbols[]');
   }
 
-  next();
+  
 });
 
 module.exports =

--- a/backend/models/CulturalProfile.js
+++ b/backend/models/CulturalProfile.js
@@ -196,12 +196,10 @@ CulturalProfileSchema.index({ branchId: 1, 'language.arabicDialect': 1 });
 CulturalProfileSchema.index({ branchId: 1, 'genderPreferences.therapistGenderPreference': 1 });
 
 // W475 Wave-18 invariants
-CulturalProfileSchema.pre('save', function (next) {
+CulturalProfileSchema.pre('save', async function () {
   // Mahram required → mahramRelationship must be filled
   if (this.genderPreferences?.mahramRequired && !this.genderPreferences.mahramRelationship) {
-    return next(
-      new Error('CulturalProfile: mahramRequired=true requires mahramRelationship to be specified')
-    );
+    throw new Error('CulturalProfile: mahramRequired=true requires mahramRelationship to be specified');
   }
 
   // Medical fasting exemption requires details ≥10 chars
@@ -210,26 +208,22 @@ CulturalProfileSchema.pre('save', function (next) {
     obs?.hasMedicalExemptionFromFasting &&
     (!obs.medicalExemptionDetails || obs.medicalExemptionDetails.trim().length < 10)
   ) {
-    return next(
-      new Error(
+    throw new Error(
         'CulturalProfile: hasMedicalExemptionFromFasting=true requires medicalExemptionDetails (≥10 chars)'
-      )
-    );
+      );
   }
 
   // Acceptable contact hours: startHour < endHour
   if (this.communication?.acceptableContactHours) {
     const { startHour, endHour } = this.communication.acceptableContactHours;
     if (typeof startHour === 'number' && typeof endHour === 'number' && startHour >= endHour) {
-      return next(
-        new Error(
+      throw new Error(
           'CulturalProfile: communication.acceptableContactHours.startHour must be < endHour'
-        )
-      );
+        );
     }
   }
 
-  next();
+  
 });
 
 module.exports =

--- a/backend/models/DecisionRightsAssessment.js
+++ b/backend/models/DecisionRightsAssessment.js
@@ -115,7 +115,7 @@ DecisionRightsAssessmentSchema.index({ branchId: 1, routedLayer: 1, assessedAt: 
 // W461 Wave-18 invariants — compute composite + route layer + enforce
 // support arrangement on Layer 2/3 + advocate involvement on Layer 3 +
 // research-consent/restraint/seclusion.
-DecisionRightsAssessmentSchema.pre('save', function (next) {
+DecisionRightsAssessmentSchema.pre('save', async function () {
   const lib = require('../intelligence/decision-rights.lib');
 
   // Always recompute composite + layer from capacity scores
@@ -129,25 +129,21 @@ DecisionRightsAssessmentSchema.pre('save', function (next) {
     this.status === 'finalized' &&
     (!this.supportArrangement || this.supportArrangement.trim().length < 20)
   ) {
-    return next(
-      new Error(
+    throw new Error(
         `DecisionRightsAssessment: ${this.routedLayer} layer requires supportArrangement (≥20 chars) before finalization`
-      )
-    );
+      );
   }
 
   // Decisions that always require advocate involvement regardless of layer
   if (lib.requiresAdvocate(this.decisionType, this.routedLayer)) {
     if (this.status === 'finalized' && !this.advocateInvolved) {
-      return next(
-        new Error(
+      throw new Error(
           `DecisionRightsAssessment: decisionType="${this.decisionType}" or layer="${this.routedLayer}" requires advocateInvolved=true before finalization`
-        )
-      );
+        );
     }
   }
 
-  next();
+  
 });
 
 module.exports =

--- a/backend/models/EmergencyPlan.js
+++ b/backend/models/EmergencyPlan.js
@@ -116,13 +116,11 @@ const EmergencyPlanSchema = new mongoose.Schema(
 );
 
 // Wave-18 invariant: at most ONE primary emergency contact.
-EmergencyPlanSchema.pre('save', function (next) {
+EmergencyPlanSchema.pre('save', async function () {
   if (Array.isArray(this.emergencyContacts)) {
     const primaries = this.emergencyContacts.filter(c => c.isPrimary === true);
     if (primaries.length > 1) {
-      return next(
-        new Error('EmergencyPlan.emergencyContacts: at most one contact may have isPrimary: true')
-      );
+      throw new Error('EmergencyPlan.emergencyContacts: at most one contact may have isPrimary: true');
     }
   }
 
@@ -134,7 +132,7 @@ EmergencyPlanSchema.pre('save', function (next) {
     this.nextReviewDue = next;
   }
 
-  next();
+  
 });
 
 module.exports =

--- a/backend/models/FamilyCounsellingSession.js
+++ b/backend/models/FamilyCounsellingSession.js
@@ -158,24 +158,20 @@ FamilyCounsellingSessionSchema.index({ branchId: 1, sessionDate: -1, sessionType
 FamilyCounsellingSessionSchema.index({ counsellorUserId: 1, sessionDate: -1 });
 
 // W470 Wave-18 invariants
-FamilyCounsellingSessionSchema.pre('save', function (next) {
+FamilyCounsellingSessionSchema.pre('save', async function () {
   // Cancelled/no_show require cancellationReason
   if (
     (this.status === 'cancelled' || this.status === 'no_show') &&
     (!this.cancellationReason || this.cancellationReason.trim().length < 5)
   ) {
-    return next(
-      new Error(
+    throw new Error(
         `FamilyCounsellingSession: status="${this.status}" requires cancellationReason (≥5 chars)`
-      )
-    );
+      );
   }
 
   // completed status: sessionDate should be in the past or now
   if (this.status === 'completed' && this.sessionDate && this.sessionDate > new Date()) {
-    return next(
-      new Error('FamilyCounsellingSession: completed session cannot have sessionDate in future')
-    );
+    throw new Error('FamilyCounsellingSession: completed session cannot have sessionDate in future');
   }
 
   // followUpActions[].completed requires completedAt
@@ -185,7 +181,7 @@ FamilyCounsellingSessionSchema.pre('save', function (next) {
     }
   }
 
-  next();
+  
 });
 
 module.exports =

--- a/backend/models/FinancialTransaction.js
+++ b/backend/models/FinancialTransaction.js
@@ -237,16 +237,16 @@ FinancialTransactionSchema.index({ status: 1, transactionDate: -1 });
 FinancialTransactionSchema.index({ transactionType: 1, transactionDate: -1 });
 
 // Validation: Ensure debit and credit amounts are equal
-FinancialTransactionSchema.pre('save', function (next) {
+FinancialTransactionSchema.pre('save', async function () {
   if (this.debitAccount.amount !== this.creditAccount.amount) {
-    return next(new Error('Debit and credit amounts must be equal'));
+    throw new Error('Debit and credit amounts must be equal');
   }
   // Money-Type Migration (audit #5) — dual-write integer-halalas siblings (dot-paths).
   require('../intelligence/money.lib').deriveHalalas(this, [
     'debitAccount.amount',
     'creditAccount.amount',
   ]);
-  next();
+  
 });
 
 // Method to post transaction

--- a/backend/models/Goal.js
+++ b/backend/models/Goal.js
@@ -183,22 +183,20 @@ goalSchema.index({ createdBy: 1, createdAt: -1 });
 goalSchema.index({ 'icfMapping.icfCode': 1 });
 
 // W452 — ICF mapping invariants enforced before save.
-goalSchema.pre('save', function (next) {
+goalSchema.pre('save', async function () {
   this.updatedAt = new Date();
 
   if (Array.isArray(this.icfMapping) && this.icfMapping.length > 0) {
     // Invariant 1: at most one primary
     const primaries = this.icfMapping.filter(m => m.isPrimary === true);
     if (primaries.length > 1) {
-      return next(new Error('Goal.icfMapping: at most one entry may have isPrimary: true'));
+      throw new Error('Goal.icfMapping: at most one entry may have isPrimary: true');
     }
 
     // Invariant 2: targetQualifier requires baselineQualifier
     for (const m of this.icfMapping) {
       if (typeof m.targetQualifier === 'number' && typeof m.baselineQualifier !== 'number') {
-        return next(
-          new Error(`Goal.icfMapping[${m.icfCode}]: targetQualifier set without baselineQualifier`)
-        );
+        throw new Error(`Goal.icfMapping[${m.icfCode}]: targetQualifier set without baselineQualifier`);
       }
     }
 
@@ -206,13 +204,13 @@ goalSchema.pre('save', function (next) {
     const seen = new Set();
     for (const m of this.icfMapping) {
       if (seen.has(m.icfCode)) {
-        return next(new Error(`Goal.icfMapping: duplicate icfCode '${m.icfCode}'`));
+        throw new Error(`Goal.icfMapping: duplicate icfCode '${m.icfCode}'`);
       }
       seen.add(m.icfCode);
     }
   }
 
-  next();
+  
 });
 
 module.exports = mongoose.models.Goal || mongoose.model('Goal', goalSchema);

--- a/backend/models/HikvisionRawEvent.js
+++ b/backend/models/HikvisionRawEvent.js
@@ -106,16 +106,16 @@ const IMMUTABLE_FIELDS = [
   'rawPayload',
 ];
 
-HikvisionRawEventSchema.pre('save', function (next) {
-  if (this.isNew) return next();
+HikvisionRawEventSchema.pre('save', async function () {
+  if (this.isNew) return;
   for (const f of IMMUTABLE_FIELDS) {
     if (this.isModified(f)) {
       const err = new Error(`HikvisionRawEvent: field "${f}" is immutable after creation`);
       err.name = 'ImmutableFieldError';
-      return next(err);
+      throw err;
     }
   }
-  return next();
+  return;
 });
 
 module.exports =

--- a/backend/models/InsuranceTariff.js
+++ b/backend/models/InsuranceTariff.js
@@ -46,11 +46,11 @@ InsuranceTariffSchema.index({ provider: 1, cptCode: 1, effectiveFrom: -1 });
 InsuranceTariffSchema.index({ providerId: 1, cptCode: 1, effectiveFrom: -1 });
 
 // Validation: effectiveTo must be after effectiveFrom when present.
-InsuranceTariffSchema.pre('validate', function (next) {
+InsuranceTariffSchema.pre('validate', async function () {
   if (this.effectiveTo && this.effectiveFrom && this.effectiveTo < this.effectiveFrom) {
-    return next(new Error('InsuranceTariff: effectiveTo must be on/after effectiveFrom'));
+    throw new Error('InsuranceTariff: effectiveTo must be on/after effectiveFrom');
   }
-  next();
+  
 });
 
 module.exports =

--- a/backend/models/ParentChatbotSession.js
+++ b/backend/models/ParentChatbotSession.js
@@ -80,7 +80,7 @@ const ParentChatbotSessionSchema = new mongoose.Schema(
 );
 
 // Wave-18 invariants
-ParentChatbotSessionSchema.pre('validate', function (next) {
+ParentChatbotSessionSchema.pre('validate', async function () {
   if (!Array.isArray(this.turns)) this.turns = [];
   if (this.turnCount !== this.turns.length) {
     // Self-heal rather than reject — turnCount is a denormalized
@@ -88,9 +88,9 @@ ParentChatbotSessionSchema.pre('validate', function (next) {
     this.turnCount = this.turns.length;
   }
   if (this.lastActivityAt && this.startedAt && this.lastActivityAt < this.startedAt) {
-    return next(new Error('lastActivityAt cannot precede startedAt'));
+    throw new Error('lastActivityAt cannot precede startedAt');
   }
-  return next();
+  return;
 });
 
 // TTL: documents whose `lastActivityAt` is older than 30 days are

--- a/backend/models/Productivity/UserPreferences.js
+++ b/backend/models/Productivity/UserPreferences.js
@@ -59,15 +59,15 @@ const UserPreferencesSchema = new mongoose.Schema(
 // savedViews where shareWithRole=true authored by another member.
 UserPreferencesSchema.index({ 'savedViews.shareWithRole': 1 });
 
-UserPreferencesSchema.pre('save', function (next) {
+UserPreferencesSchema.pre('save', async function () {
   this.updatedAt = new Date();
   // Enforce pin limit at the DB layer as a backstop (service layer
   // already rejects with PIN_LIMIT_EXCEEDED, but if a bad caller
   // sneaks past, this catches it).
   if (Array.isArray(this.pinnedWidgets) && this.pinnedWidgets.length > 6) {
-    return next(new Error('UserPreferences: pinnedWidgets exceeds max of 6'));
+    throw new Error('UserPreferences: pinnedWidgets exceeds max of 6');
   }
-  next();
+  
 });
 
 module.exports =

--- a/backend/models/SiblingAdjustmentRecord.js
+++ b/backend/models/SiblingAdjustmentRecord.js
@@ -132,7 +132,7 @@ SiblingAdjustmentRecordSchema.index({ branchId: 1, totalBand: 1, assessmentDate:
 SiblingAdjustmentRecordSchema.index({ siblingId: 1, assessmentDate: -1 });
 
 // W468 Wave-18 — recompute SDQ totals via lib
-SiblingAdjustmentRecordSchema.pre('save', function (next) {
+SiblingAdjustmentRecordSchema.pre('save', async function () {
   const lib = require('../intelligence/sdq-scoring.lib');
   const scoresObj = this.scores ? this.scores.toObject?.() || this.scores : {};
   const result = lib.scoreSDQ({
@@ -144,9 +144,7 @@ SiblingAdjustmentRecordSchema.pre('save', function (next) {
   });
 
   if (!result.valid) {
-    return next(
-      new Error(`SiblingAdjustmentRecord: invalid SDQ scores: ${result.errors.join(', ')}`)
-    );
+    throw new Error(`SiblingAdjustmentRecord: invalid SDQ scores: ${result.errors.join(', ')}`);
   }
 
   this.totalDifficulties = result.total;
@@ -162,7 +160,7 @@ SiblingAdjustmentRecordSchema.pre('save', function (next) {
     }
   }
 
-  next();
+  
 });
 
 module.exports =

--- a/backend/privacy/consent.model.js
+++ b/backend/privacy/consent.model.js
@@ -79,7 +79,7 @@ const ConsentSchema = new mongoose.Schema(
 ConsentSchema.index({ subjectType: 1, subjectId: 1, purpose: 1, grantedAt: -1 });
 
 /** Disallow edits after creation (immutable ledger). */
-ConsentSchema.pre('findOneAndUpdate', function (next) {
+ConsentSchema.pre('findOneAndUpdate', async function () {
   const update = this.getUpdate() || {};
   const immutable = [
     'subjectType',
@@ -92,10 +92,10 @@ ConsentSchema.pre('findOneAndUpdate', function (next) {
   const $set = update.$set || update;
   for (const f of immutable) {
     if ($set && Object.prototype.hasOwnProperty.call($set, f)) {
-      return next(new Error(`Consent field '${f}' is immutable`));
+      throw new Error(`Consent field '${f}' is immutable`);
     }
   }
-  next();
+  
 });
 
 ConsentSchema.statics.latestFor = function (subjectType, subjectId, purpose) {

--- a/backend/scripts/check-mongoose-hook-style.js
+++ b/backend/scripts/check-mongoose-hook-style.js
@@ -82,25 +82,10 @@ const HOOK_RE =
 // entry from this Set, commit. Same wave pattern that drove W325c
 // phantom-ref baseline 58 → 0 across ~12 waves.
 const KNOWN_CALLBACK_HOOK_BASELINE = new Set([
-  // W948 — remaining SYNC callback hooks with next(arg) bodies (need manual
-  // throw-conversion); the 50 bare-next baseline files were converted to async.
-  "models/AccountingExpense.js",
-  "models/AiRecommendationBundle.js",
-  "models/BeneficiaryVoiceLog.js",
-  "models/CulturalProfile.js",
-  "models/DecisionRightsAssessment.js",
-  "models/EmergencyPlan.js",
-  "models/FamilyCounsellingSession.js",
-  "models/FinancialTransaction.js",
-  "models/Goal.js",
-  "models/HikvisionRawEvent.js",
-  "models/InsuranceTariff.js",
-  "models/ParentChatbotSession.js",
-  "models/Productivity/UserPreferences.js",
-  "models/SiblingAdjustmentRecord.js",
+  // W949 — only guarded false-positives remain (auditLog hooks guard
+  // `typeof next === 'function'`, so they are Mongoose-9-safe). All real
+  // callback hooks (async+next W946, sync W948, next(arg) W949) are converted.
   "models/auditLog.model.js",
-  "privacy/consent.model.js",
-  "services/whatsapp/templateSync.service.js",
 ]);
 
 function listSchemaFiles(roots) {

--- a/backend/services/whatsapp/templateSync.service.js
+++ b/backend/services/whatsapp/templateSync.service.js
@@ -63,9 +63,9 @@ const WhatsAppTemplateSchema = new mongoose.Schema(
 WhatsAppTemplateSchema.index({ templateName: 1, language: 1 }, { unique: true });
 WhatsAppTemplateSchema.index({ status: 1 });
 
-WhatsAppTemplateSchema.pre('save', function (next) {
+WhatsAppTemplateSchema.pre('save', async function () {
   this.updatedAt = new Date();
-  next();
+  
 });
 
 // Pattern D (W842): Meta provider template sync (distinct from comm/whatsapp-models Template)


### PR DESCRIPTION
الدفعة الأخيرة من قوس إصلاح خطّافات Mongoose-9 (W946 async+next، W948 sync-bare).

## المشكلة
16 خطّافاً تمرّر وسيطاً لـ next() (`next(new Error(...))` / `return next(err)`) — لا يمكن للـregex البسيط تحويلها (أقواس متداخلة).

## الحل
codemod **متوازن-الأقواس**: `return next(ERR)`/`next(ERR)` → `throw ERR;`، `return next()` → `return`، `next()` فارغ يُحذف، التوقيع → `async function ()`. مُتحقَّق: الموديلات تصل لتحقّق الحقول بدل الكسر.

القاعدة: **17 → 1** (يبقى `auditLog.model.js` فقط — خطّافاته تحرس `typeof next === 'function'` فهي آمنة في Mongoose 9 — إيجابية كاذبة موثّقة). البوابة خضراء + اختبارها الذاتي 23/23.

## المحصّلة الكلية (W946+W948+W949)
~149 خطّاف حفظ/تحقّق مكسوراً أُصلح — **فئة الخطّافات المكسورة أصبحت صفراً فعلياً** (لا يتبقّى إلا إيجابيات كاذبة محروسة).

🤖 Generated with [Claude Code](https://claude.com/claude-code)