### PR TITLE
feat(family): W985 wire family-visit outcomes onto the unified-core timeline

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1253,6 +1253,8 @@ on:
       - 'backend/__tests__/retention-sweeper-bootstrap-wave983.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/complaint-core-linkage-wave984.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/family-visit-core-linkage-wave985.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2489,6 +2491,8 @@ on:
       - 'backend/__tests__/retention-sweeper-bootstrap-wave983.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/complaint-core-linkage-wave984.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/family-visit-core-linkage-wave985.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/ddd-event-contracts-wave374.test.js
+++ b/backend/__tests__/ddd-event-contracts-wave374.test.js
@@ -67,6 +67,7 @@ const EXPECTED_DOMAIN_GROUPS = Object.freeze([
   'screenings', // W980 — vision / hearing screening finalized → core timeline
   'medication', // W981 — medication administered / not-given → core timeline
   'complaints', // W984 — complaint filed about a beneficiary → core timeline
+  'family', // W985 — family visit completed / no-show → core timeline
 ]);
 
 // Allowed `eventType` prefixes. Most match W354 TIER domain names; a few are
@@ -108,6 +109,7 @@ const ALLOWED_EVENT_PREFIXES = Object.freeze(
     'screening', // W980
     'medication', // W981
     'complaint', // W984
+    'visit', // W985
   ])
 );
 
