### PR TITLE
feat(followup): W992 follow-up-visit core-linkage + ENABLE_MODEL_EVENT_BRIDGE runbook

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1259,6 +1259,8 @@ on:
       - 'backend/__tests__/transition-plan-core-linkage-wave986.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/postrehab-case-core-linkage-wave987.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/followup-visit-core-linkage-wave992.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2501,6 +2503,8 @@ on:
       - 'backend/__tests__/transition-plan-core-linkage-wave986.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/postrehab-case-core-linkage-wave987.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/followup-visit-core-linkage-wave992.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/followup-visit-core-linkage-wave992.test.js
+++ b/backend/__tests__/followup-visit-core-linkage-wave992.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+/**
+ * followup-visit-core-linkage-wave992.test.js — W992.
+ *
+ * Wires post-rehab follow-up *visits* onto the unified-core timeline (companion
+ * to the case-level W987): an attended visit (engagement — success) and a missed
+ * visit (the family didn't show — warning). Producer: native FollowUpVisit
+ * post-save hook (status flip to COMPLETED / MISSED). RUNTIME end-to-end against
+ * a real in-memory Mongo + the real integration bus + real subscribers →
+ * `followup_visit` CareTimeline rows. eventTypes are visit.attended/visit.missed
+ * (the W985 family domain owns visit.completed/no_show — eventTypes are unique).
+ *
+ * NOTE: the model's beneficiary ref field is `beneficiary` (not `beneficiaryId`).
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let FollowUpVisit, CareTimeline;
+
+async function waitForTimeline(query, { timeout = 4000, interval = 25 } = {}) {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const row = await CareTimeline.findOne(query);
+    if (row) return row;
+    if (Date.now() - start > timeout) return null;
+    await new Promise(r => setTimeout(r, interval));
+  }
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w992-followupvisit' } });
+  await mongoose.connect(mongod.getUri());
+  FollowUpVisit = require('../models/post-rehab/FollowUpVisit.model');
+  ({ CareTimeline } = require('../domains/timeline/models/CareTimeline'));
+  require('../models/Beneficiary');
+  const { integrationBus } = require('../integration/systemIntegrationBus');
+  const { initializeDDDSubscribers } = require('../integration/dddCrossModuleSubscribers');
+  initializeDDDSubscribers(integrationBus);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+afterEach(async () => {
+  await Promise.all([FollowUpVisit.deleteMany({}), CareTimeline.deleteMany({})]);
+});
+
+// Create a fresh SCHEDULED visit (required: postRehabCase, beneficiary,
+// visitNumber, visitType, scheduledDate, conductedBy).
+function newScheduledVisit(extra = {}) {
+  return FollowUpVisit.create({
+    postRehabCase: new mongoose.Types.ObjectId(),
+    beneficiary: new mongoose.Types.ObjectId(),
+    visitNumber: 1,
+    visitType: 'HOME_VISIT',
+    scheduledDate: new Date(),
+    conductedBy: new mongoose.Types.ObjectId(),
+    status: 'SCHEDULED',
+    ...extra,
+  });
+}
+
+describe('W992 — post-rehab follow-up visits reach the unified-core timeline', () => {
+  it('a scheduled visit produces no timeline row until it is attended/missed', async () => {
+    const v = await newScheduledVisit();
+    await new Promise(r => setTimeout(r, 150));
+    expect(await CareTimeline.countDocuments({ beneficiaryId: v.beneficiary })).toBe(0);
+
+    const loaded = await FollowUpVisit.findById(v._id);
+    loaded.status = 'COMPLETED';
+    await loaded.save();
+
+    const tl = await waitForTimeline({ beneficiaryId: v.beneficiary, eventType: 'followup_visit' });
+    expect(tl).toBeTruthy();
+    expect(tl.category).toBe('clinical');
+    expect(tl.severity).toBe('success');
+  });
+
+  it('a missed visit lands a WARNING followup_visit row', async () => {
+    const v = await newScheduledVisit();
+    const loaded = await FollowUpVisit.findById(v._id);
+    loaded.status = 'MISSED';
+    await loaded.save();
+    const tl = await waitForTimeline({ beneficiaryId: v.beneficiary, eventType: 'followup_visit' });
+    expect(tl).toBeTruthy();
+    expect(tl.severity).toBe('warning');
+  });
+
+  it('a non-terminal status change (RESCHEDULED) produces no row', async () => {
+    const v = await newScheduledVisit();
+    const loaded = await FollowUpVisit.findById(v._id);
+    loaded.status = 'RESCHEDULED';
+    await loaded.save();
+    await new Promise(r => setTimeout(r, 200));
+    expect(await CareTimeline.countDocuments({ beneficiaryId: v.beneficiary })).toBe(0);
+  });
+});

--- a/backend/domains/timeline/models/CareTimeline.js
+++ b/backend/domains/timeline/models/CareTimeline.js
@@ -46,6 +46,7 @@ const careTimelineSchema = new mongoose.Schema(
         'medication_not_given', // W981
         'followup_completed', // W987 — post-rehab follow-up case completed
         'followup_lost', // W987 — beneficiary lost to post-rehab follow-up
+        'followup_visit', // W992 — post-rehab follow-up visit attended / missed
         'assessment_scheduled',
         'reassessment_due',
         'care_plan_created',

--- a/backend/events/contracts/dddEventContracts.js
+++ b/backend/events/contracts/dddEventContracts.js
@@ -854,6 +854,43 @@ const FOLLOWUP_EVENTS = {
     priority: PRIORITY.HIGH,
     consumers: ['timeline', 'dashboards', 'ai-recommendations'],
   },
+
+  // W992 — visit-level follow-up (companion to the case-level events above).
+  // eventTypes are visit.attended/visit.missed (NOT visit.completed/no_show,
+  // which the W985 family domain owns — registry-wide eventType strings are unique).
+  VISIT_ATTENDED: {
+    domain: 'followup',
+    eventType: 'visit.attended',
+    version: 1,
+    description: 'حضور زيارة متابعة — Post-rehab follow-up visit attended',
+    payload: {
+      visitId: 'string',
+      beneficiaryId: 'string',
+      caseId: 'string',
+      visitType: 'string',
+      visitNumber: 'number',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards'],
+  },
+
+  VISIT_MISSED: {
+    domain: 'followup',
+    eventType: 'visit.missed',
+    version: 1,
+    description: 'تغيّب عن زيارة متابعة — Post-rehab follow-up visit missed',
+    payload: {
+      visitId: 'string',
+      beneficiaryId: 'string',
+      caseId: 'string',
+      visitType: 'string',
+      visitNumber: 'number',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.REALTIME, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards', 'ai-recommendations'],
+  },
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/integration/dddCrossModuleSubscribers.js
+++ b/backend/integration/dddCrossModuleSubscribers.js
@@ -1217,6 +1217,56 @@ function initializeDDDSubscribers(integrationBus, _moduleConnector) {
     },
   });
 
+  // ─── Follow-up → Timeline: visit attended (W992, engagement) ──────
+  subscribers.push({
+    name: 'followup:visit_attended → timeline:record',
+    pattern: 'followup.visit.attended',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'followup_visit',
+            category: 'clinical',
+            severity: 'success',
+            title: `Follow-up visit attended (${event.payload.visitType || ''})`.trim(),
+            title_ar: `حضور زيارة متابعة (${event.payload.visitType || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Followup-visit-attended timeline failed: ${err.message}`);
+      }
+    },
+  });
+
+  // ─── Follow-up → Timeline: visit missed (W992, disengagement) ─────
+  subscribers.push({
+    name: 'followup:visit_missed → timeline:record',
+    pattern: 'followup.visit.missed',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'followup_visit',
+            category: 'clinical',
+            severity: 'warning',
+            title: `Follow-up visit missed (${event.payload.visitType || ''})`.trim(),
+            title_ar: `تغيّب عن زيارة متابعة (${event.payload.visitType || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Followup-visit-missed timeline failed: ${err.message}`);
+      }
+    },
+  });
+
   // ── Register all subscribers ───────────────────────────────────────
   let registered = 0;
   for (const sub of subscribers) {

--- a/backend/models/post-rehab/FollowUpVisit.model.js
+++ b/backend/models/post-rehab/FollowUpVisit.model.js
@@ -149,6 +149,42 @@ followUpVisitSchema.index({ beneficiary: 1, status: 1 });
 followUpVisitSchema.index({ conductedBy: 1, scheduledDate: 1 });
 followUpVisitSchema.index({ status: 1, scheduledDate: 1 });
 
+// W992 — surface post-rehab follow-up visits on the unified-core timeline: an
+// attended visit (an engagement touchpoint — positive) and a missed one (the
+// family didn't show for a scheduled follow-up — an actionable warning). Fires
+// once on the status flip to COMPLETED / MISSED. Native pre-compile hooks per the
+// proven W970 pattern (the modelEventBridge-is-dead workaround); guarded +
+// fire-and-forget so persistence never blocks. Consumed by
+// dddCrossModuleSubscribers → CareTimeline. Companion to the case-level W987
+// (PostRehabCase completed / lost). NOTE: the beneficiary ref field is
+// `beneficiary` (not `beneficiaryId`). eventTypes are visit.attended/visit.missed
+// (NOT visit.completed/no_show — those are owned by the W985 family domain).
+followUpVisitSchema.post('init', function () {
+  this.$__prevStatus = this.status;
+});
+followUpVisitSchema.post('save', function (doc) {
+  try {
+    if (doc.status === this.$__prevStatus) return; // no status change
+    const { integrationBus } = require('../../integration/systemIntegrationBus');
+    if (!integrationBus || typeof integrationBus.publish !== 'function') return;
+    if (!doc.beneficiary) return;
+    const base = {
+      visitId: String(doc._id),
+      beneficiaryId: String(doc.beneficiary),
+      caseId: doc.postRehabCase ? String(doc.postRehabCase) : '',
+      visitType: doc.visitType || '',
+      visitNumber: doc.visitNumber,
+    };
+    if (doc.status === 'COMPLETED') {
+      Promise.resolve(integrationBus.publish('followup', 'visit.attended', base)).catch(() => {});
+    } else if (doc.status === 'MISSED') {
+      Promise.resolve(integrationBus.publish('followup', 'visit.missed', base)).catch(() => {});
+    }
+  } catch (_) {
+    /* bus not wired — never block persistence */
+  }
+});
+
 const FollowUpVisit =
   mongoose.models.FollowUpVisit || mongoose.model('FollowUpVisit', followUpVisitSchema);
 

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -740,3 +740,4 @@ __tests__/complaint-core-linkage-wave984.test.js
 __tests__/family-visit-core-linkage-wave985.test.js
 __tests__/transition-plan-core-linkage-wave986.test.js
 __tests__/postrehab-case-core-linkage-wave987.test.js
