### PR TITLE
feat(lifecycle): W986 wire life-stage transition plans onto the unified-core timeline

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1255,6 +1255,8 @@ on:
       - 'backend/__tests__/complaint-core-linkage-wave984.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/family-visit-core-linkage-wave985.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/transition-plan-core-linkage-wave986.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2493,6 +2495,8 @@ on:
       - 'backend/__tests__/complaint-core-linkage-wave984.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/family-visit-core-linkage-wave985.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/transition-plan-core-linkage-wave986.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/ddd-event-contracts-wave374.test.js
+++ b/backend/__tests__/ddd-event-contracts-wave374.test.js
@@ -68,6 +68,7 @@ const EXPECTED_DOMAIN_GROUPS = Object.freeze([
   'medication', // W981 — medication administered / not-given → core timeline
   'complaints', // W984 — complaint filed about a beneficiary → core timeline
   'family', // W985 — family visit completed / no-show → core timeline
+  'lifecycle', // W986 — life-stage transition plan completed / cancelled → core timeline
 ]);
 
 // Allowed `eventType` prefixes. Most match W354 TIER domain names; a few are
@@ -110,6 +111,7 @@ const ALLOWED_EVENT_PREFIXES = Object.freeze(
     'medication', // W981
     'complaint', // W984
     'visit', // W985
+    'transition', // W986
   ])
 );
 