@@ -157,6 +159,7 @@ describe('W374 DDD event-contracts drift guard', () => {
         screenings: 'SCREENING_EVENTS', // W980
         medication: 'MEDICATION_EVENTS', // W981
         complaints: 'COMPLAINT_EVENTS', // W984
+        family: 'FAMILY_EVENTS', // W985
       };
       for (const [group, exportName] of Object.entries(groupExportMap)) {
         expect(contracts[exportName]).toBe(contracts.DDD_CONTRACTS[group]);

--- a/backend/__tests__/family-visit-core-linkage-wave985.test.js
+++ b/backend/__tests__/family-visit-core-linkage-wave985.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+/**
+ * family-visit-core-linkage-wave985.test.js — W985.
+ *
+ * Wires family engagement onto the unified-core timeline: a completed family
+ * visit (positive, success) and a no-show (disengagement, warning). Producer:
+ * native FamilyVisitRequest post-save hook (status flip to completed / no_show).
+ * RUNTIME end-to-end against a real in-memory Mongo + the real integration bus +
+ * real subscribers. Reuses the existing 'family_meeting' CareTimeline eventType.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let FamilyVisit, CareTimeline;
+
+async function waitForTimeline(query, { timeout = 4000, interval = 25 } = {}) {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const row = await CareTimeline.findOne(query);
+    if (row) return row;
+    if (Date.now() - start > timeout) return null;
+    await new Promise(r => setTimeout(r, interval));
+  }
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w985-familyvisit' } });
+  await mongoose.connect(mongod.getUri());
+  FamilyVisit = require('../models/FamilyVisitRequest');
+  ({ CareTimeline } = require('../domains/timeline/models/CareTimeline'));
+  require('../models/Beneficiary');
+  const { integrationBus } = require('../integration/systemIntegrationBus');
+  const { initializeDDDSubscribers } = require('../integration/dddCrossModuleSubscribers');
+  initializeDDDSubscribers(integrationBus);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+afterEach(async () => {
+  await Promise.all([FamilyVisit.deleteMany({}), CareTimeline.deleteMany({})]);
+});
+
+function newVisit(extra = {}) {
+  return FamilyVisit.create({
+    beneficiaryId: new mongoose.Types.ObjectId(),
+    parentName: 'أبو سالم',
+    parentNationalId: '1234567890',
+    relationship: 'father',
+    requestedDate: new Date(),
+    slot: 'morning',
+    ...extra,
+  });
+}
+
+describe('W985 — family visits reach the unified-core timeline', () => {
+  it('a requested visit produces no timeline row until it completes', async () => {
+    const v = await newVisit();
+    await new Promise(r => setTimeout(r, 150));
+    expect(await CareTimeline.countDocuments({ beneficiaryId: v.beneficiaryId })).toBe(0);
+
+    const loaded = await FamilyVisit.findById(v._id);
+    loaded.status = 'completed';
+    await loaded.save();
+
+    const tl = await waitForTimeline({ beneficiaryId: v.beneficiaryId, eventType: 'family_meeting' });
+    expect(tl).toBeTruthy();
+    expect(tl.category).toBe('family');
+    expect(tl.severity).toBe('success');
+  });
+
+  it('a no-show lands a WARNING family_meeting row', async () => {
+    const v = await newVisit();
+    const loaded = await FamilyVisit.findById(v._id);
+    loaded.status = 'no_show';
+    await loaded.save();
+    const tl = await waitForTimeline({ beneficiaryId: v.beneficiaryId, eventType: 'family_meeting' });
+    expect(tl).toBeTruthy();
+    expect(tl.severity).toBe('warning');
+  });
+
+  it('an approved (not completed) visit produces no row', async () => {
+    const v = await newVisit();
+    const loaded = await FamilyVisit.findById(v._id);
+    loaded.status = 'approved';
+    loaded.approvedAt = new Date();
+    await loaded.save();
+    await new Promise(r => setTimeout(r, 200));
+    expect(await CareTimeline.countDocuments({ beneficiaryId: v.beneficiaryId })).toBe(0);
+  });
+});

--- a/backend/events/contracts/dddEventContracts.js
+++ b/backend/events/contracts/dddEventContracts.js
@@ -730,6 +730,47 @@ const COMPLAINT_EVENTS = {
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
+//  Family Events — أحداث الأسرة (W985)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Family engagement on the timeline: a completed visit (positive) and a no-show
+// (disengagement signal). Producer: native FamilyVisitRequest post-save hook.
+
+const FAMILY_EVENTS = {
+  VISIT_COMPLETED: {
+    domain: 'family',
+    eventType: 'visit.completed',
+    version: 1,
+    description: 'تمت زيارة أسرية — Family visit completed',
+    payload: {
+      visitId: 'string',
+      beneficiaryId: 'string',
+      relationship: 'string',
+      requestedDate: 'date',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards'],
+  },
+
+  VISIT_NO_SHOW: {
+    domain: 'family',
+    eventType: 'visit.no_show',
+    version: 1,
+    description: 'تغيّبت الأسرة عن زيارة — Family visit no-show',
+    payload: {
+      visitId: 'string',
+      beneficiaryId: 'string',
+      relationship: 'string',
+      requestedDate: 'date',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.REALTIME, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards', 'ai-recommendations'],
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
 //  Aggregated Contracts Registry
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -749,6 +790,7 @@ const DDD_CONTRACTS = {
   screenings: SCREENING_EVENTS,
   medication: MEDICATION_EVENTS,
   complaints: COMPLAINT_EVENTS,
+  family: FAMILY_EVENTS,
 };
 
 /**
@@ -781,6 +823,7 @@ module.exports = {
   SCREENING_EVENTS,
   MEDICATION_EVENTS,
   COMPLAINT_EVENTS,
+  FAMILY_EVENTS,
   DDD_CONTRACTS,
   getDDDContractStats,
 };

--- a/backend/integration/dddCrossModuleSubscribers.js
+++ b/backend/integration/dddCrossModuleSubscribers.js
@@ -1067,6 +1067,56 @@ function initializeDDDSubscribers(integrationBus, _moduleConnector) {
     },
   });
 
+  // ─── Family → Timeline: Visit completed (W985, engagement) ────────
+  subscribers.push({
+    name: 'family:visit_completed → timeline:record',
+    pattern: 'family.visit.completed',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'family_meeting',
+            category: 'family',
+            severity: 'success',
+            title: `Family visit completed (${event.payload.relationship || ''})`.trim(),
+            title_ar: `زيارة أسرية مكتملة (${event.payload.relationship || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Family-visit-completed timeline failed: ${err.message}`);
+      }
+    },
+  });
+
+  // ─── Family → Timeline: Visit no-show (W985, disengagement) ───────
+  subscribers.push({
+    name: 'family:visit_no_show → timeline:record',
+    pattern: 'family.visit.no_show',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'family_meeting',
+            category: 'family',
+            severity: 'warning',
+            title: `Family visit no-show (${event.payload.relationship || ''})`.trim(),
+            title_ar: `تغيّب الأسرة عن زيارة (${event.payload.relationship || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Family-visit-no-show timeline failed: ${err.message}`);
+      }
+    },
+  });
+
   // ── Register all subscribers ───────────────────────────────────────
   let registered = 0;
   for (const sub of subscribers) {

--- a/backend/models/FamilyVisitRequest.js
+++ b/backend/models/FamilyVisitRequest.js
@@ -92,6 +92,37 @@ FamilyVisitRequestSchema.path('__invariants').validate(function () {
   return ok;
 });
 
+// W985 — surface family engagement on the unified-core timeline: a completed
+// family visit (positive engagement) and a no-show (disengagement signal).
+// Fires on the status flip to completed / no_show (once). Native pre-compile
+// hooks per the proven W970 pattern; guarded, fire-and-forget. Consumed by
+// dddCrossModuleSubscribers → CareTimeline (reuses the existing family_meeting
+// eventType, severity by outcome).
+FamilyVisitRequestSchema.post('init', function () {
+  this.$__prevStatus = this.status;
+});
+FamilyVisitRequestSchema.post('save', function (doc) {
+  try {
+    if (doc.status === this.$__prevStatus) return; // no status change
+    const { integrationBus } = require('../integration/systemIntegrationBus');
+    if (!integrationBus || typeof integrationBus.publish !== 'function') return;
+    if (!doc.beneficiaryId) return;
+    const base = {
+      visitId: String(doc._id),
+      beneficiaryId: String(doc.beneficiaryId),
+      relationship: doc.relationship || '',
+      requestedDate: doc.requestedDate,
+    };
+    if (doc.status === 'completed') {
+      Promise.resolve(integrationBus.publish('family', 'visit.completed', base)).catch(() => {});
+    } else if (doc.status === 'no_show') {
+      Promise.resolve(integrationBus.publish('family', 'visit.no_show', base)).catch(() => {});
+    }
+  } catch (_) {
+    /* bus not wired — never block persistence */
+  }
+});
+
 module.exports =
   mongoose.models.FamilyVisitRequest ||
   mongoose.model('FamilyVisitRequest', FamilyVisitRequestSchema);

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -737,3 +737,4 @@ __tests__/medication-core-linkage-wave981.test.js
 __tests__/beneficiary-status-core-linkage-wave982.test.js
 __tests__/retention-sweeper-bootstrap-wave983.test.js
 __tests__/complaint-core-linkage-wave984.test.js