+__tests__/followup-visit-core-linkage-wave992.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -52,7 +52,7 @@ Per-beneficiary timeline + dashboards react in real time to:
 - **Complaints (CRM)** — filed about a beneficiary (W984)
 - **Family visits** — completed / no-show (W985)
 - **Life-stage transitions** — transition plan completed / cancelled (W986)
-- **Post-rehab follow-up** — case completed / lost-to-follow-up (W987)
+- **Post-rehab follow-up** — case completed / lost-to-follow-up (W987) + visit attended / missed (W992)
 - **(env-gated, W974)** HR (hire/terminate/leave/salary/transfer), Finance
   (invoice/payment/expense/payroll), Medical (record/therapy/prescription/risk),
   Attendance (check-in/out), Notification (delivery_failed)
@@ -106,6 +106,7 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 | Discharge / transition | `TransitionPlan` | `lifecycle.transition.completed` / `.cancelled` → `care_transition` | ✅ **W986** |
 | Referrals | `TherapyReferral` / `CommunityReferral` / `medicalReferral` / `ReferralTracking` | `referral.made/accepted` | ⏳ **DEFERRED** — 4-model fragmentation; pick a canonical with domain input before wiring (`Referral` is the referring-ORG directory, not a beneficiary referral) |
 | Follow-up cases | `PostRehabCase` | `followup.case.completed` / `.lost` → `followup_completed` / `followup_lost` | ✅ **W987** |
