### PR TITLE
feat(consent): W1002 wire consent lifecycle onto the unified-core timeline (PDPL/CRPD)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1270,6 +1270,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/legacy-hook-adapter-wave954.test.js'
       - 'backend/__tests__/legacy-hook-no-hang-behavioral-wave954.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/consent-core-linkage-wave1002.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2523,6 +2525,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/legacy-hook-adapter-wave954.test.js'
       - 'backend/__tests__/legacy-hook-no-hang-behavioral-wave954.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/consent-core-linkage-wave1002.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/consent-core-linkage-wave1002.test.js
+++ b/backend/__tests__/consent-core-linkage-wave1002.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+/**
+ * consent-core-linkage-wave1002.test.js — W1002.
+ *
+ * Wires consent lifecycle (PDPL/CRPD) onto the unified-core timeline: a consent
+ * OBTAINED (granted — care/data processing permitted, success) and a consent
+ * REVOKED (withdrawn — access at risk, warning). Producer: native Consent
+ * post-save hook. Fills the CareTimeline's long-declared-but-producerless
+ * `consent_obtained` enum value + a new `consent_revoked`. RUNTIME end-to-end
+ * against a real in-memory Mongo + the real integration bus + real subscribers.
+ *
+ * The append-only model has no `status` enum: the pre-save captures `isNew` (so a
+ * later metadata re-save does NOT re-fire `obtained`) and post-init captures the
+ * prior `revokedAt` (so a revoke fires exactly once).
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let Consent, CareTimeline;
+
+async function waitForTimeline(query, { timeout = 4000, interval = 25 } = {}) {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const row = await CareTimeline.findOne(query);
+    if (row) return row;
+    if (Date.now() - start > timeout) return null;
+    await new Promise(r => setTimeout(r, interval));
+  }
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w1002-consent' } });
+  await mongoose.connect(mongod.getUri());
+  ({ Consent } = require('../models/Consent'));
+  ({ CareTimeline } = require('../domains/timeline/models/CareTimeline'));
+  require('../models/Beneficiary');
+  const { integrationBus } = require('../integration/systemIntegrationBus');
+  const { initializeDDDSubscribers } = require('../integration/dddCrossModuleSubscribers');
+  initializeDDDSubscribers(integrationBus);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+afterEach(async () => {
+  await Promise.all([Consent.deleteMany({}), CareTimeline.deleteMany({})]);
+});
+
+describe('W1002 — consent lifecycle reaches the unified-core timeline', () => {
+  it('granting consent lands a SUCCESS consent_obtained row', async () => {
+    const ben = new mongoose.Types.ObjectId();
+    await Consent.create({ beneficiaryId: ben, type: 'treatment' });
+    const tl = await waitForTimeline({ beneficiaryId: ben, eventType: 'consent_obtained' });
+    expect(tl).toBeTruthy();
+    expect(tl.category).toBe('administrative');
+    expect(tl.severity).toBe('success');
+    expect(tl.metadata.consentType).toBe('treatment');
+  });
+
+  it('revoking consent lands a WARNING consent_revoked row', async () => {
+    const ben = new mongoose.Types.ObjectId();
+    const c = await Consent.create({ beneficiaryId: ben, type: 'data_sharing' });
+    // wait for the obtained row, then revoke
+    await waitForTimeline({ beneficiaryId: ben, eventType: 'consent_obtained' });
+    const loaded = await Consent.findById(c._id);
+    loaded.revokedAt = new Date();
+    loaded.revokedReason = 'guardian withdrew';
+    await loaded.save();
+    const tl = await waitForTimeline({ beneficiaryId: ben, eventType: 'consent_revoked' });
+    expect(tl).toBeTruthy();
+    expect(tl.severity).toBe('warning');
+  });
+
+  it('a metadata-only re-save (no revoke) does NOT re-fire — exactly one row', async () => {
+    const ben = new mongoose.Types.ObjectId();
+    const c = await Consent.create({ beneficiaryId: ben, type: 'photography' });
+    await waitForTimeline({ beneficiaryId: ben, eventType: 'consent_obtained' });
+    const loaded = await Consent.findById(c._id);
+    loaded.signatureRef = 'sig-abc';
+    await loaded.save();
+    await new Promise(r => setTimeout(r, 200));
+    expect(await CareTimeline.countDocuments({ beneficiaryId: ben })).toBe(1);
+  });
+});

--- a/backend/__tests__/ddd-event-contracts-wave374.test.js
+++ b/backend/__tests__/ddd-event-contracts-wave374.test.js
@@ -72,6 +72,7 @@ const EXPECTED_DOMAIN_GROUPS = Object.freeze([
   'followup', // W987 — post-rehab follow-up case completed / lost-to-follow-up → core timeline
   'insurance', // W994 — insurance claim approved / rejected → core timeline
   'referral', // W997 — referral accepted / completed / rejected (shared across 4 models) → core timeline
+  'consent', // W1002 — consent obtained / revoked (PDPL/CRPD) → core timeline
 ]);
 
 // Allowed `eventType` prefixes. Most match W354 TIER domain names; a few are
@@ -118,6 +119,7 @@ const ALLOWED_EVENT_PREFIXES = Object.freeze(
     'case', // W987
     'claim', // W994
     'referral', // W997
+    'consent', // W1002
   ])
 );
 
@@ -172,6 +174,7 @@ describe('W374 DDD event-contracts drift guard', () => {
         followup: 'FOLLOWUP_EVENTS', // W987
         insurance: 'INSURANCE_EVENTS', // W994
         referral: 'REFERRAL_EVENTS', // W997
+        consent: 'CONSENT_EVENTS', // W1002
       };
       for (const [group, exportName] of Object.entries(groupExportMap)) {
         expect(contracts[exportName]).toBe(contracts.DDD_CONTRACTS[group]);

--- a/backend/domains/timeline/models/CareTimeline.js
+++ b/backend/domains/timeline/models/CareTimeline.js
@@ -93,6 +93,7 @@ const careTimelineSchema = new mongoose.Schema(
         'family_contact',
         'family_meeting',
         'consent_obtained',
+        'consent_revoked', // W1002 — consent withdrawn (PDPL/CRPD)
         'home_program_assigned',
         // Communication
         'note_added',

--- a/backend/events/contracts/dddEventContracts.js
+++ b/backend/events/contracts/dddEventContracts.js
@@ -1000,6 +1000,46 @@ const REFERRAL_EVENTS = {
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
+//  Consent Events — أحداث الموافقات (W1002, PDPL/CRPD)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Consent lifecycle on the beneficiary timeline. obtained = care/data processing
+// permitted (positive); revoked = consent withdrawn (care/data access at risk —
+// a compliance-significant warning). Producer: native Consent post-save hook.
+
+const CONSENT_EVENTS = {
+  OBTAINED: {
+    domain: 'consent',
+    eventType: 'consent.obtained',
+    version: 1,
+    description: 'منح موافقة — Consent granted for the beneficiary',
+    payload: {
+      consentId: 'string',
+      beneficiaryId: 'string',
+      consentType: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards'],
+  },
+
+  REVOKED: {
+    domain: 'consent',
+    eventType: 'consent.revoked',
+    version: 1,
+    description: 'سحب موافقة — Consent revoked / withdrawn',
+    payload: {
+      consentId: 'string',
+      beneficiaryId: 'string',
+      consentType: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.REALTIME, DELIVERY.LOCAL],
+    priority: PRIORITY.HIGH,
+    consumers: ['timeline', 'dashboards', 'ai-recommendations'],
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
 //  Aggregated Contracts Registry
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -1024,6 +1064,7 @@ const DDD_CONTRACTS = {
   followup: FOLLOWUP_EVENTS,
   insurance: INSURANCE_EVENTS,
   referral: REFERRAL_EVENTS,
+  consent: CONSENT_EVENTS,
 };
 
 /**
@@ -1061,6 +1102,7 @@ module.exports = {
   FOLLOWUP_EVENTS,
   INSURANCE_EVENTS,
   REFERRAL_EVENTS,
+  CONSENT_EVENTS,
   DDD_CONTRACTS,
   getDDDContractStats,
 };

--- a/backend/integration/dddCrossModuleSubscribers.js
+++ b/backend/integration/dddCrossModuleSubscribers.js
@@ -1392,6 +1392,56 @@ function initializeDDDSubscribers(integrationBus, _moduleConnector) {
     },
   });
 
+  // ─── Consent → Timeline: obtained (W1002, PDPL/CRPD) ───────────────
+  subscribers.push({
+    name: 'consent:obtained → timeline:record',
+    pattern: 'consent.consent.obtained',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'consent_obtained',
+            category: 'administrative',
+            severity: 'success',
+            title: `Consent obtained (${event.payload.consentType || ''})`.trim(),
+            title_ar: `منح موافقة (${event.payload.consentType || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Consent-obtained timeline failed: ${err.message}`);
+      }
+    },
+  });
+
+  // ─── Consent → Timeline: revoked (W1002, withdrawal — warning) ─────
+  subscribers.push({
+    name: 'consent:revoked → timeline:record',
+    pattern: 'consent.consent.revoked',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'consent_revoked',
+            category: 'administrative',
+            severity: 'warning',
+            title: `Consent revoked (${event.payload.consentType || ''})`.trim(),
+            title_ar: `سحب موافقة (${event.payload.consentType || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Consent-revoked timeline failed: ${err.message}`);
+      }
+    },
+  });
+
   // ── Register all subscribers ───────────────────────────────────────
   let registered = 0;
   for (const sub of subscribers) {

--- a/backend/models/Consent.js
+++ b/backend/models/Consent.js
@@ -86,6 +86,45 @@ const consentSchema = new mongoose.Schema(
 // Primary lookup: latest records of this type for this beneficiary.
 consentSchema.index({ beneficiaryId: 1, type: 1, grantedAt: -1 });
 
+// W1002 — surface consent lifecycle on the unified-core timeline (PDPL/CRPD):
+// a consent OBTAINED (granted — care/data processing now permitted) and a consent
+// REVOKED (withdrawn — care/data access at risk). Fills the CareTimeline's
+// long-declared but producerless `consent_obtained` enum value + a new
+// `consent_revoked`. Native pre-compile hooks per the W970 pattern (the
+// modelEventBridge-is-dead workaround); guarded + fire-and-forget.
+//
+// W954-SAFE hook signatures: the global legacy-hook shim only wraps a hook whose
+// sole param is literally named `next`. `post('save', function (doc) {…})`,
+// `pre('save', function () {…})` (0-param) and `post('init', …)` all pass through
+// untouched — no save-hang. The append-only model has no `status` enum, so the
+// pre-save captures `isNew` (reliable create-detection, no double-fire on
+// re-save) and post-init captures the prior `revokedAt` (revoke transition).
+consentSchema.post('init', function () {
+  this.$__prevRevokedAt = this.revokedAt;
+});
+consentSchema.pre('save', function () {
+  this.$__wasNew = this.isNew;
+});
+consentSchema.post('save', function (doc) {
+  try {
+    const { integrationBus } = require('../integration/systemIntegrationBus');
+    if (!integrationBus || typeof integrationBus.publish !== 'function') return;
+    if (!doc.beneficiaryId) return;
+    const base = {
+      consentId: String(doc._id),
+      beneficiaryId: String(doc.beneficiaryId),
+      consentType: doc.type,
+    };
+    if (doc.$__wasNew) {
+      Promise.resolve(integrationBus.publish('consent', 'consent.obtained', base)).catch(() => {});
+    } else if (!doc.$__prevRevokedAt && doc.revokedAt) {
+      Promise.resolve(integrationBus.publish('consent', 'consent.revoked', base)).catch(() => {});
+    }
+  } catch (_) {
+    /* bus not wired — never block persistence */
+  }
+});
+
 const Consent = mongoose.models.Consent || mongoose.model('Consent', consentSchema);
 
 module.exports = { Consent, CONSENT_TYPES, REQUIRED_TYPES };

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -744,5 +744,6 @@ __tests__/followup-visit-core-linkage-wave992.test.js
 __tests__/insurance-claim-core-linkage-wave994.test.js
 __tests__/referrals-core-linkage-wave997.test.js
 __tests__/core-timeline-subscriber-shape-wave998.test.js
