### PR TITLE
feat(complaints): W984 wire beneficiary complaints onto the unified-core timeline

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1251,6 +1251,8 @@ on:
       - 'backend/__tests__/beneficiary-status-core-linkage-wave982.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/retention-sweeper-bootstrap-wave983.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/complaint-core-linkage-wave984.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2485,6 +2487,8 @@ on:
       - 'backend/__tests__/beneficiary-status-core-linkage-wave982.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/retention-sweeper-bootstrap-wave983.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/complaint-core-linkage-wave984.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/complaint-core-linkage-wave984.test.js
+++ b/backend/__tests__/complaint-core-linkage-wave984.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+/**
+ * complaint-core-linkage-wave984.test.js — W984 (renumbered at push if taken).
+ *
+ * Wires a complaint/grievance ABOUT a beneficiary onto the unified-core timeline
+ * at filing. Only beneficiary-linked complaints fire (org/staff complaints have
+ * no beneficiary timeline). Producer: native Complaint post-save hook
+ * (create-only). RUNTIME end-to-end against a real in-memory Mongo + the real
+ * integration bus + real subscribers.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let Complaint, CareTimeline;
+
+async function waitForTimeline(query, { timeout = 4000, interval = 25 } = {}) {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const row = await CareTimeline.findOne(query);
+    if (row) return row;
+    if (Date.now() - start > timeout) return null;
+    await new Promise(r => setTimeout(r, interval));
+  }
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w983-complaint' } });
+  await mongoose.connect(mongod.getUri());
+  Complaint = require('../models/Complaint');
+  ({ CareTimeline } = require('../domains/timeline/models/CareTimeline'));
+  require('../models/Beneficiary');
+  const { integrationBus } = require('../integration/systemIntegrationBus');
+  const { initializeDDDSubscribers } = require('../integration/dddCrossModuleSubscribers');
+  initializeDDDSubscribers(integrationBus);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+afterEach(async () => {
+  await Promise.all([Complaint.deleteMany({}), CareTimeline.deleteMany({})]);
+});
+
+function newComplaint(extra = {}) {
+  return Complaint.create({
+    type: 'complaint',
+    source: 'parent',
+    category: 'service',
+    subject: 'تأخر في الرد',
+    description: 'تفاصيل الشكوى',
+    submittedBy: new mongoose.Types.ObjectId(),
+    ...extra,
+  });
+}
+
+describe('W984 — beneficiary complaints reach the unified-core timeline', () => {
+  it('a complaint linked to a beneficiary lands a complaint_filed row', async () => {
+    const beneficiaryId = new mongoose.Types.ObjectId();
+    await newComplaint({ beneficiaryId });
+    const tl = await waitForTimeline({ beneficiaryId, eventType: 'complaint_filed' });
+    expect(tl).toBeTruthy();
+    expect(tl.category).toBe('communication');
+    expect(tl.severity).toBe('info');
+  });
+
+  it('a grievance lands a WARNING complaint_filed row', async () => {
+    const beneficiaryId = new mongoose.Types.ObjectId();
+    await newComplaint({ beneficiaryId, type: 'grievance' });
+    const tl = await waitForTimeline({ beneficiaryId, eventType: 'complaint_filed' });
+    expect(tl).toBeTruthy();
+    expect(tl.severity).toBe('warning');
+  });
+
+  it('a complaint with NO beneficiary produces no timeline row', async () => {
+    await newComplaint(); // no beneficiaryId
+    await new Promise(r => setTimeout(r, 200));
+    expect(await CareTimeline.countDocuments({ eventType: 'complaint_filed' })).toBe(0);
+  });
+});

--- a/backend/__tests__/ddd-event-contracts-wave374.test.js
+++ b/backend/__tests__/ddd-event-contracts-wave374.test.js
@@ -66,6 +66,7 @@ const EXPECTED_DOMAIN_GROUPS = Object.freeze([
   'waitlist', // W979 — waitlist added / booked (admission) → core timeline
   'screenings', // W980 — vision / hearing screening finalized → core timeline
   'medication', // W981 — medication administered / not-given → core timeline
+  'complaints', // W984 — complaint filed about a beneficiary → core timeline
 ]);
 
 // Allowed `eventType` prefixes. Most match W354 TIER domain names; a few are
@@ -106,6 +107,7 @@ const ALLOWED_EVENT_PREFIXES = Object.freeze(
     'waitlist', // W979
     'screening', // W980
     'medication', // W981
+    'complaint', // W984
   ])
 );
 
@@ -154,6 +156,7 @@ describe('W374 DDD event-contracts drift guard', () => {
         waitlist: 'WAITLIST_EVENTS', // W979
         screenings: 'SCREENING_EVENTS', // W980
         medication: 'MEDICATION_EVENTS', // W981
+        complaints: 'COMPLAINT_EVENTS', // W984
       };
       for (const [group, exportName] of Object.entries(groupExportMap)) {
         expect(contracts[exportName]).toBe(contracts.DDD_CONTRACTS[group]);

--- a/backend/domains/timeline/models/CareTimeline.js
+++ b/backend/domains/timeline/models/CareTimeline.js
@@ -77,6 +77,7 @@ const careTimelineSchema = new mongoose.Schema(
         'risk_flag_resolved',
         'quality_alert',
         'compliance_issue',
+        'complaint_filed', // W984
         'behavior_incident', // W970 — behavior subscriber (already on main) needs this enum value
         // Safety (W977)
         'seizure_event',

--- a/backend/events/contracts/dddEventContracts.js
+++ b/backend/events/contracts/dddEventContracts.js
@@ -703,6 +703,33 @@ const MEDICATION_EVENTS = {
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
+//  Complaint Events — أحداث الشكاوى (W984)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// A complaint/grievance ABOUT a beneficiary surfaces on the timeline at filing
+// (CRPD-relevant). Producer: native Complaint post-save hook (beneficiary-linked
+// only). Consumer: CareTimeline subscriber.
+
+const COMPLAINT_EVENTS = {
+  FILED: {
+    domain: 'complaints',
+    eventType: 'complaint.filed',
+    version: 1,
+    description: 'تم تقديم شكوى عن مستفيد — Complaint filed about a beneficiary',
+    payload: {
+      complaintId: 'string',
+      beneficiaryId: 'string',
+      type: 'string',
+      category: 'string',
+      subject: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.REALTIME, DELIVERY.LOCAL],
+    priority: PRIORITY.HIGH,
+    consumers: ['timeline', 'dashboards', 'notification'],
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
 //  Aggregated Contracts Registry
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -721,6 +748,7 @@ const DDD_CONTRACTS = {
   waitlist: WAITLIST_EVENTS,
   screenings: SCREENING_EVENTS,
   medication: MEDICATION_EVENTS,
+  complaints: COMPLAINT_EVENTS,
 };
 
 /**
@@ -752,6 +780,7 @@ module.exports = {
   WAITLIST_EVENTS,
   SCREENING_EVENTS,
   MEDICATION_EVENTS,
+  COMPLAINT_EVENTS,
   DDD_CONTRACTS,
   getDDDContractStats,
 };

--- a/backend/integration/dddCrossModuleSubscribers.js
+++ b/backend/integration/dddCrossModuleSubscribers.js
@@ -1041,6 +1041,32 @@ function initializeDDDSubscribers(integrationBus, _moduleConnector) {
     },
   });
 
+  // ─── Complaints → Timeline: Filed about a beneficiary (W984) ──────
+  subscribers.push({
+    name: 'complaints:filed → timeline:record',
+    pattern: 'complaints.complaint.filed',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          const grievance = event.payload.type === 'grievance';
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'complaint_filed',
+            category: 'communication',
+            severity: grievance ? 'warning' : 'info',
+            title: `${grievance ? 'Grievance' : 'Complaint'} filed (${event.payload.category || ''})`.trim(),
+            title_ar: `${grievance ? 'تظلّم' : 'شكوى'} (${event.payload.category || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Complaint-filed timeline failed: ${err.message}`);
+      }
+    },
+  });
+
   // ── Register all subscribers ───────────────────────────────────────
   let registered = 0;
   for (const sub of subscribers) {

--- a/backend/models/Complaint.js
+++ b/backend/models/Complaint.js
@@ -163,4 +163,32 @@ complaintSchema.pre('save', async function () {
   }
 });
 
+// W984 — surface a complaint/grievance ABOUT a beneficiary on the unified-core
+// timeline at filing time (a grievance is a CRPD-relevant signal). Only fires
+// when the complaint is linked to a beneficiary (org/staff complaints have no
+// beneficiary timeline). Native pre-compile hooks per the proven W970 pattern;
+// create-only, guarded, fire-and-forget. Consumed by dddCrossModuleSubscribers.
+complaintSchema.pre('save', function () {
+  this.$__wasNew = this.isNew;
+});
+complaintSchema.post('save', function (doc) {
+  try {
+    if (!this.$__wasNew) return; // record once, at filing
+    if (!doc.beneficiaryId) return; // only beneficiary-linked complaints
+    const { integrationBus } = require('../integration/systemIntegrationBus');
+    if (!integrationBus || typeof integrationBus.publish !== 'function') return;
+    Promise.resolve(
+      integrationBus.publish('complaints', 'complaint.filed', {
+        complaintId: String(doc._id),
+        beneficiaryId: String(doc.beneficiaryId),
+        type: doc.type || 'complaint',
+        category: doc.category || '',
+        subject: doc.subject || '',
+      })
+    ).catch(() => {});
+  } catch (_) {
+    /* bus not wired — never block persistence */
+  }
+});
+
 module.exports = mongoose.models.Complaint || mongoose.model('Complaint', complaintSchema);

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -736,3 +736,4 @@ __tests__/no-async-next-save-hooks-wave978.test.js
 __tests__/medication-core-linkage-wave981.test.js
 __tests__/beneficiary-status-core-linkage-wave982.test.js
 __tests__/retention-sweeper-bootstrap-wave983.test.js
+__tests__/complaint-core-linkage-wave984.test.js


### PR DESCRIPTION
Tier-2 ledger item: complaint/grievance ABOUT a beneficiary → timeline at filing (grievance=warning). Only beneficiary-linked complaints fire. Native Complaint post-save hook (create-only) + COMPLAINT_EVENTS contract + W374 + complaint_filed enum + 1 subscriber. Verified end-to-end (wave984, 3 tests); W389/W374/W375 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)