+| Follow-up visits | `FollowUpVisit` | `followup.visit.attended` / `.missed` → `followup_visit` | ✅ **W992** |
 
 ### Tier 2 — family / CRM visibility
 | Domain | Model | Event | Status |
@@ -141,11 +142,11 @@ persist to the EventStore — intended behaviour. It is a **prod behaviour chang
 
 ## 6. Coverage snapshot (updated 2026-06-08)
 
-- Real timeline/dashboard linkage: the **clinical spine** + 11 leaf domains wired
+- Real timeline/dashboard linkage: the **clinical spine** + 12 leaf domains wired
   since 2026-06-05 via native pre-compile hooks (W977 safety · W979 waitlist ·
   W980 screenings · W981 MAR · W982 beneficiary-status · W984 complaints ·
-  W985 family-visits · W986 transitions · W987 post-rehab follow-up — all merged
-  to main).
+  W985 family-visits · W986 transitions · W987 post-rehab follow-up cases ·
+  W992 follow-up visits — all merged to main).
 - + 21 LIVE-registry mappings, **wired but dormant behind the flag**.
 - ≈ **460 route files** still operate as standalone CRUD with no core emission.
 - The frozen V4 `services/core` is **not** consumed by the live UI and is out of

--- a/docs/architecture/DORMANT_CAPABILITY_ACTIVATION_RUNBOOK_2026-06.md
+++ b/docs/architecture/DORMANT_CAPABILITY_ACTIVATION_RUNBOOK_2026-06.md
@@ -42,6 +42,8 @@ to get value from reporting + quality + incident emails in one move.
 | **Incident → NCR auto-link** (W976) | `ENABLE_INCIDENT_NCR_AUTOLINK=true` | OFF | On a NEW incident, emits `quality.incident.reported`; the pipeline auto-creates an NCR + CAPA for **serious** incidents (severity major/critical/sentinel — self-filtered) | **Creates** NCR + CAPA records; emits alert | — |
 | **Retention sweep** (W983) | `ENABLE_RETENTION_SWEEP=true` (`RETENTION_SWEEP_CRON`, `RETENTION_SWEEP_BRANCH_IDS`, `RETENTION_SWEEP_LIMIT`) | OFF | Daily batch churn/retention-risk re-assessment | **Creates** RetentionAssessment rows; **emits interventions** (psychologist notify / home-visit request / case flag) | validate the churn model + scope before enabling org-wide |
 
