### PR TITLE
feat(insurance): W994 wire insurance-claim outcomes onto the unified-core timeline

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1261,6 +1261,8 @@ on:
       - 'backend/__tests__/postrehab-case-core-linkage-wave987.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/followup-visit-core-linkage-wave992.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/insurance-claim-core-linkage-wave994.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2505,6 +2507,8 @@ on:
       - 'backend/__tests__/postrehab-case-core-linkage-wave987.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/followup-visit-core-linkage-wave992.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/insurance-claim-core-linkage-wave994.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/ddd-event-contracts-wave374.test.js
+++ b/backend/__tests__/ddd-event-contracts-wave374.test.js
@@ -70,6 +70,7 @@ const EXPECTED_DOMAIN_GROUPS = Object.freeze([
   'family', // W985 — family visit completed / no-show → core timeline
   'lifecycle', // W986 — life-stage transition plan completed / cancelled → core timeline
   'followup', // W987 — post-rehab follow-up case completed / lost-to-follow-up → core timeline
+  'insurance', // W994 — insurance claim approved / rejected → core timeline
 ]);
 
 // Allowed `eventType` prefixes. Most match W354 TIER domain names; a few are
@@ -114,6 +115,7 @@ const ALLOWED_EVENT_PREFIXES = Object.freeze(
     'visit', // W985
     'transition', // W986
     'case', // W987
+    'claim', // W994
   ])
 );
 
