### PR TITLE
feat(core): W982 wire beneficiary lifecycle status changes onto the unified-core timeline

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1247,6 +1247,8 @@ on:
       - 'backend/__tests__/no-async-next-save-hooks-wave978.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/medication-core-linkage-wave981.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/beneficiary-status-core-linkage-wave982.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2477,6 +2479,8 @@ on:
       - 'backend/__tests__/no-async-next-save-hooks-wave978.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/medication-core-linkage-wave981.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/beneficiary-status-core-linkage-wave982.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/beneficiary-status-core-linkage-wave982.test.js
+++ b/backend/__tests__/beneficiary-status-core-linkage-wave982.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+/**
+ * beneficiary-status-core-linkage-wave982.test.js — W982.
+ *
+ * Wires beneficiary lifecycle STATUS changes (active → completed / paused /
+ * dropped) onto the unified-core timeline via the canonical
+ * `core.beneficiary.status_changed` event (the contract already existed but had
+ * no producer + no timeline subscriber). This is the ONLY path that records a
+ * status change on the CareTimeline — the env-gated modelEventBridge emits the
+ * 'beneficiary.*' variant to the LIVE-registry subscribers (notify/re-publish),
+ * which do not write the timeline.
+ *
+ * Producer: native Beneficiary post-save hook (update-only). RUNTIME end-to-end
+ * against a real in-memory Mongo + the real integration bus + real subscribers.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let Beneficiary, CareTimeline;
+
+async function waitForTimeline(query, { timeout = 4000, interval = 25 } = {}) {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const row = await CareTimeline.findOne(query);
+    if (row) return row;
+    if (Date.now() - start > timeout) return null;
+    await new Promise(r => setTimeout(r, interval));
+  }
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w982-benstatus' } });
+  await mongoose.connect(mongod.getUri());
+  Beneficiary = require('../models/Beneficiary');
+  ({ CareTimeline } = require('../domains/timeline/models/CareTimeline'));
+  const { integrationBus } = require('../integration/systemIntegrationBus');
+  const { initializeDDDSubscribers } = require('../integration/dddCrossModuleSubscribers');
+  initializeDDDSubscribers(integrationBus);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+afterEach(async () => {
+  await Promise.all([Beneficiary.deleteMany({}), CareTimeline.deleteMany({})]);
+});
+
+function newBeneficiary(extra = {}) {
+  return Beneficiary.create({ firstName: 'سالم', lastName: 'الأحمد', ...extra });
+}
+
+describe('W982 — beneficiary status changes reach the unified-core timeline', () => {
+  it('creating a beneficiary does NOT emit a status_changed row', async () => {
+    const b = await newBeneficiary();
+    await new Promise(r => setTimeout(r, 150));
+    expect(
+      await CareTimeline.countDocuments({ beneficiaryId: b._id, eventType: 'status_changed' })
+    ).toBe(0);
+  });
+
+  it('active → graduated lands a success status_changed row', async () => {
+    const b = await newBeneficiary();
+    const loaded = await Beneficiary.findById(b._id);
+    loaded.status = 'graduated';
+    await loaded.save();
+    const tl = await waitForTimeline({ beneficiaryId: b._id, eventType: 'status_changed' });
+    expect(tl).toBeTruthy();
+    expect(tl.severity).toBe('success');
+    expect(tl.metadata.oldStatus).toBe('active');
+    expect(tl.metadata.newStatus).toBe('graduated');
+  });
+
+  it('active → deceased lands a CRITICAL status_changed row', async () => {
+    const b = await newBeneficiary();
+    const loaded = await Beneficiary.findById(b._id);
+    loaded.status = 'deceased';
+    await loaded.save();
+    const tl = await waitForTimeline({ beneficiaryId: b._id, eventType: 'status_changed' });
+    expect(tl).toBeTruthy();
+    expect(tl.severity).toBe('critical');
+  });
+});

--- a/backend/domains/timeline/models/CareTimeline.js
+++ b/backend/domains/timeline/models/CareTimeline.js
@@ -37,6 +37,7 @@ const careTimelineSchema = new mongoose.Schema(
         'discharge',
         'transfer',
         'readmission',
+        'status_changed', // W982 — beneficiary lifecycle status change
         // Clinical
         'assessment_completed',
         'screening_completed', // W980 — vision/hearing screening finalized

--- a/backend/integration/dddCrossModuleSubscribers.js
+++ b/backend/integration/dddCrossModuleSubscribers.js
@@ -1006,6 +1006,41 @@ function initializeDDDSubscribers(integrationBus, _moduleConnector) {
     },
   });
 
+  // ─── Core → Timeline: Beneficiary status changed (W982) ───────────
+  subscribers.push({
+    name: 'core:status_changed → timeline:record',
+    pattern: 'core.beneficiary.status_changed',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          const ns = event.payload.newStatus;
+          // deceased = critical; transferred/inactive = warning; graduated = success
+          const severity =
+            ns === 'deceased'
+              ? 'critical'
+              : ns === 'transferred' || ns === 'inactive'
+                ? 'warning'
+                : ns === 'graduated'
+                  ? 'success'
+                  : 'info';
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'status_changed',
+            category: 'administrative',
+            severity,
+            title: `Status: ${event.payload.oldStatus || ''} → ${event.payload.newStatus || ''}`.trim(),
+            title_ar: `تغيّر الحالة: ${event.payload.oldStatus || ''} ← ${event.payload.newStatus || ''}`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Status-changed timeline failed: ${err.message}`);
+      }
+    },
+  });
+
   // ── Register all subscribers ───────────────────────────────────────
   let registered = 0;
   for (const sub of subscribers) {

--- a/backend/models/Beneficiary.js
+++ b/backend/models/Beneficiary.js
@@ -698,4 +698,38 @@ try {
   // CI bootstrap — silently skip so the model still registers.
 }
 
+// W982 — surface beneficiary lifecycle status changes (active → completed /
+// paused / dropped) on the unified-core timeline. This is the ONLY path that
+// records a status change on the CareTimeline: the env-gated modelEventBridge
+// emits `beneficiary.beneficiary.status_changed` to the LIVE-registry
+// subscribers (notification/re-publish), which do NOT write the timeline. Here
+// we publish the canonical `core.beneficiary.status_changed` consumed by
+// dddCrossModuleSubscribers → CareTimeline. Native pre-compile hooks per the
+// proven W970 pattern; update-only (a status change, not creation); guarded,
+// fire-and-forget. The contract already exists (BENEFICIARY_DDD_EVENTS.STATUS_CHANGED).
+beneficiarySchema.pre('save', function () {
+  this.$__wasNew = this.isNew;
+});
+beneficiarySchema.post('init', function () {
+  this.$__prevStatus = this.status;
+});
+beneficiarySchema.post('save', function (doc) {
+  try {
+    if (this.$__wasNew) return; // creation handled by core.beneficiary.registered
+    if (!doc.status || doc.status === this.$__prevStatus) return; // no status change
+    const { integrationBus } = require('../integration/systemIntegrationBus');
+    if (!integrationBus || typeof integrationBus.publish !== 'function') return;
+    Promise.resolve(
+      integrationBus.publish('core', 'beneficiary.status_changed', {
+        beneficiaryId: String(doc._id),
+        oldStatus: this.$__prevStatus || 'unknown',
+        newStatus: doc.status,
+        reason: doc.statusReason || doc.statusChangeReason || '',
+      })
+    ).catch(() => {});
+  } catch (_) {
+    /* bus not wired — never block persistence */
+  }
+});
+
 module.exports = mongoose.models.Beneficiary || mongoose.model('Beneficiary', beneficiarySchema);

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -734,3 +734,4 @@ __tests__/screening-core-linkage-wave980.test.js
 __tests__/auth-alias-user-id-wave947.test.js
 __tests__/no-async-next-save-hooks-wave978.test.js
 __tests__/medication-core-linkage-wave981.test.js
+__tests__/beneficiary-status-core-linkage-wave982.test.js


### PR DESCRIPTION
core.beneficiary.status_changed had a contract but no producer/timeline-subscriber. Now beneficiary status changes (active→inactive/waitlisted/transferred/deceased/graduated) record a CareTimeline 'status_changed' row (deceased=critical, graduated=success). Native Beneficiary post-save hook (update-only) + enum value + 1 subscriber. Verified end-to-end (wave982, 3 tests); W389/W374/W375 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)