+| **modelEventBridge** (PR #283, env `ENABLE_MODEL_EVENT_BRIDGE`) | `ENABLE_MODEL_EVENT_BRIDGE=true` | OFF | Activates **21 model→event mappings** at once (HR hire/terminate/leave/salary · finance invoice/payment/expense/payroll · medical record/therapy/prescription/risk · attendance check-in/out · notification delivery_failed). On every matching `.save()` it publishes the domain event → `crossModuleSubscribers` fire notifications + persist to the EventStore | **Emits notifications** (to staff/family via `notification.send`) + persists events; no NEW DB writes in the subscriber path (audited) | email/SMS channel (for the notifications to actually deliver) |
+
 > Always-on (no flag, shipped this session): **W941/W974** unified the quality event
 > bus so audit/quality events reach the email notification router. These need only
 > the email secret to actually send.
@@ -65,8 +67,34 @@ to get value from reporting + quality + incident emails in one move.
 6. **`ENABLE_RETENTION_SWEEP`** — highest blast radius (mass interventions). Pilot on
    ONE branch via `RETENTION_SWEEP_BRANCH_IDS=<one>` + a low `RETENTION_SWEEP_LIMIT`,
    review the generated assessments/interventions, then widen.
+7. **`ENABLE_MODEL_EVENT_BRIDGE`** — broadest reach (21 model→event mappings across
+   HR/finance/medical/attendance/notification) and outward-facing (it makes real
+   notifications start firing). **Set the email/SMS channel FIRST**, then enable in a
+   low-traffic window. Pilot check: trigger ONE mapped save (e.g. mark one invoice
+   paid, or one attendance check-in) and confirm the corresponding notification fires
+   + an EventStore entry appears — then watch the notification volume for one cycle
+   before considering it settled. Reversible like the rest (unset + restart).
 
 Each is independently reversible: unset the flag + `pm2 restart --update-env`.
+
+### `ENABLE_MODEL_EVENT_BRIDGE` — why it was dormant + why it's safe
+
+The bridge attaches a **global mongoose plugin** (registered in `app.js` before any
+model compiles — PR #283) that adds one generic post-save hook to every schema; at
+save-time it dispatches by `modelName` against the 21 mappings. It was **runtime-dead
+for ~its whole life** because the old implementation added `schema.post('save')`
+hooks *after* `mongoose.model()` compilation, which never fire. The PR #283
+resurrection fixed the ordering but kept it **default OFF** because enabling it is a
+**prod behaviour change** (notifications fire, events persist), in the same
+owner-gated class as `BRANCH_SCOPE_FAIL_CLOSED`.
+
+**Audited safe (2026-06-05, see `CORE_LINKAGE_LEDGER.md` §5):** the 21 producers feed
+`crossModuleSubscribers.js` handlers that either call `notification.send` (behind a
+`moduleConnector.hasService()` guard) or re-publish KPI/audit/sync events that have
+**no persisting subscriber** (terminal). The handlers contain **no** `.create()` /
+`new Model()` / `.save()` — so there is no subscriber-shape persistence bug in this
+path (unlike the CareTimeline bug class #2). The only live effects of flipping it are
+the intended ones: notifications begin firing + events persist to the EventStore.
 
 ---
 
@@ -84,5 +112,6 @@ Each is independently reversible: unset the flag + `pm2 restart --update-env`.
 
 Per-wave detail in agent memory (`project_reporting_scheduler_w762_*`,
 `project_reporting_webhooks_w931_*`, `project_care_plan_workers_w973_*`,
-`project_retention_sweeper_w983_*`) + `QUALITY_EVENT_BUS_FINDINGS_2026-06-05.md`
-(W941/W974/W976 quality bus).
+`project_retention_sweeper_w983_*`, `project_core_linkage_silent_failures_2026-06-05`
+for the modelEventBridge) + `QUALITY_EVENT_BUS_FINDINGS_2026-06-05.md`
+(W941/W974/W976 quality bus) + `CORE_LINKAGE_LEDGER.md` §5 (bridge activation gate).


### PR DESCRIPTION
## W992 — Post-rehab follow-up VISITS on the timeline + make the bridge flip owner-ready

Two commits, both part of the core-linkage program (`docs/architecture/CORE_LINKAGE_LEDGER.md`):

### 1. `docs(ops)` — document the `ENABLE_MODEL_EVENT_BRIDGE` activation
The bridge (PR #283) is the single biggest remaining coverage win — it activates **21 model→event mappings at once** (HR/finance/medical/attendance/notification) — but it was missing from the 2026-06 dormant-capability runbook. Adds a capabilities-table row, activation-order step 7 (broadest reach + outward-facing → set the email/SMS channel first, enable in a low-traffic window, pilot one mapped save), and a dedicated *why-dormant / why-safe* subsection (global-plugin pre-compile fix + the 2026-06-05 audit). **No code/prod change — the flag stays default OFF until an owner flips it.**

### 2. `feat(followup)` — W992 follow-up-visit leaf
Companion to the case-level W987: an attended follow-up visit (engagement → success) and a missed one (family didn't show → warning) now appear on the beneficiary `CareTimeline`.

- **Producer** — native post-save hooks in `models/post-rehab/FollowUpVisit.model.js` (status flip COMPLETED/MISSED → `integrationBus.publish('followup', 'visit.<x>', …)`), guarded + fire-and-forget. Field is `beneficiary` (not `beneficiaryId`).
- **Unique eventTypes** — `visit.attended`/`visit.missed`, deliberately **not** `visit.completed`/`no_show` (the W985 family domain owns those; W374 enforces registry-wide-unique eventType strings). Reuses the W987 `followup` domain + already-allowed `visit` prefix → no W374 marker changes, just two new FOLLOWUP_EVENTS entries.
- **CareTimeline enum** — one new `followup_visit` value (severity differentiates attended=success / missed=warning, the W985 `family_meeting` pattern).
- **Subscribers** — 2 → `CareTimeline` rows (clinical).
- **Runtime e2e test** (3 assertions): completed→success, missed→warning, RESCHEDULED→nothing. Ledger updated (Tier-1 row + snapshot).

Guards green: **W374/W375/W389/W392** + `check:hook-style` + sprint-hygiene meta-tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