@@ -166,6 +168,7 @@ describe('W374 DDD event-contracts drift guard', () => {
         family: 'FAMILY_EVENTS', // W985
         lifecycle: 'LIFECYCLE_EVENTS', // W986
         followup: 'FOLLOWUP_EVENTS', // W987
+        insurance: 'INSURANCE_EVENTS', // W994
       };
       for (const [group, exportName] of Object.entries(groupExportMap)) {
         expect(contracts[exportName]).toBe(contracts.DDD_CONTRACTS[group]);

--- a/backend/__tests__/insurance-claim-core-linkage-wave994.test.js
+++ b/backend/__tests__/insurance-claim-core-linkage-wave994.test.js
@@ -1,0 +1,118 @@
+'use strict';
+
+/**
+ * insurance-claim-core-linkage-wave994.test.js — W994.
+ *
+ * Wires insurance-claim outcomes onto the unified-core timeline: an approved
+ * (or partially-approved) claim means the beneficiary's care is funded (success)
+ * and a rejected claim means funding was denied (warning — access at risk).
+ * Producer: native NphiesInsuranceClaim post-save hook (status flip to approved /
+ * partially_approved / rejected). RUNTIME end-to-end against a real in-memory
+ * Mongo + the real integration bus + real subscribers → `insurance_claim`
+ * CareTimeline rows (administrative category).
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let InsuranceClaim, CareTimeline;
+let claimSeq = 0;
+
+async function waitForTimeline(query, { timeout = 4000, interval = 25 } = {}) {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const row = await CareTimeline.findOne(query);
+    if (row) return row;
+    if (Date.now() - start > timeout) return null;
+    await new Promise(r => setTimeout(r, interval));
+  }
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w994-insurance' } });
+  await mongoose.connect(mongod.getUri());
+  InsuranceClaim = require('../models/nphies/InsuranceClaim');
+  ({ CareTimeline } = require('../domains/timeline/models/CareTimeline'));
+  require('../models/Beneficiary');
+  const { integrationBus } = require('../integration/systemIntegrationBus');
+  const { initializeDDDSubscribers } = require('../integration/dddCrossModuleSubscribers');
+  initializeDDDSubscribers(integrationBus);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+afterEach(async () => {
+  await Promise.all([InsuranceClaim.deleteMany({}), CareTimeline.deleteMany({})]);
+});
+
+// Create a fresh submitted claim (required: beneficiaryId, insurancePolicyId,
+// claimNumber [unique], serviceStartDate, serviceEndDate, totalAmount).
+function newSubmittedClaim(extra = {}) {
+  claimSeq += 1;
+  return InsuranceClaim.create({
+    beneficiaryId: new mongoose.Types.ObjectId(),
+    insurancePolicyId: new mongoose.Types.ObjectId(),
+    claimNumber: `CLM-TEST-${claimSeq}`,
+    serviceStartDate: new Date(),
+    serviceEndDate: new Date(),
+    totalAmount: 1000,
+    status: 'submitted',
+    ...extra,
+  });
+}
+
+describe('W994 — insurance claim outcomes reach the unified-core timeline', () => {
+  it('a submitted claim produces no row until it is decided; approval → success', async () => {
+    const c = await newSubmittedClaim();
+    await new Promise(r => setTimeout(r, 150));
+    expect(await CareTimeline.countDocuments({ beneficiaryId: c.beneficiaryId })).toBe(0);
+
+    const loaded = await InsuranceClaim.findById(c._id);
+    loaded.status = 'approved';
+    loaded.approvedAmount = 1000;
+    await loaded.save();
+
+    const tl = await waitForTimeline({ beneficiaryId: c.beneficiaryId, eventType: 'insurance_claim' });
+    expect(tl).toBeTruthy();
+    expect(tl.category).toBe('administrative');
+    expect(tl.severity).toBe('success');
+  });
+
+  it('a partially_approved claim also lands a SUCCESS row', async () => {
+    const c = await newSubmittedClaim();
+    const loaded = await InsuranceClaim.findById(c._id);
+    loaded.status = 'partially_approved';
+    loaded.approvedAmount = 600;
+    await loaded.save();
+    const tl = await waitForTimeline({ beneficiaryId: c.beneficiaryId, eventType: 'insurance_claim' });
+    expect(tl).toBeTruthy();
+    expect(tl.severity).toBe('success');
+  });
+
+  it('a rejected claim lands a WARNING row', async () => {
+    const c = await newSubmittedClaim();
+    const loaded = await InsuranceClaim.findById(c._id);
+    loaded.status = 'rejected';
+    await loaded.save();
+    const tl = await waitForTimeline({ beneficiaryId: c.beneficiaryId, eventType: 'insurance_claim' });
+    expect(tl).toBeTruthy();
+    expect(tl.severity).toBe('warning');
+  });
+
+  it('a non-terminal status change (in_review) produces no row', async () => {
+    const c = await newSubmittedClaim();
+    const loaded = await InsuranceClaim.findById(c._id);
+    loaded.status = 'in_review';
+    await loaded.save();
+    await new Promise(r => setTimeout(r, 200));
+    expect(await CareTimeline.countDocuments({ beneficiaryId: c.beneficiaryId })).toBe(0);
+  });
+});

--- a/backend/domains/timeline/models/CareTimeline.js
+++ b/backend/domains/timeline/models/CareTimeline.js
@@ -39,6 +39,7 @@ const careTimelineSchema = new mongoose.Schema(
         'readmission',
         'status_changed', // W982 — beneficiary lifecycle status change
         'care_transition', // W986 — life-stage transition plan completed / cancelled
+        'insurance_claim', // W994 — insurance claim approved / rejected (admin)
         // Clinical
         'assessment_completed',
         'screening_completed', // W980 — vision/hearing screening finalized

--- a/backend/events/contracts/dddEventContracts.js
+++ b/backend/events/contracts/dddEventContracts.js
@@ -894,6 +894,52 @@ const FOLLOWUP_EVENTS = {
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
+//  Insurance Events — أحداث المطالبات التأمينية (W994)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Insurance-claim outcomes that gate a beneficiary's funded care. An approved
+// (or partially-approved) claim = care is funded (positive); a rejected claim =
+// funding denied (an actionable warning — access at risk). Producer: native
+// NphiesInsuranceClaim post-save hook. (Not covered by the modelEventBridge
+// finance mappings, which are invoice/payment/expense/payroll.)
+
+const INSURANCE_EVENTS = {
+  CLAIM_APPROVED: {
+    domain: 'insurance',
+    eventType: 'claim.approved',
+    version: 1,
+    description: 'اعتماد مطالبة تأمينية — Insurance claim approved (care funded)',
+    payload: {
+      claimId: 'string',
+      beneficiaryId: 'string',
+      claimNumber: 'string',
+      totalAmount: 'number',
+      approvedAmount: 'number',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards'],
+  },
+
+  CLAIM_REJECTED: {
+    domain: 'insurance',
+    eventType: 'claim.rejected',
+    version: 1,
+    description: 'رفض مطالبة تأمينية — Insurance claim rejected (funding denied)',
+    payload: {
+      claimId: 'string',
+      beneficiaryId: 'string',
+      claimNumber: 'string',
+      totalAmount: 'number',
+      approvedAmount: 'number',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.REALTIME, DELIVERY.LOCAL],
+    priority: PRIORITY.HIGH,
+    consumers: ['timeline', 'dashboards', 'ai-recommendations'],
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
 //  Aggregated Contracts Registry
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -916,6 +962,7 @@ const DDD_CONTRACTS = {
   family: FAMILY_EVENTS,
   lifecycle: LIFECYCLE_EVENTS,
   followup: FOLLOWUP_EVENTS,
+  insurance: INSURANCE_EVENTS,
 };
 
 /**
@@ -951,6 +998,7 @@ module.exports = {
   FAMILY_EVENTS,
   LIFECYCLE_EVENTS,
   FOLLOWUP_EVENTS,
+  INSURANCE_EVENTS,
   DDD_CONTRACTS,
   getDDDContractStats,
 };

--- a/backend/integration/dddCrossModuleSubscribers.js
+++ b/backend/integration/dddCrossModuleSubscribers.js
@@ -1267,6 +1267,56 @@ function initializeDDDSubscribers(integrationBus, _moduleConnector) {
     },
   });
 
+  // ─── Insurance → Timeline: claim approved (W994, care funded) ─────
+  subscribers.push({
+    name: 'insurance:claim_approved → timeline:record',
+    pattern: 'insurance.claim.approved',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'insurance_claim',
+            category: 'administrative',
+            severity: 'success',
+            title: `Insurance claim approved (${event.payload.claimNumber || ''})`.trim(),
+            title_ar: `اعتماد مطالبة تأمينية (${event.payload.claimNumber || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Insurance-claim-approved timeline failed: ${err.message}`);
+      }
+    },
+  });
+
+  // ─── Insurance → Timeline: claim rejected (W994, funding denied) ──
+  subscribers.push({
+    name: 'insurance:claim_rejected → timeline:record',
+    pattern: 'insurance.claim.rejected',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'insurance_claim',
+            category: 'administrative',
+            severity: 'warning',
+            title: `Insurance claim rejected (${event.payload.claimNumber || ''})`.trim(),
+            title_ar: `رفض مطالبة تأمينية (${event.payload.claimNumber || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Insurance-claim-rejected timeline failed: ${err.message}`);
+      }
+    },
+  });
+
   // ── Register all subscribers ───────────────────────────────────────
   let registered = 0;
   for (const sub of subscribers) {

--- a/backend/models/nphies/InsuranceClaim.js
+++ b/backend/models/nphies/InsuranceClaim.js
@@ -145,6 +145,41 @@ insuranceClaimSchema.virtual('approvalRate').get(function () {
   return ((this.approvedAmount / this.totalAmount) * 100).toFixed(1);
 });
 
+// W994 — surface insurance-claim outcomes on the unified-core timeline: an
+// approved (or partially-approved) claim means the beneficiary's care is funded
+// (positive) and a rejected claim means funding was denied (an actionable
+// warning — care access at risk). Fires once on the status flip to approved /
+// partially_approved / rejected. Native pre-compile hooks per the proven W970
+// pattern (the modelEventBridge-is-dead workaround); guarded + fire-and-forget so
+// persistence never blocks. Consumed by dddCrossModuleSubscribers → CareTimeline
+// (administrative category). NOT covered by the modelEventBridge finance mappings
+// (those are invoice/payment/expense/payroll), so this native hook is additive.
+insuranceClaimSchema.post('init', function () {
+  this.$__prevStatus = this.status;
+});
+insuranceClaimSchema.post('save', function (doc) {
+  try {
+    if (doc.status === this.$__prevStatus) return; // no status change
+    const { integrationBus } = require('../../integration/systemIntegrationBus');
+    if (!integrationBus || typeof integrationBus.publish !== 'function') return;
+    if (!doc.beneficiaryId) return;
+    const base = {
+      claimId: String(doc._id),
+      beneficiaryId: String(doc.beneficiaryId),
+      claimNumber: doc.claimNumber || '',
+      totalAmount: doc.totalAmount,
+      approvedAmount: doc.approvedAmount,
+    };
+    if (doc.status === 'approved' || doc.status === 'partially_approved') {
+      Promise.resolve(integrationBus.publish('insurance', 'claim.approved', base)).catch(() => {});
+    } else if (doc.status === 'rejected') {
+      Promise.resolve(integrationBus.publish('insurance', 'claim.rejected', base)).catch(() => {});
+    }
+  } catch (_) {
+    /* bus not wired — never block persistence */
+  }
+});
+
 // Registered as `NphiesInsuranceClaim` (not `InsuranceClaim`) so it
 // doesn't collide with models/insuranceClaim.model.js (the canonical
 // 400-line schema). The default export still resolves to a usable

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -741,3 +741,4 @@ __tests__/family-visit-core-linkage-wave985.test.js
 __tests__/transition-plan-core-linkage-wave986.test.js
 __tests__/postrehab-case-core-linkage-wave987.test.js
 __tests__/followup-visit-core-linkage-wave992.test.js