@@ -160,6 +162,7 @@ describe('W374 DDD event-contracts drift guard', () => {
         medication: 'MEDICATION_EVENTS', // W981
         complaints: 'COMPLAINT_EVENTS', // W984
         family: 'FAMILY_EVENTS', // W985
+        lifecycle: 'LIFECYCLE_EVENTS', // W986
       };
       for (const [group, exportName] of Object.entries(groupExportMap)) {
         expect(contracts[exportName]).toBe(contracts.DDD_CONTRACTS[group]);

--- a/backend/__tests__/transition-plan-core-linkage-wave986.test.js
+++ b/backend/__tests__/transition-plan-core-linkage-wave986.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+/**
+ * transition-plan-core-linkage-wave986.test.js — W986.
+ *
+ * Wires life-stage transition plans onto the unified-core timeline: a completed
+ * plan (the beneficiary successfully moved to the next life stage — success) and
+ * a cancelled plan (the transition was abandoned — warning). Producer: native
+ * TransitionPlan post-save hook (status flip to completed / cancelled).
+ * RUNTIME end-to-end against a real in-memory Mongo + the real integration bus +
+ * real subscribers → a `care_transition` CareTimeline row.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let TransitionPlan, CareTimeline;
+
+async function waitForTimeline(query, { timeout = 4000, interval = 25 } = {}) {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const row = await CareTimeline.findOne(query);
+    if (row) return row;
+    if (Date.now() - start > timeout) return null;
+    await new Promise(r => setTimeout(r, interval));
+  }
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w986-transition' } });
+  await mongoose.connect(mongod.getUri());
+  TransitionPlan = require('../models/TransitionPlan');
+  ({ CareTimeline } = require('../domains/timeline/models/CareTimeline'));
+  require('../models/Beneficiary');
+  const { integrationBus } = require('../integration/systemIntegrationBus');
+  const { initializeDDDSubscribers } = require('../integration/dddCrossModuleSubscribers');
+  initializeDDDSubscribers(integrationBus);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+afterEach(async () => {
+  await Promise.all([TransitionPlan.deleteMany({}), CareTimeline.deleteMany({})]);
+});
+
+// Create a fresh DRAFT plan (draft requires no lead; transitionType + beneficiaryId required).
+function newDraftPlan(extra = {}) {
+  return TransitionPlan.create({
+    beneficiaryId: new mongoose.Types.ObjectId(),
+    transitionType: 'rehab_to_community',
+    status: 'draft',
+    ...extra,
+  });
+}
+
+describe('W986 — transition plans reach the unified-core timeline', () => {
+  it('a draft plan produces no timeline row until it reaches a terminal status', async () => {
+    const p = await newDraftPlan();
+    await new Promise(r => setTimeout(r, 150));
+    expect(await CareTimeline.countDocuments({ beneficiaryId: p.beneficiaryId })).toBe(0);
+
+    // draft → completed (invariants: actualTransitionDate + a transition lead)
+    const loaded = await TransitionPlan.findById(p._id);
+    loaded.status = 'completed';
+    loaded.actualTransitionDate = new Date();
+    loaded.transitionLeadName = 'منسق الانتقال';
+    await loaded.save();
+
+    const tl = await waitForTimeline({
+      beneficiaryId: p.beneficiaryId,
+      eventType: 'care_transition',
+    });
+    expect(tl).toBeTruthy();
+    expect(tl.category).toBe('clinical');
+    expect(tl.severity).toBe('success');
+  });
+
+  it('a cancelled plan lands a WARNING care_transition row', async () => {
+    const p = await newDraftPlan();
+    const loaded = await TransitionPlan.findById(p._id);
+    loaded.status = 'cancelled';
+    loaded.transitionLeadName = 'منسق الانتقال';
+    await loaded.save();
+    const tl = await waitForTimeline({
+      beneficiaryId: p.beneficiaryId,
+      eventType: 'care_transition',
+    });
+    expect(tl).toBeTruthy();
+    expect(tl.severity).toBe('warning');
+  });
+
+  it('a non-terminal status change (paused) produces no row', async () => {
+    const p = await newDraftPlan();
+    const loaded = await TransitionPlan.findById(p._id);
+    loaded.status = 'paused';
+    loaded.transitionLeadName = 'منسق الانتقال';
+    await loaded.save();
+    await new Promise(r => setTimeout(r, 200));
+    expect(await CareTimeline.countDocuments({ beneficiaryId: p.beneficiaryId })).toBe(0);
+  });
+});

--- a/backend/domains/timeline/models/CareTimeline.js
+++ b/backend/domains/timeline/models/CareTimeline.js
@@ -38,6 +38,7 @@ const careTimelineSchema = new mongoose.Schema(
         'transfer',
         'readmission',
         'status_changed', // W982 — beneficiary lifecycle status change
+        'care_transition', // W986 — life-stage transition plan completed / cancelled
         // Clinical
         'assessment_completed',
         'screening_completed', // W980 — vision/hearing screening finalized

--- a/backend/events/contracts/dddEventContracts.js
+++ b/backend/events/contracts/dddEventContracts.js
@@ -771,6 +771,49 @@ const FAMILY_EVENTS = {
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
+//  Lifecycle Events — أحداث الانتقال بين مراحل الحياة (W986)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Life-stage transition plans (early→school, school→work, rehab→community, …).
+// A completed plan = the beneficiary successfully transitioned (positive); a
+// cancelled plan = the transition was abandoned. Producer: native
+// TransitionPlan post-save hook.
+
+const LIFECYCLE_EVENTS = {
+  TRANSITION_COMPLETED: {
+    domain: 'lifecycle',
+    eventType: 'transition.completed',
+    version: 1,
+    description: 'اكتملت خطة الانتقال — Life-stage transition plan completed',
+    payload: {
+      transitionPlanId: 'string',
+      beneficiaryId: 'string',
+      transitionType: 'string',
+      targetPlacement: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards'],
+  },
+
+  TRANSITION_CANCELLED: {
+    domain: 'lifecycle',
+    eventType: 'transition.cancelled',
+    version: 1,
+    description: 'أُلغيت خطة الانتقال — Life-stage transition plan cancelled',
+    payload: {
+      transitionPlanId: 'string',
+      beneficiaryId: 'string',
+      transitionType: 'string',
+      targetPlacement: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.REALTIME, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards', 'ai-recommendations'],
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
 //  Aggregated Contracts Registry
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -791,6 +834,7 @@ const DDD_CONTRACTS = {
   medication: MEDICATION_EVENTS,
   complaints: COMPLAINT_EVENTS,
   family: FAMILY_EVENTS,
+  lifecycle: LIFECYCLE_EVENTS,
 };
 
 /**
@@ -824,6 +868,7 @@ module.exports = {
   MEDICATION_EVENTS,
   COMPLAINT_EVENTS,
   FAMILY_EVENTS,
+  LIFECYCLE_EVENTS,
   DDD_CONTRACTS,
   getDDDContractStats,
 };

--- a/backend/integration/dddCrossModuleSubscribers.js
+++ b/backend/integration/dddCrossModuleSubscribers.js
@@ -1117,6 +1117,56 @@ function initializeDDDSubscribers(integrationBus, _moduleConnector) {
     },
   });
 
+  // ─── Lifecycle → Timeline: transition plan completed (W986) ───────
+  subscribers.push({
+    name: 'lifecycle:transition_completed → timeline:record',
+    pattern: 'lifecycle.transition.completed',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'care_transition',
+            category: 'clinical',
+            severity: 'success',
+            title: `Transition plan completed (${event.payload.transitionType || ''})`.trim(),
+            title_ar: `اكتملت خطة الانتقال (${event.payload.transitionType || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Transition-completed timeline failed: ${err.message}`);
+      }
+    },
+  });
+
+  // ─── Lifecycle → Timeline: transition plan cancelled (W986) ───────
+  subscribers.push({
+    name: 'lifecycle:transition_cancelled → timeline:record',
+    pattern: 'lifecycle.transition.cancelled',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'care_transition',
+            category: 'clinical',
+            severity: 'warning',
+            title: `Transition plan cancelled (${event.payload.transitionType || ''})`.trim(),
+            title_ar: `أُلغيت خطة الانتقال (${event.payload.transitionType || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Transition-cancelled timeline failed: ${err.message}`);
+      }
+    },
+  });
+
   // ── Register all subscribers ───────────────────────────────────────
   let registered = 0;
   for (const sub of subscribers) {

--- a/backend/models/TransitionPlan.js
+++ b/backend/models/TransitionPlan.js
@@ -260,6 +260,44 @@ TransitionPlanSchema.virtual('isOverdue').get(function () {
 TransitionPlanSchema.set('toJSON', { virtuals: true });
 TransitionPlanSchema.set('toObject', { virtuals: true });
 
+// W986 — surface life-stage transitions on the unified-core timeline: a
+// completed transition plan (the beneficiary successfully moved to the next
+// life stage — positive) and a cancelled one (the transition was abandoned).
+// Fires once on the status flip to completed / cancelled. Native pre-compile
+// hooks per the proven W970 pattern (the modelEventBridge-is-dead workaround —
+// hooks added after mongoose.model() compilation never fire); guarded +
+// fire-and-forget so persistence never blocks. Consumed by
+// dddCrossModuleSubscribers → CareTimeline (care_transition eventType, severity
+// by outcome).
+TransitionPlanSchema.post('init', function () {
+  this.$__prevStatus = this.status;
+});
+TransitionPlanSchema.post('save', function (doc) {
+  try {
+    if (doc.status === this.$__prevStatus) return; // no status change
+    const { integrationBus } = require('../integration/systemIntegrationBus');
+    if (!integrationBus || typeof integrationBus.publish !== 'function') return;
+    if (!doc.beneficiaryId) return;
+    const base = {
+      transitionPlanId: String(doc._id),
+      beneficiaryId: String(doc.beneficiaryId),
+      transitionType: doc.transitionType || '',
+      targetPlacement: doc.targetPlacement || '',
+    };
+    if (doc.status === 'completed') {
+      Promise.resolve(integrationBus.publish('lifecycle', 'transition.completed', base)).catch(
+        () => {}
+      );
+    } else if (doc.status === 'cancelled') {
+      Promise.resolve(integrationBus.publish('lifecycle', 'transition.cancelled', base)).catch(
+        () => {}
+      );
+    }
+  } catch (_) {
+    /* bus not wired — never block persistence */
+  }
+});
+
 module.exports =
   mongoose.models.TransitionPlan || mongoose.model('TransitionPlan', TransitionPlanSchema);
 

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -738,3 +738,4 @@ __tests__/beneficiary-status-core-linkage-wave982.test.js
 __tests__/retention-sweeper-bootstrap-wave983.test.js
 __tests__/complaint-core-linkage-wave984.test.js
 __tests__/family-visit-core-linkage-wave985.test.js
