### PR TITLE
fix(mongoose): W954 — global shim hung every .save() with a sync post(doc) hook (prod root cause of "data won't save")

### DIFF
--- a/.github/workflows/deploy-hostinger.yml
+++ b/.github/workflows/deploy-hostinger.yml
@@ -133,6 +133,20 @@ jobs:
     # jest --shard (deploy gates on ALL shards: needs.test.result=='success'
     # requires every matrix leg green). Each shard ≈ suite/4 (~9 min) → scales as
     # the suite grows. fail-fast:false so one failing shard still reports the rest.
+    #
+    # W953/W954 (2026-06-08) — the first run that actually COMPLETED (sharding
+    # let it finish instead of being cancelled at the cap) exposed TWO problems
+    # masked for months on Mongo-backed behavioral/route suites:
+    #   W953 (this step) — ~349 suites call `MongoMemoryServer.create()`, which
+    #     cold-downloads a ~90s mongod binary; on CI each is invoked INSIDE a
+    #     30-45s jest test, so the download is KILLED before it finishes. Fix =
+    #     download the binary ONCE in an unbounded pre-warm step + cache
+    #     ~/.cache/mongodb-binaries, so every MMS.create() then starts in ~1s.
+    #   W954 (config/mongoose.plugins.js) — the deeper cause, proven by the same
+    #     suites hanging LOCALLY where the binary was already cached: the global
+    #     legacy-hook shim wrapped `post('save', function(doc){})` hooks, leaving
+    #     the wrapper Promise unresolved → every .save() hung. Fixed separately;
+    #     this pre-warm only removes the CI cold-download half.
     strategy:
       fail-fast: false
       matrix:
@@ -148,6 +162,22 @@ jobs:
       - name: Install backend dependencies
         working-directory: backend
         run: npm ci --legacy-peer-deps 2>&1 || npm install --legacy-peer-deps
+
+      # W953 — cache + pre-warm the MongoMemoryServer mongod binary (see comment
+      # above). restore-keys falls back to the most recent prior binary cache so
+      # a package-lock bump that doesn't change the mongod version is a cache hit.
+      - name: Cache MongoMemoryServer binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-binaries-${{ runner.os }}-${{ hashFiles('backend/package-lock.json') }}
+          restore-keys: |
+            mongodb-binaries-${{ runner.os }}-
+      - name: Pre-warm MongoMemoryServer binary (unbounded — avoids per-test download timeout)
+        working-directory: backend
+        run: |
+          node -e "const{MongoMemoryServer}=require('mongodb-memory-server');MongoMemoryServer.create().then(async m=>{console.log('mongod ready at',m.getUri());await m.stop();process.exit(0)}).catch(e=>{console.error('prewarm failed:',e&&e.message);process.exit(1)})" \
+            || echo '⚠️ MMS pre-warm failed — Mongo-backed tests may time out (binary mirror unreachable?)'
 
       - name: Run backend tests (sharded sprint gate)
         working-directory: backend

--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1267,6 +1267,9 @@ on:
       - 'backend/__tests__/referrals-core-linkage-wave997.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/core-timeline-subscriber-shape-wave998.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/legacy-hook-adapter-wave954.test.js'
+      - 'backend/__tests__/legacy-hook-no-hang-behavioral-wave954.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2517,6 +2520,9 @@ on:
       - 'backend/__tests__/referrals-core-linkage-wave997.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/core-timeline-subscriber-shape-wave998.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/legacy-hook-adapter-wave954.test.js'