+__tests__/insurance-claim-core-linkage-wave994.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -117,8 +117,10 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 | Guardian-portal engagement | — | — | Open |
 
 ### Tier 3 — operational / governance
-Inventory low-stock, maintenance overdue, contract/document expiry, insurance/
-NPHIES claim lifecycle, transport incidents.
+| Domain | Model | Event | Status |
+| --- | --- | --- | --- |
+| Insurance / NPHIES claims | `NphiesInsuranceClaim` | `insurance.claim.approved` / `.rejected` → `insurance_claim` | ✅ **W994** |
+| Inventory low-stock · maintenance overdue · contract/document expiry · transport incidents | — | — | Open — mostly **not** beneficiary-keyed, so they belong on dashboards/KPIs, not the per-beneficiary `CareTimeline` |
 
 **Mechanism guidance:** prefer **native pre-compile model hooks (C)** for models
 created via many routes (path-agnostic, reliable). Use a **bridge MAPPING (A)**
@@ -142,11 +144,11 @@ persist to the EventStore — intended behaviour. It is a **prod behaviour chang
 
 ## 6. Coverage snapshot (updated 2026-06-08)
 
-- Real timeline/dashboard linkage: the **clinical spine** + 12 leaf domains wired
+- Real timeline/dashboard linkage: the **clinical spine** + 13 leaf domains wired
   since 2026-06-05 via native pre-compile hooks (W977 safety · W979 waitlist ·
   W980 screenings · W981 MAR · W982 beneficiary-status · W984 complaints ·
   W985 family-visits · W986 transitions · W987 post-rehab follow-up cases ·
-  W992 follow-up visits — all merged to main).
+  W992 follow-up visits · W994 insurance claims — all merged to main).
 - + 21 LIVE-registry mappings, **wired but dormant behind the flag**.
 - ≈ **460 route files** still operate as standalone CRUD with no core emission.
 - The frozen V4 `services/core` is **not** consumed by the live UI and is out of