+__tests__/transition-plan-core-linkage-wave986.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -44,6 +44,14 @@ Per-beneficiary timeline + dashboards react in real time to:
 - **Behavior** — incident_recorded
 - **Appointments** — booked / cancelled / no-show (W970)
 - **Quality** — corrective_action_required
+- **Safety** — seizure / safeguarding / restraint (W977)
+- **Waitlist → admission** — added / booked (W979)
+- **Screenings** — vision / hearing finalized (W980)
+- **Medication (MAR)** — administered / not-given (W981)
+- **Beneficiary status lifecycle** — graduated / transferred / deceased / … (W982)
+- **Complaints (CRM)** — filed about a beneficiary (W984)
+- **Family visits** — completed / no-show (W985)
+- **Life-stage transitions** — transition plan completed / cancelled (W986)
 - **(env-gated, W974)** HR (hire/terminate/leave/salary/transfer), Finance
   (invoice/payment/expense/payroll), Medical (record/therapy/prescription/risk),
   Attendance (check-in/out), Notification (delivery_failed)
@@ -88,17 +96,23 @@ Out of **498 route files**, only ~a dozen feed the core. The bridge (once
 enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 
 ### Tier 1 — clinical, belongs on the timeline
-| Domain | Model (exists) | Suggested event | Mechanism |
+| Domain | Model (exists) | Event | Status |
 | --- | --- | --- | --- |
-| Referrals | `Referral` / `medicalReferrals` | `referral.made/accepted` | B or C |
-| Waitlist → admission | `Waitlist` | `admission.confirmed` | C |
-| Safety events | `SeizureEvent` · `SafeguardingConcern` · `RestraintSeclusion` | `seizure_event` / `safeguarding_concern` (enum reserved in CareTimeline) | C native hook |
-| Screenings | `VisionScreening` · `HearingScreening` | `screening.completed` | C native hook |
-| Medication admin (MAR) | verify model name | `medication.administered` | B or C |
-| Discharge / follow-up | `post-rehab-followup` · `transition-plan` | `discharge.followup_due` | C |
+| Waitlist → admission | `Waitlist` | `waitlist.*` → `waitlisted` / `waitlist_booked` | ✅ **W979** |
+| Safety events | `SeizureEvent` · `SafeguardingConcern` · `RestraintSeclusion` | `safety.*` → `seizure_event` / `safeguarding_concern` / `restraint_applied` | ✅ **W977** |
+| Screenings | `VisionScreening` · `HearingScreening` | `screening.completed` | ✅ **W980** |
+| Medication admin (MAR) | `MedicationAdministrationRecord` | `medication.administered` / `.not_given` | ✅ **W981** |
+| Discharge / transition | `TransitionPlan` | `lifecycle.transition.completed` / `.cancelled` → `care_transition` | ✅ **W986** |
+| Referrals | `TherapyReferral` / `CommunityReferral` / `medicalReferral` / `ReferralTracking` | `referral.made/accepted` | ⏳ **DEFERRED** — 4-model fragmentation; pick a canonical with domain input before wiring (`Referral` is the referring-ORG directory, not a beneficiary referral) |
+| Follow-up cases | `PostRehabCase` | `followup.*` | Candidate — beneficiary-keyed + active routes; not yet wired |
 
 ### Tier 2 — family / CRM visibility
-Complaints (`Complaint`), family visits, guardian-portal engagement.
+| Domain | Model | Event | Status |
+| --- | --- | --- | --- |
+| Beneficiary status lifecycle | `Beneficiary` | `beneficiary.status_changed` → `status_changed` | ✅ **W982** |
+| Complaints (CRM) | `Complaint` | `complaint.filed` → `complaint_filed` | ✅ **W984** |
+| Family visits | `FamilyVisitRequest` | `family.visit.completed` / `.no_show` → `family_meeting` | ✅ **W985** |
+| Guardian-portal engagement | — | — | Open |
 
 ### Tier 3 — operational / governance
 Inventory low-stock, maintenance overdue, contract/document expiry, insurance/
@@ -124,11 +138,14 @@ persist to the EventStore — intended behaviour. It is a **prod behaviour chang
 
 ---
 
-## 6. Coverage snapshot (2026-06-05)
+## 6. Coverage snapshot (updated 2026-06-08)
 
-- Real timeline/dashboard linkage: the **clinical spine** (≈ a dozen domains).
+- Real timeline/dashboard linkage: the **clinical spine** + 10 leaf domains wired
+  since 2026-06-05 via native pre-compile hooks (W977 safety · W979 waitlist ·
+  W980 screenings · W981 MAR · W982 beneficiary-status · W984 complaints ·
+  W985 family-visits · W986 transitions — all merged to main).
 - + 21 LIVE-registry mappings, **wired but dormant behind the flag**.
-- ≈ **470 route files** still operate as standalone CRUD with no core emission.
+- ≈ **460 route files** still operate as standalone CRUD with no core emission.
 - The frozen V4 `services/core` is **not** consumed by the live UI and is out of
   scope here.
 
@@ -139,4 +156,4 @@ and the remaining work is now a list — not a discovery.
 ---
 
 _See agent memory `project_core_linkage_silent_failures_2026-06-05` for the
-full incident detail (PRs #276 W970, #283 W974)._
+full incident detail + the per-wave PR list (PRs #276 W970 … #316 W985, + W986)._


### PR DESCRIPTION
## W986 — Life-stage transition plans on the unified-core timeline

Closes the **Tier-1 "discharge / transition" leaf** of the core-linkage roadmap (`docs/architecture/CORE_LINKAGE_LEDGER.md`). A completed transition plan (the beneficiary successfully moved to the next life stage — `school→work`, `rehab→community`, …) and a cancelled one appear on the beneficiary `CareTimeline`.

### How
- **Producer** — native pre-compile post-save hooks in `models/TransitionPlan.js`:
  - `post('init')` captures `prevStatus`; `post('save')` fires **once** on the status flip to `completed`/`cancelled` via `integrationBus.publish('lifecycle', 'transition.<x>', …)`.
  - Guarded + fire-and-forget so persistence never blocks. The **modelEventBridge-is-dead workaround (W974)** — schema hooks added after `mongoose.model()` compilation never fire, so the publish lives in the model file itself.
- **Contracts** — `LIFECYCLE_EVENTS` group in `dddEventContracts.js` (`transition.completed` [info], `transition.cancelled` [warning, + `ai-recommendations` consumer]) + aggregator + export.
- **CareTimeline enum** — new `care_transition` value (Lifecycle group).
- **Subscribers** — 2 in `dddCrossModuleSubscribers.js` → `CareTimeline` rows (`completed` = success, `cancelled` = warning, category `clinical`).

### Verification
- **Runtime e2e test** (`transition-plan-core-linkage-wave986.test.js`, 3 assertions) against real in-memory Mongo + real bus + real subscribers: completed → success row, cancelled → warning row, a non-terminal flip (`paused`) → nothing.
- Guards green: **W374** (lifecycle domain + `transition` prefix + `LIFECYCLE_EVENTS` export) / **W375** / **W389** / **W392** + `check:hook-style` + sprint-hygiene meta-tests.

### Ledger refresh (folded in)
`CORE_LINKAGE_LEDGER.md` was 6 waves stale. This PR marks **W977/W979/W980/W981/W982/W984/W985/W986** as shipped in the "what IS linked" list + the Tier-1/Tier-2 tables, flags **referrals as DEFERRED** (4-model fragmentation — needs a canonical-model decision), and updates the coverage snapshot.

### Risk
Additive. Only fires for the two terminal outcomes, only when `beneficiaryId` is present. No env flag — the subscribers are already wired into the DDD bus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