+__tests__/consent-core-linkage-wave1002.test.js
 __tests__/legacy-hook-adapter-wave954.test.js
 __tests__/legacy-hook-no-hang-behavioral-wave954.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -55,6 +55,7 @@ Per-beneficiary timeline + dashboards react in real time to:
 - **Post-rehab follow-up** — case completed / lost-to-follow-up (W987) + visit attended / missed (W992)
 - **Insurance claims** — approved / rejected (W994)
 - **Referrals** — accepted / completed / rejected across all 4 referral subsystems (W997)
+- **Consent (PDPL/CRPD)** — obtained / revoked (W1002)
 - **(env-gated, W974)** HR (hire/terminate/leave/salary/transfer), Finance
   (invoice/payment/expense/payroll), Medical (record/therapy/prescription/risk),
   Attendance (check-in/out), Notification (delivery_failed)
@@ -121,6 +122,7 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 | Beneficiary status lifecycle | `Beneficiary` | `beneficiary.status_changed` → `status_changed` | ✅ **W982** |
 | Complaints (CRM) | `Complaint` | `complaint.filed` → `complaint_filed` | ✅ **W984** |
 | Family visits | `FamilyVisitRequest` | `family.visit.completed` / `.no_show` → `family_meeting` | ✅ **W985** |