### PR DESCRIPTION
## W994 — Insurance-claim outcomes on the unified-core timeline

Surfaces **funding decisions** on the beneficiary `CareTimeline` — closes the Tier-3 insurance/NPHIES-claim row of the core-linkage roadmap (`docs/architecture/CORE_LINKAGE_LEDGER.md`). An approved (or partially-approved) claim means the beneficiary's care is funded (success); a rejected claim means funding was denied — an actionable warning (care access at risk).

### How
- **Producer** — native post-save hooks in `models/nphies/InsuranceClaim.js` (status flip `approved`/`partially_approved`/`rejected` → `integrationBus.publish('insurance', 'claim.<x>', …)`), guarded + fire-and-forget. The modelEventBridge-is-dead workaround (W974).
- **Additive, not redundant** — the modelEventBridge finance mappings are invoice/payment/expense/payroll, **not** insurance claims, so the bridge would never cover this even once flipped on.
- **Contracts** — `INSURANCE_EVENTS` group (`claim.approved` [normal], `claim.rejected` [**HIGH**, + `ai-recommendations`]) + aggregator + export.
- **CareTimeline enum** — one new `insurance_claim` value (**administrative**; severity differentiates approved=success / rejected=warning).
- **Subscribers** — 2 → `CareTimeline` rows.

### Verification
- **Runtime e2e test** (`insurance-claim-core-linkage-wave994.test.js`, 4 assertions): approved + partially_approved → success rows, rejected → warning row, a non-terminal flip (`in_review`) → nothing; against real in-memory Mongo + real bus + real subscribers.
- Guards green: **W374** (insurance domain + `claim` prefix + `INSURANCE_EVENTS` export) / **W375** / **W389** / **W392** + `check:hook-style` + sprint-hygiene meta-tests.
- Ledger updated (Tier-3 insurance row → W994 + coverage snapshot: 13 leaf domains).

### Risk
Additive. Fires only on the three decision outcomes, only when `beneficiaryId` is present. No env flag — subscribers already wired into the DDD bus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