+      - 'backend/__tests__/legacy-hook-no-hang-behavioral-wave954.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/legacy-hook-adapter-wave954.test.js
+++ b/backend/__tests__/legacy-hook-adapter-wave954.test.js
@@ -1,0 +1,121 @@
+/**
+ * W954 — regression guard for the legacy-hook adapter in
+ * config/mongoose.plugins.js.
+ *
+ * THE BUG (root cause of "البيانات لا تُحفظ" / data won't save):
+ *   The adapter wrapped ANY hook function with exactly one declared parameter,
+ *   assuming that param is the legacy `next` continuation. But a `post` hook
+ *   receives the DOCUMENT as its sole param — `post('save', function (doc) {…})`.
+ *   Wrapping it passed the wrapper's `next` callback in AS `doc`; since a sync
+ *   post hook neither calls next() nor returns a thenable, the wrapper Promise
+ *   NEVER resolved → mongoose awaited it forever → every .save()/.create() on
+ *   any model carrying such a post hook HUNG until the caller timed out. The
+ *   shim is registered globally in server.js, so it silently broke saves in
+ *   production across ~24+ models (Beneficiary, Appointment, Invoice, MAR,
+ *   Complaint, …).
+ *
+ * THE FIX:
+ *   Only adapt a hook whose sole parameter is literally named `next` (a true
+ *   legacy `function (next) {…}` callback). `(doc)` / `(docs)` / `(err)` hooks
+ *   are left untouched. When the source can't be parsed, fall through and wrap
+ *   (preserves the W946 legacy-callback rescue).
+ *
+ * This is a PURE-helper static guard (no mongoose, no DB) so it runs fast and
+ * deterministically in CI. End-to-end no-hang behaviour is covered by
+ * legacy-hook-no-hang-behavioral-wave954.test.js.
+ */
+
+'use strict';
+
+const { legacyHookAdapter, firstParamName } = require('../config/mongoose.plugins');
+
+describe('W954 — firstParamName extracts the sole declared parameter', () => {
+  it('reads a classic function expression param', () => {
+    expect(firstParamName(function (doc) {})).toBe('doc');
+    expect(firstParamName(function (next) {})).toBe('next');
+  });
+
+  it('reads an async function param', () => {
+    expect(firstParamName(async function (next) {})).toBe('next');
+  });
+
+  it('reads a named function param', () => {
+    expect(firstParamName(function deriveBranch(next) {})).toBe('next');
+  });
+
+  it('reads arrow-function params (parenthesised + bare)', () => {
+    // eslint-disable-next-line arrow-body-style
+    expect(firstParamName((doc) => {})).toBe('doc');
+    // eslint-disable-next-line arrow-body-style
+    expect(firstParamName(next => {})).toBe('next');
+  });
+});
+
+describe('W954 — legacyHookAdapter ONLY wraps true `(next)` callbacks', () => {
+  it('does NOT wrap a sync 1-param POST hook `function (doc)` (the prod-hang bug)', () => {
+    const postHook = function (doc) {
+      return doc;
+    };
+    // Must be returned untouched — wrapping it is what hung every save().
+    expect(legacyHookAdapter(postHook)).toBe(postHook);
+  });
+
+  it('does NOT wrap `(docs)` / `(err)` / `(result)` single-param hooks', () => {
+    const a = function (docs) {};
+    const b = function (err) {};
+    const c = function (result) {};
+    expect(legacyHookAdapter(a)).toBe(a);
+    expect(legacyHookAdapter(b)).toBe(b);
+    expect(legacyHookAdapter(c)).toBe(c);
+  });
+
+  it('does NOT wrap modern (0-param) or parallel (2-param) hooks', () => {
+    const zero = function () {};
+    const two = function (doc, next) {};
+    expect(legacyHookAdapter(zero)).toBe(zero);
+    expect(legacyHookAdapter(two)).toBe(two);
+  });
+
+  it('DOES wrap a genuine legacy `function (next)` hook (W946 rescue preserved)', () => {
+    const legacy = function (next) {
+      next();
+    };
+    const wrapped = legacyHookAdapter(legacy);
+    expect(wrapped).not.toBe(legacy);
+    expect(typeof wrapped).toBe('function');
+  });
+
+  it('the wrapped legacy hook RESOLVES when next() is called synchronously', async () => {
+    let ran = false;
+    const wrapped = legacyHookAdapter(function (next) {
+      ran = true;
+      next();
+    });
+    await expect(wrapped.call({})).resolves.toBeUndefined();
+    expect(ran).toBe(true);
+  });
+
+  it('the wrapped legacy hook REJECTS when next(err) is called', async () => {
+    const wrapped = legacyHookAdapter(function (next) {
+      next(new Error('boom'));
+    });
+    await expect(wrapped.call({})).rejects.toThrow('boom');
+  });
+
+  it('a sync `(doc)` post hook, left unwrapped, runs synchronously and returns (never hangs)', () => {
+    const postHook = function (doc) {
+      return doc && doc.id;
+    };
+    const fn = legacyHookAdapter(postHook); // === postHook
+    // Calling it returns immediately (no Promise that could hang the save chain).
+    expect(fn.call({}, { id: 7 })).toBe(7);
+  });
+
+  it('is idempotent — re-adapting a genuine wrapped hook does not double-wrap', () => {
+    const wrapped1 = legacyHookAdapter(function (next) {
+      next();
+    });
+    const wrapped2 = legacyHookAdapter(wrapped1);
+    expect(wrapped2).toBe(wrapped1);
+  });
+});