+| Consent (PDPL/CRPD) | `Consent` | `consent.obtained` / `.revoked` → `consent_obtained` / `consent_revoked` | ✅ **W1002** — filled the long-declared but producerless `consent_obtained` enum |
 | Guardian-portal engagement | — | — | Open |
 
 ### Tier 3 — operational / governance
@@ -151,12 +153,12 @@ persist to the EventStore — intended behaviour. It is a **prod behaviour chang
 
 ## 6. Coverage snapshot (updated 2026-06-08)
 
-- Real timeline/dashboard linkage: the **clinical spine** + 14 leaf domains wired
+- Real timeline/dashboard linkage: the **clinical spine** + 15 leaf domains wired
   since 2026-06-05 via native pre-compile hooks (W977 safety · W979 waitlist ·
   W980 screenings · W981 MAR · W982 beneficiary-status · W984 complaints ·
   W985 family-visits · W986 transitions · W987 post-rehab follow-up cases ·
-  W992 follow-up visits · W994 insurance claims · W997 referrals (4 subsystems) —
-  all merged to main).
+  W992 follow-up visits · W994 insurance claims · W997 referrals (4 subsystems) ·
+  W1002 consent (PDPL/CRPD) — all merged to main). All shape-guarded by W998.
 - + 21 LIVE-registry mappings, **wired but dormant behind the flag**.
 - ≈ **460 route files** still operate as standalone CRUD with no core emission.
 - The frozen V4 `services/core` is **not** consumed by the live UI and is out of