+__tests__/family-visit-core-linkage-wave985.test.js


### PR DESCRIPTION
## W985 — Family-visit outcomes on the unified-core timeline

Continues the core-linkage roadmap (`docs/architecture/CORE_LINKAGE_LEDGER.md`). The **family-engagement leaf** is now wired: a completed family visit and a no-show appear on the beneficiary `CareTimeline`.

### What & why
The unified-core "nervous system" (`integrationBus` → `dddCrossModuleSubscribers` → `CareTimeline`) had no visibility into family engagement. A parent observing a session is a positive engagement signal; a no-show is a disengagement signal worth surfacing on the journey.

### How
- **Producer** — native pre-compile post-save hooks in `models/FamilyVisitRequest.js`:
  - `post('init')` captures `prevStatus`; `post('save')` fires **once** on the status flip to `completed`/`no_show` via `integrationBus.publish('family', 'visit.<x>', …)`.
  - Guarded + fire-and-forget so persistence never blocks. This is the **modelEventBridge-is-dead workaround (W974)** — schema hooks added after `mongoose.model()` compilation never fire, so the publish lives in the model file itself.
- **Contracts** — `FAMILY_EVENTS` group in `dddEventContracts.js` (`visit.completed` [info], `visit.no_show` [warning, + `ai-recommendations` consumer]) + aggregator + export.
- **Subscribers** — 2 in `dddCrossModuleSubscribers.js` → `CareTimeline` rows, **reusing the existing `family_meeting` eventType** (completed = success, no_show = warning). No new enum value needed.

### Verification
- **Runtime e2e test** (`family-visit-core-linkage-wave985.test.js`, 3 assertions) against real in-memory Mongo + real bus + real subscribers: completed → success row, no_show → warning row, approved/requested → nothing.
- Guards green: **W374** (family domain + `visit` prefix + `FAMILY_EVENTS` export) / **W375** / **W389** / **W392** + `check:hook-style` + sprint-hygiene meta-tests.

### Risk
Additive. Only fires for the two terminal outcomes, only when `beneficiaryId` is present. No env flag — the subscribers are already wired into the DDD bus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
