### PR TITLE
ci(deploy): W951 raise deploy test-gate timeout 35→55min — fixes 2-day prod-stale

### DIFF
--- a/.github/workflows/deploy-hostinger.yml
+++ b/.github/workflows/deploy-hostinger.yml
@@ -124,12 +124,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: preflight
     if: ${{ github.event.inputs.skip_tests != 'true' }}
-    # 35 min: backend test count grew past 25,115 (jest 30 bump + new
-    # domain tests). Local: ~17 min on a fast box; GitHub runner ~50-100%
-    # slower → 25m kept hitting the cap on routine deploys (last one was
-    # the lockfile-refresh commit on 2026-05-13 timing out at exactly
-    # 25m16s, leaving production stale on e06a7667 for 11+ hours).
-    timeout-minutes: 35
+    # W951 (2026-06-08): raised 35 → 55. The 35-min cap recurred — the sprint
+    # suite kept growing (25,115+ tests, accelerated by the 2026-06 W98x core-
+    # linkage wave series) so `test:sprint` now runs ~35m on the GitHub runner
+    # and hit the cap on EVERY deploy → "🧪 Run Tests" cancelled → "🚀 Deploy to
+    # VPS" skipped → production stale on W976 for ~2 days while ~6 waves piled up
+    # merged-but-undeployed. The same suite is already proven green by the
+    # separate "🧪 Sprint Tests" push workflow, so this gate is a redundant
+    # re-run; 55m gives headroom until it's split or dropped (owner decision).
+    # History: an identical cap bit the 2026-05-13 lockfile-refresh deploy (25m16s,
+    # prod stale 11+ hours on e06a7667).
+    timeout-minutes: 55
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## الحادثة
**لا نشر إنتاج اكتمل منذ W976 (يومان)** رغم دمج ~6 موجات (W949 + W981–W987). السبب: وظيفة `🧪 Run Tests` في النشر (`test:guard && test:sprint`) تتجاوز سقف **35 دقيقة** (المجموعة نمت لـ25,115+ اختباراً بفعل سلسلة W98x) → تُلغى → `🚀 Deploy to VPS` يُتخطّى.

نفس فئة حادثة 2026-05-13 الموثّقة (W552).

## الإصلاح
رفع `timeout-minutes` من 35 إلى **55** (المجموعة نفسها مُثبتة خضراء في workflow «Sprint Tests» المنفصل، فهذه البوّابة تكرار — 55 تعيد الهامش). `cancel-in-progress: false` يضمن أن أي نشر يبدأ فعلاً يكتمل دون إلغائه بدفعة جديدة.

الحلّ الجذري (تقسيم المجموعة أو إسقاط البوّابة المكرّرة) متروك لقراركم — موثّق في تعليق الوظيفة.

🤖 Generated with [Claude Code](https://claude.com/claude-code)