### PR DESCRIPTION
## W1002 — Consent lifecycle on the unified-core timeline (PDPL/CRPD)

Fills a gap the timeline schema was **literally designed for**: the `consent_obtained` CareTimeline enum value has existed for ages with **no producer**. A consent **obtained** (granted — care/data processing permitted, success) and a consent **revoked** (withdrawn — access at risk, warning) now appear on the beneficiary timeline. Consent is central to a Saudi disability platform under **PDPL + CRPD**.

### How
- **Producer** — native pre-compile hooks in `models/Consent.js`. The model is append-only (no `status` enum), so:
  - `post('init')` captures the prior `revokedAt`,
  - `pre('save')` (**0-param**) captures `isNew` — so a later metadata re-save does **not** re-fire `obtained` (verified by a no-double-fire test),
  - `post('save', function(doc))` fires `consent.obtained` on create / `consent.revoked` on the `null→set` `revokedAt` transition.

### W954-safe (this is the bug that just bit the whole effort)
All hook signatures are W954-safe: the global legacy-hook shim only wraps a hook whose sole param is literally named `next`. `function(doc)` / 0-param `function()` pass through untouched → **no save-hang**. Verified green with these hooks present: `legacy-hook-adapter-wave954` + `legacy-hook-no-hang-behavioral-wave954` + `check:hook-style` (callback baseline stays 1).

### Rest of the slice
- `CONSENT_EVENTS` contract group (`consent.obtained` [normal], `consent.revoked` [HIGH, +`ai-recommendations`]) + aggregator + export.
- W374: `consent` domain + `consent` prefix + `CONSENT_EVENTS` export.
- CareTimeline enum: **reuses** existing `consent_obtained` + adds `consent_revoked`.
- 2 subscribers → CareTimeline rows (administrative).

### Verification
- **Runtime e2e** (`consent-core-linkage-wave1002.test.js`, 3 assertions): grant → success row, revoke → warning row, metadata re-save → exactly one row (no double-fire).
- Guards green: **W374/W375/W389/W392** + the **W998** capstone shape-guard (validates the new subscribers) + **hook-style** + **W954** hook-shim guards + sprint-hygiene.
- Ledger: Consent added to Tier-2 + spine list + snapshot (15 leaf domains).

### Risk
Additive. No env flag — subscribers already wired into the DDD bus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