--- a/backend/__tests__/legacy-hook-no-hang-behavioral-wave954.test.js
+++ b/backend/__tests__/legacy-hook-no-hang-behavioral-wave954.test.js
@@ -1,0 +1,90 @@
+/**
+ * W954 behavioral — end-to-end proof that a SYNC 1-param post('save') hook does
+ * NOT hang .save() once the global legacy-hook shim is installed.
+ *
+ * Reproduces the exact prod bug: config/mongoose.plugins.js (loaded globally in
+ * server.js via registerGlobalPlugins) patches Schema.prototype.pre/post. Before
+ * the W954 fix it wrapped `post('save', function (doc) {…})`, passing the
+ * wrapper's `next` in as `doc`; the sync body never called next nor returned a
+ * thenable, so the wrapper Promise never resolved → save() hung forever. This
+ * test would TIME OUT on the buggy shim and PASS on the fixed one.
+ *
+ * Paired with the static guard legacy-hook-adapter-wave954.test.js per the
+ * "pair every static drift guard with a behavioral counterpart" doctrine.
+ */
+
+'use strict';
+
+jest.unmock('mongoose');
+
+const mongoose = require('mongoose');
+const fs = require('fs');
+const path = require('path');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let postHookRan = false;
+let postHookSawRealDoc = false;
+let Probe;
+
+beforeAll(async () => {
+  const URI_FILE = path.join(__dirname, '..', '.test-mongo-uri');
+  let uri;
+  if (fs.existsSync(URI_FILE)) {
+    uri = fs.readFileSync(URI_FILE, 'utf-8').trim();
+  } else {
+    mongod = await MongoMemoryServer.create({ instance: { dbName: 'w954-no-hang' } });
+    uri = mongod.getUri();
+  }
+  await mongoose.connect(uri);
+
+  // Install the global shim exactly as server.js does, so Schema.prototype is
+  // patched before our probe schema declares its hooks.
+  const plugins = require('../config/mongoose.plugins');
+  plugins.registerGlobalPlugins();
+
+  const schema = new mongoose.Schema({ name: String });
+
+  // The bug pattern: synchronous, single param named `doc` (the document).
+  schema.post('save', function (doc) {
+    postHookRan = true;
+    // On the buggy shim, `doc` would actually be the wrapper's `next` function.
+    postHookSawRealDoc = !!doc && typeof doc.name === 'string' && typeof doc !== 'function';
+  });
+
+  Probe = mongoose.models.W954HangProbe || mongoose.model('W954HangProbe', schema);
+  await Probe.init();
+}, 60000);
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+describe('W954 — a sync `post(save, function(doc))` hook never hangs save()', () => {
+  it('resolves create() promptly (would time out on the pre-W954 shim)', async () => {
+    const doc = await Probe.create({ name: 'no-hang' });
+    expect(doc).toBeTruthy();
+    expect(doc.name).toBe('no-hang');
+  }, 15000);
+
+  it('the post hook ran and received the real document (not the wrapper next)', () => {
+    expect(postHookRan).toBe(true);
+    expect(postHookSawRealDoc).toBe(true);
+  });
+
+  it('a legacy `pre(save, function(next))` callback still works (W946 rescue intact)', async () => {
+    let preRan = false;
+    const s2 = new mongoose.Schema({ v: Number });
+    // eslint-disable-next-line func-names
+    s2.pre('save', function (next) {
+      preRan = true;
+      this.v = (this.v || 0) + 1;
+      next();
+    });
+    const M2 = mongoose.models.W954PreProbe || mongoose.model('W954PreProbe', s2);
+    const d = await M2.create({ v: 1 });
+    expect(preRan).toBe(true);
+    expect(d.v).toBe(2);
+  }, 15000);
+});

--- a/backend/config/mongoose.plugins.js
+++ b/backend/config/mongoose.plugins.js
@@ -29,9 +29,31 @@ const SLOW_QUERY_MS = parseInt(process.env.SLOW_QUERY_THRESHOLD_MS, 10) || 500;
 //
 // Modern hooks (no parameter, return-promise) and parallel hooks (two
 // parameters: next + done) bypass the wrapper untouched.
