### PR TITLE
feat(care): W983 schedule the dormant beneficiary-retention sweep

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1249,6 +1249,8 @@ on:
       - 'backend/__tests__/medication-core-linkage-wave981.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/beneficiary-status-core-linkage-wave982.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/retention-sweeper-bootstrap-wave983.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2481,6 +2483,8 @@ on:
       - 'backend/__tests__/medication-core-linkage-wave981.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/beneficiary-status-core-linkage-wave982.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/retention-sweeper-bootstrap-wave983.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/retention-sweeper-bootstrap-wave983.test.js
+++ b/backend/__tests__/retention-sweeper-bootstrap-wave983.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+/**
+ * W983 drift guard — retentionSweeperBootstrap.
+ *
+ * Schedules the dormant beneficiary-retention sweep (services/care/retention.service
+ * `sweep()`), which careBootstrap builds + exposes but only a manual POST ever ran
+ * (W225 dormant-capability pattern; careBootstrap notes "Future commits add retention
+ * sweepers"). Env-gated, default OFF — a run mutates state + emits interventions, so
+ * activation is an operator decision; the wiring ships inert.
+ *
+ * Locks: env-gated default OFF; throws without logger; graceful skip when the service
+ * is absent; schedules when enabled; each tick calls sweep (per branch); a sweep throw
+ * is swallowed; wired into schedulers.js after bootstrapCare. node-cron mocked.
+ */
+
+jest.mock('node-cron', () => ({ schedule: jest.fn(() => ({ stop() {} })) }));
+const cron = require('node-cron');
+
+const fs = require('fs');
+const path = require('path');
+const { wireRetentionSweeper } = require('../startup/retentionSweeperBootstrap');
+
+const SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'startup', 'retentionSweeperBootstrap.js'),
+  'utf8'
+);
+const SCHED_SRC = fs.readFileSync(path.join(__dirname, '..', 'startup', 'schedulers.js'), 'utf8');
+
+const silent = { info() {}, warn() {}, error() {} };
+
+afterEach(() => {
+  delete process.env.ENABLE_RETENTION_SWEEP;
+  delete process.env.RETENTION_SWEEP_BRANCH_IDS;
+  delete process.env.RETENTION_SWEEP_LIMIT;
+  cron.schedule.mockClear();
+});
+
+describe('W983 retentionSweeperBootstrap — source shape', () => {
+  it('env-gates on ENABLE_RETENTION_SWEEP', () => {
+    expect(SRC).toMatch(/process\.env\.ENABLE_RETENTION_SWEEP\s*!==\s*'true'/);
+  });
+  it('calls retentionService.sweep', () => {
+    expect(SRC).toMatch(/retentionService\.sweep\(/);
+  });
+  it('loads node-cron via loadOptional', () => {
+    expect(SRC).toMatch(/loadOptional\(\s*'node-cron'\s*\)/);
+  });
+  it('guards each tick', () => {
+    expect(SRC).toMatch(/catch \(err\)/);
+  });
+  it('exports wireRetentionSweeper', () => {
+    expect(SRC).toMatch(/module\.exports\s*=\s*\{\s*wireRetentionSweeper\s*\}/);
+  });
+  it('is wired into schedulers.js after bootstrapCare', () => {
+    expect(SCHED_SRC).toMatch(/wireRetentionSweeper\(\{/);
+    expect(SCHED_SRC.indexOf('bootstrapCare(')).toBeLessThan(
+      SCHED_SRC.indexOf('wireRetentionSweeper(')
+    );
+  });
+});
+
+describe('W983 retentionSweeperBootstrap — behavior', () => {
+  it('throws without a logger', () => {
+    expect(() => wireRetentionSweeper({})).toThrow(/logger required/);
+  });
+
+  it('is inert when the flag is unset (no cron scheduled)', () => {
+    const res = wireRetentionSweeper({ logger: silent, retentionService: { sweep: jest.fn() } });
+    expect(res).toEqual({ started: false });
+    expect(cron.schedule).not.toHaveBeenCalled();
+  });
+
+  it('skips gracefully when retentionService is absent', () => {
+    process.env.ENABLE_RETENTION_SWEEP = 'true';
+    expect(wireRetentionSweeper({ logger: silent })).toEqual({ started: false });
+    expect(cron.schedule).not.toHaveBeenCalled();
+  });
+
+  it('schedules when enabled; the tick sweeps once (all-branches) by default', async () => {
+    process.env.ENABLE_RETENTION_SWEEP = 'true';
+    const sweep = jest.fn(async () => ({ assessed: 3, totalCandidates: 3, errors: [] }));
+    const res = wireRetentionSweeper({ logger: silent, retentionService: { sweep } });
+    expect(res.started).toBe(true);
+    expect(cron.schedule).toHaveBeenCalledTimes(1);
+    await cron.schedule.mock.calls[0][1](); // invoke the tick
+    expect(sweep).toHaveBeenCalledTimes(1);
+    expect(sweep.mock.calls[0][0]).toMatchObject({ branchId: null, triggeredBy: 'scheduler' });
+  });
+
+  it('sweeps per branch when RETENTION_SWEEP_BRANCH_IDS is set', async () => {
+    process.env.ENABLE_RETENTION_SWEEP = 'true';
+    process.env.RETENTION_SWEEP_BRANCH_IDS = 'b1, b2';
+    const sweep = jest.fn(async () => ({ assessed: 1, totalCandidates: 1, errors: [] }));
+    wireRetentionSweeper({ logger: silent, retentionService: { sweep } });
+    await cron.schedule.mock.calls[0][1]();
+    expect(sweep).toHaveBeenCalledTimes(2);
+    expect(sweep.mock.calls.map(c => c[0].branchId)).toEqual(['b1', 'b2']);
+  });
+
+  it('swallows a sweep throw (one branch failure never aborts the tick)', async () => {
+    process.env.ENABLE_RETENTION_SWEEP = 'true';
+    process.env.RETENTION_SWEEP_BRANCH_IDS = 'b1, b2';
+    const sweep = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ assessed: 1, totalCandidates: 1, errors: [] });
+    wireRetentionSweeper({ logger: silent, retentionService: { sweep } });
+    await expect(cron.schedule.mock.calls[0][1]()).resolves.toBeUndefined();
+    expect(sweep).toHaveBeenCalledTimes(2); // b2 still ran after b1 threw
+  });
+});

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -735,3 +735,4 @@ __tests__/auth-alias-user-id-wave947.test.js
 __tests__/no-async-next-save-hooks-wave978.test.js
 __tests__/medication-core-linkage-wave981.test.js
 __tests__/beneficiary-status-core-linkage-wave982.test.js
+__tests__/retention-sweeper-bootstrap-wave983.test.js

--- a/backend/startup/retentionSweeperBootstrap.js
+++ b/backend/startup/retentionSweeperBootstrap.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * retentionSweeperBootstrap.js — W983.
+ *
+ * Schedules the DORMANT beneficiary-retention sweep. `services/care/retention.service.js`
+ * exposes `sweep({ branchId?, beneficiaryIds?, limit })` — batch-assess churn/retention
+ * risk + emit interventions when a risk band escalates — and careBootstrap constructs
+ * + exposes the service, but only a manual `POST /api/care/retention/sweep` ever calls
+ * it. careBootstrap even notes (line ~287) "Future commits add retention sweepers /
+ * scoring schedulers." Nothing scheduled it → the periodic re-assessment never ran
+ * (W225 dormant-capability pattern, same shape as W762/W973).
+ *
+ * GATED OFF BY DEFAULT (ENABLE_RETENTION_SWEEP=true). Ships inert. This matters more
+ * than the read-only sweepers: a run CREATES RetentionAssessment rows and EMITS
+ * interventions (psychologist notification / home-visit request / case flagging), so
+ * activation is an operator decision (cadence + scope + churn-model validation). The
+ * wiring ships ready; the operator opts in after testing.
+ *
+ * Env:
+ *   ENABLE_RETENTION_SWEEP       — 'true' to schedule (default: OFF)
+ *   RETENTION_SWEEP_CRON         — cron expr (default = daily 04:00 Asia/Riyadh)
+ *   RETENTION_SWEEP_BRANCH_IDS   — comma-separated branch ids; empty = one all-branches
+ *                                  sweep (capped by limit)
+ *   RETENTION_SWEEP_LIMIT        — max beneficiaries assessed per branch/run (default 200)
+ *
+ * Fully guarded: a sweep throw is caught per-tick and never breaks boot or other branches.
+ */
+
+function loadOptional(modulePath) {
+  try {
+    return require(modulePath);
+  } catch {
+    return null;
+  }
+}
+
+function wireRetentionSweeper(deps = {}) {
+  const { retentionService, logger } = deps;
+  if (!logger) {
+    throw new Error('retentionSweeperBootstrap.wireRetentionSweeper: logger required');
+  }
+
+  if (process.env.ENABLE_RETENTION_SWEEP !== 'true') {
+    logger.info(
+      '[startup] retention sweep disabled (set ENABLE_RETENTION_SWEEP=true to schedule churn re-assessment)'
+    );
+    return { started: false };
+  }
+
+  if (!retentionService || typeof retentionService.sweep !== 'function') {
+    logger.warn('[startup] retention service unavailable (sweep absent); sweeper not scheduled');
+    return { started: false };
+  }
+
+  const cron = loadOptional('node-cron');
+  if (!cron) {
+    logger.warn('[startup] node-cron not available; retention sweep not scheduled');
+    return { started: false };
+  }
+
+  const schedule = process.env.RETENTION_SWEEP_CRON || '0 4 * * *';
+  const limit = Number(process.env.RETENTION_SWEEP_LIMIT) || 200;
+  const branchIds = (process.env.RETENTION_SWEEP_BRANCH_IDS || '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  const TZ = { timezone: 'Asia/Riyadh' };
+
+  cron.schedule(
+    schedule,
+    async () => {
+      // One all-branches sweep when no branch list is given; otherwise per-branch
+      // (each isolated so one branch failure doesn't abort the rest).
+      const targets = branchIds.length ? branchIds : [null];
+      for (const branchId of targets) {
+        try {
+          const res = await retentionService.sweep({ branchId, limit, triggeredBy: 'scheduler' });
+          logger.info(
+            `[retention-sweep] ${branchId || 'all-branches'}: assessed=${(res && res.assessed) ?? '?'} candidates=${(res && res.totalCandidates) ?? '?'} errors=${(res && res.errors && res.errors.length) || 0}`
+          );
+        } catch (err) {
+          logger.error('[retention-sweep] failed', {
+            branchId: branchId || 'all',
+            error: err && err.message,
+          });
+        }
+      }
+    },
+    TZ
+  );
+
+  logger.info(
+    `[startup] W983 retention sweep scheduled (${schedule} Asia/Riyadh; ${branchIds.length ? branchIds.length + ' branch(es)' : 'all branches'}, limit ${limit})`
+  );
+  return { started: true, branches: branchIds.length || 'all', limit };
+}
+
+module.exports = { wireRetentionSweeper };

--- a/backend/startup/schedulers.js
+++ b/backend/startup/schedulers.js
@@ -136,6 +136,17 @@ function setupSchedulers({ isTestEnv }) {
       if (care) {
         registerShutdownHook('Care', care.shutdown);
         logger.info('✅ Phase 17 Care Platform online (CRM lead funnel)');
+        // W983 — schedule the dormant retention sweep (churn re-assessment).
+        // careBootstrap builds retentionService but only a manual POST ever ran it;
+        // env-gated, default OFF (ENABLE_RETENTION_SWEEP=true). Guarded internally.
+        try {
+          require('./retentionSweeperBootstrap').wireRetentionSweeper({
+            retentionService: care.retentionService,
+            logger,
+          });
+        } catch (rsErr) {
+          logger.warn('⚠️  Retention sweeper wiring failed', { error: rsErr.message });
+        }
       }
     } catch (err) {
       logger.warn('⚠️  Care bootstrap failed', { error: err.message });


### PR DESCRIPTION
## What

`services/care/retention.service.js` exposes `sweep({ branchId?, limit })` — batch churn/retention-risk assessment that emits interventions on band escalation — and careBootstrap builds + exposes the service, but **only a manual `POST /api/care/retention/sweep` ever called it**. careBootstrap itself notes *"Future commits add retention sweepers / scoring schedulers."* Nothing scheduled it → the periodic re-assessment never ran (W225 dormant-capability pattern; same shape as W762/W973).

## How

New `startup/retentionSweeperBootstrap.js` schedules `retentionService.sweep()` via node-cron (Asia/Riyadh), wired into `schedulers.js` right after `bootstrapCare` (where the service instance exists). Per-branch (`RETENTION_SWEEP_BRANCH_IDS`) or one all-branches sweep; `RETENTION_SWEEP_CRON` (default daily 04:00); `RETENTION_SWEEP_LIMIT` (default 200, conservative).

## Safety

**Gated OFF by default** (`ENABLE_RETENTION_SWEEP=true`) — ships inert. Gated more deliberately than read-only sweepers: a run **creates** `RetentionAssessment` rows + **emits** interventions (psychologist notify / home-visit request / case flag), so **enabling** is an operator decision (cadence + scope + churn-model validation); the wiring ships ready. Fully guarded — a sweep throw is caught per-tick *and* per-branch so one failure never aborts the rest or boot.

Verified **cold** (only lint churn, not the parallel agent's core work) + **no existing retention cron** (W978 lesson: checked fresh main history before building).

## Tests (12, node-cron mocked)

env-gated inert default; throws without logger; graceful no-service skip; schedules when on; tick sweeps (all-branches + per-branch); a sweep throw is swallowed; wired into schedulers.js after bootstrapCare. eslint clean, schedulers loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)