+// Extract the sole declared parameter name of a 1-arg function (best-effort).
+function firstParamName(fn) {
+  const src = Function.prototype.toString.call(fn);
+  let m = src.match(/^(?:async\s+)?function\b[^(]*\(\s*([^),\s]+)/);
+  if (!m) m = src.match(/^\s*\(\s*([^),\s]+)\s*\)\s*=>/); // (p) =>
+  if (!m) m = src.match(/^\s*([A-Za-z_$][\w$]*)\s*=>/); //  p  =>
+  return m ? m[1] : null;
+}
+
 function legacyHookAdapter(fn) {
   if (typeof fn !== 'function') return fn;
   if (fn.length !== 1) return fn; // 0 = modern, 2 = parallel — leave alone
+  // W954 (2026-06-08) — CRITICAL: only adapt a TRUE legacy callback hook, whose
+  // sole parameter is the `next` continuation. A 1-param POST hook receives the
+  // document (`post('save', function (doc) {…})`), NOT next. Wrapping it passed
+  // `next` in as `doc`; since the body neither calls next() nor returns a
+  // thenable, the wrapper Promise NEVER resolved → every .save()/.create() on
+  // any model carrying such a post hook HUNG until the caller timed out. This
+  // shim is registered globally in server.js, so it silently broke saves in
+  // production — a root cause of "البيانات لا تُحفظ" (data won't save). Keying on
+  // the param name leaves `(doc)` post hooks (and `(err)` handlers) untouched
+  // while still rescuing genuine `function (next) {…}` legacy hooks. (When the
+  // source can't be parsed, fall through and wrap — preserves the W946 rescue.)
+  const p = firstParamName(fn);
+  if (p && p !== 'next') return fn;
   // Avoid double-wrapping when registerGlobalPlugins runs again in tests.
   if (fn.__legacyShimmed) return fn;
 
@@ -195,4 +217,7 @@ module.exports = {
   toJSONPlugin,
   registerGlobalPlugins,
   getConnectionPoolHealth,
+  // Exported for the W954 regression guard (legacy-hook-adapter-wave954.test.js).
+  legacyHookAdapter,
+  firstParamName,
 };

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -744,3 +744,5 @@ __tests__/followup-visit-core-linkage-wave992.test.js
 __tests__/insurance-claim-core-linkage-wave994.test.js
 __tests__/referrals-core-linkage-wave997.test.js
 __tests__/core-timeline-subscriber-shape-wave998.test.js
+__tests__/legacy-hook-adapter-wave954.test.js
+__tests__/legacy-hook-no-hang-behavioral-wave954.test.js


### PR DESCRIPTION
## 🔴 خلل إنتاجي حرج — السبب الجذري لـ«البيانات لا تُحفظ»

`config/mongoose.plugins.js` يُركّب رقعة عامة على `Schema.prototype.pre/post` (يُحمّلها `server.js` عبر `registerGlobalPlugins`). كانت تلفّ **أي** خطّاف بمُعامل واحد ظنّاً أنه `next` — لكن خطّاف `post` مُعامله الواحد هو **المستند**: `post('save', function (doc) {…})`. فيُمرَّر `next` مكان `doc`، والجسم المتزامن لا يستدعي next ولا يُعيد promise → **وعد الغلاف لا يُحلّ أبداً** → mongoose ينتظره للأبد → **كل `.save()`/`.create()` على أي نموذج فيه خطّاف كهذا يتعلّق** حتى تنتهي مهلة الطلب.

**نطاق الضرر ≥24 نموذجاً** منها **Beneficiary** (سطح الشكوى الأصلية) + Appointment + Invoice + MedicationAdministrationRecord + Complaint + FamilyVisitRequest + إضافات عامة (audit-trail/query-cache/multi-tenant). أُدخِل في `c165f25ad` (شيم ترحيل mongoose-9).

### الإصلاح
يلفّ المُحوّل خطّافاً **فقط** إذا كان مُعامله الوحيد اسمه `next` فعلاً (`firstParamName`). خطّافات `(doc)`/`(docs)`/`(err)` تمرّ دون لمس؛ خطّافات `function (next)` القديمة (إنقاذ W946) تبقى ملفوفة. غير القابل للتحليل → يُلفّ (يحافظ على السلوك السابق).

### الإثبات
المجموعات السلوكية الأربع الفاشلة في CI (family-finance، complaint، mar-routes، student-registration) كانت تتعلّق 30-45s **محلياً مع ثنائي mongod دافئ** (ينفي نظرية التنزيل) — كلها خضراء بعد الإصلاح (154 اختباراً)، وكذلك Beneficiary + Appointment.

### الحُرّاس (كلاهما في test:sprint)
- `legacy-hook-adapter-wave954.test.js` — 12 ثابت
- `legacy-hook-no-hang-behavioral-wave954.test.js` — 3 سلوكي

### W953 (مُضمَّن) — `deploy-hostinger.yml`
cache + خطوة pre-warm غير مُقيّدة لثنائي MongoMemoryServer كي لا تنتهي مهلة الـ349 مجموعة التي تُنزّله بارداً في CI (النصف الخاص بـCI من احمرار بوّابة النشر المُجزّأة) — منفصل عن تعلّق الحفظ أعلاه.

🤖 Generated with [Claude Code](https://claude.com/claude-code)