### PR TITLE
feat(home-program): W1003 wire home-program lifecycle onto the unified-core timeline

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1272,6 +1272,8 @@ on:
       - 'backend/__tests__/legacy-hook-no-hang-behavioral-wave954.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/consent-core-linkage-wave1002.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/home-program-core-linkage-wave1003.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2527,6 +2529,8 @@ on:
       - 'backend/__tests__/legacy-hook-no-hang-behavioral-wave954.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/consent-core-linkage-wave1002.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/home-program-core-linkage-wave1003.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/ddd-event-contracts-wave374.test.js
+++ b/backend/__tests__/ddd-event-contracts-wave374.test.js
@@ -73,6 +73,7 @@ const EXPECTED_DOMAIN_GROUPS = Object.freeze([
   'insurance', // W994 — insurance claim approved / rejected → core timeline
   'referral', // W997 — referral accepted / completed / rejected (shared across 4 models) → core timeline
   'consent', // W1002 — consent obtained / revoked (PDPL/CRPD) → core timeline
+  'home_program', // W1003 — home program assigned / completed → core timeline
 ]);
 
 // Allowed `eventType` prefixes. Most match W354 TIER domain names; a few are
@@ -120,6 +121,7 @@ const ALLOWED_EVENT_PREFIXES = Object.freeze(
     'claim', // W994
     'referral', // W997
     'consent', // W1002
+    'home_program', // W1003
   ])
 );
 
@@ -175,6 +177,7 @@ describe('W374 DDD event-contracts drift guard', () => {
         insurance: 'INSURANCE_EVENTS', // W994
         referral: 'REFERRAL_EVENTS', // W997
         consent: 'CONSENT_EVENTS', // W1002
+        home_program: 'HOME_PROGRAM_EVENTS', // W1003
       };
       for (const [group, exportName] of Object.entries(groupExportMap)) {
         expect(contracts[exportName]).toBe(contracts.DDD_CONTRACTS[group]);

--- a/backend/__tests__/home-program-core-linkage-wave1003.test.js
+++ b/backend/__tests__/home-program-core-linkage-wave1003.test.js
@@ -1,0 +1,142 @@
+'use strict';
+
+/**
+ * home-program-core-linkage-wave1003.test.js — W1003.
+ *
+ * Wires home-program lifecycle onto the unified-core timeline via a SHARED
+ * `home_program` vocabulary across FamilyHomeProgram + HomeAssignment (the same
+ * shared-domain pattern as W997 referrals). A program ASSIGNED (parent-administered
+ * home exercises — care extends home, info) and COMPLETED (success). Fills the
+ * long-declared-but-producerless `home_program_assigned` CareTimeline enum + a new
+ * `home_program_completed`. RUNTIME end-to-end against real in-memory Mongo + the
+ * real integration bus + real subscribers. Covers both field-name variants
+ * (`beneficiaryId` for FamilyHomeProgram, `beneficiary` for HomeAssignment).
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let FamilyHomeProgram, HomeAssignment, CareTimeline;
+
+async function waitForTimeline(query, { timeout = 4000, interval = 25 } = {}) {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const row = await CareTimeline.findOne(query);
+    if (row) return row;
+    if (Date.now() - start > timeout) return null;
+    await new Promise(r => setTimeout(r, interval));
+  }
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w1003-homeprog' } });
+  await mongoose.connect(mongod.getUri());
+
+  // Install the global legacy-hook shim EXACTLY as server.js does, BEFORE the
+  // models declare their hooks. This makes FamilyHomeProgram's existing
+  // `pre('validate', function (next))` callback hook work under Mongoose 9 (the
+  // W946/W954 rescue) AND — crucially — exercises MY new `post('save',
+  // function(doc))` / 0-param hooks through the REAL prod shim, proving they are
+  // W954-safe (don't hang). This is the prod boot path the W974/W954 saga showed
+  // a plain MMS test does NOT replicate.
+  const plugins = require('../config/mongoose.plugins');
+  plugins.registerGlobalPlugins();
+
+  FamilyHomeProgram = require('../models/FamilyHomeProgram');
+  HomeAssignment = require('../models/HomeAssignment');
+  ({ CareTimeline } = require('../domains/timeline/models/CareTimeline'));
+  require('../models/Beneficiary');
+  const { integrationBus } = require('../integration/systemIntegrationBus');
+  const { initializeDDDSubscribers } = require('../integration/dddCrossModuleSubscribers');
+  initializeDDDSubscribers(integrationBus);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+afterEach(async () => {
+  await Promise.all([
+    FamilyHomeProgram.deleteMany({}),
+    HomeAssignment.deleteMany({}),
+    CareTimeline.deleteMany({}),
+  ]);
+});
+
+describe('W1003 — home programs reach the unified-core timeline', () => {
+  it('FamilyHomeProgram (beneficiaryId): assigned on create → INFO, completed → SUCCESS', async () => {
+    const ben = new mongoose.Types.ObjectId();
+    const p = await FamilyHomeProgram.create({
+      beneficiaryId: ben,
+      branchId: new mongoose.Types.ObjectId(),
+      title: 'Daily stretching',
+      startDate: new Date(),
+    });
+    const assigned = await waitForTimeline({
+      beneficiaryId: ben,
+      eventType: 'home_program_assigned',
+    });
+    expect(assigned).toBeTruthy();
+    expect(assigned.category).toBe('clinical');
+    expect(assigned.severity).toBe('info');
+    expect(assigned.metadata.programType).toBe('family');
+
+    const loaded = await FamilyHomeProgram.findById(p._id);
+    loaded.status = 'COMPLETED';
+    await loaded.save();
+    const completed = await waitForTimeline({
+      beneficiaryId: ben,
+      eventType: 'home_program_completed',
+    });
+    expect(completed).toBeTruthy();
+    expect(completed.severity).toBe('success');
+  });
+
+  it('HomeAssignment (beneficiary): assigned on create → INFO, completed → SUCCESS', async () => {
+    const ben = new mongoose.Types.ObjectId();
+    const a = await HomeAssignment.create({
+      beneficiary: ben,
+      assignedBy: new mongoose.Types.ObjectId(),
+      title: 'Balance drills',
+      description: 'Stand on one leg 30s x3',
+    });
+    const assigned = await waitForTimeline({
+      beneficiaryId: ben,
+      eventType: 'home_program_assigned',
+    });
+    expect(assigned).toBeTruthy();
+    expect(assigned.metadata.programType).toBe('assignment');
+
+    const loaded = await HomeAssignment.findById(a._id);
+    loaded.status = 'COMPLETED';
+    await loaded.save();
+    const completed = await waitForTimeline({
+      beneficiaryId: ben,
+      eventType: 'home_program_completed',
+    });
+    expect(completed).toBeTruthy();
+    expect(completed.severity).toBe('success');
+  });
+
+  it('a metadata-only re-save (no status change) does NOT re-fire — exactly one row', async () => {
+    const ben = new mongoose.Types.ObjectId();
+    const a = await HomeAssignment.create({
+      beneficiary: ben,
+      assignedBy: new mongoose.Types.ObjectId(),
+      title: 'x',
+      description: 'y',
+    });
+    await waitForTimeline({ beneficiaryId: ben, eventType: 'home_program_assigned' });
+    const loaded = await HomeAssignment.findById(a._id);
+    loaded.videoUrl = 'http://example/v';
+    await loaded.save();
+    await new Promise(r => setTimeout(r, 200));
+    expect(await CareTimeline.countDocuments({ beneficiaryId: ben })).toBe(1);
+  });
+});

--- a/backend/domains/timeline/models/CareTimeline.js
+++ b/backend/domains/timeline/models/CareTimeline.js
@@ -95,6 +95,7 @@ const careTimelineSchema = new mongoose.Schema(
         'consent_obtained',
         'consent_revoked', // W1002 — consent withdrawn (PDPL/CRPD)
         'home_program_assigned',
+        'home_program_completed', // W1003 — home program completed
         // Communication
         'note_added',
         'document_uploaded',

--- a/backend/events/contracts/dddEventContracts.js
+++ b/backend/events/contracts/dddEventContracts.js
@@ -1040,6 +1040,49 @@ const CONSENT_EVENTS = {
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
+//  Home Program Events — أحداث البرنامج المنزلي (W1003)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Parent-administered home exercise programs (care extends into the home). A
+// shared vocabulary across FamilyHomeProgram + HomeAssignment, with a
+// `programType` discriminator. assigned = a program was given to the family;
+// completed = the program ran its course. Producer: native post-save hooks.
+
+const HOME_PROGRAM_EVENTS = {
+  ASSIGNED: {
+    domain: 'home_program',
+    eventType: 'home_program.assigned',
+    version: 1,
+    description: 'إسناد برنامج منزلي — Home program assigned to the family',
+    payload: {
+      programId: 'string',
+      beneficiaryId: 'string',
+      programType: 'string',
+      title: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards'],
+  },
+
+  COMPLETED: {
+    domain: 'home_program',
+    eventType: 'home_program.completed',
+    version: 1,
+    description: 'اكتمال برنامج منزلي — Home program completed',
+    payload: {
+      programId: 'string',
+      beneficiaryId: 'string',
+      programType: 'string',
+      title: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards'],
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
 //  Aggregated Contracts Registry
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -1065,6 +1108,7 @@ const DDD_CONTRACTS = {
   insurance: INSURANCE_EVENTS,
   referral: REFERRAL_EVENTS,
   consent: CONSENT_EVENTS,
+  home_program: HOME_PROGRAM_EVENTS,
 };
 
 /**
@@ -1103,6 +1147,7 @@ module.exports = {
   INSURANCE_EVENTS,
   REFERRAL_EVENTS,
   CONSENT_EVENTS,
+  HOME_PROGRAM_EVENTS,
   DDD_CONTRACTS,
   getDDDContractStats,
 };

--- a/backend/integration/dddCrossModuleSubscribers.js
+++ b/backend/integration/dddCrossModuleSubscribers.js
@@ -1442,6 +1442,56 @@ function initializeDDDSubscribers(integrationBus, _moduleConnector) {
     },
   });
 
+  // ─── Home program → Timeline: assigned (W1003) ────────────────────
+  subscribers.push({
+    name: 'home_program:assigned → timeline:record',
+    pattern: 'home_program.home_program.assigned',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'home_program_assigned',
+            category: 'clinical',
+            severity: 'info',
+            title: `Home program assigned (${event.payload.title || event.payload.programType || ''})`.trim(),
+            title_ar: `إسناد برنامج منزلي (${event.payload.title || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Home-program-assigned timeline failed: ${err.message}`);
+      }
+    },
+  });
+
+  // ─── Home program → Timeline: completed (W1003) ───────────────────
+  subscribers.push({
+    name: 'home_program:completed → timeline:record',
+    pattern: 'home_program.home_program.completed',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'home_program_completed',
+            category: 'clinical',
+            severity: 'success',
+            title: `Home program completed (${event.payload.title || event.payload.programType || ''})`.trim(),
+            title_ar: `اكتمال برنامج منزلي (${event.payload.title || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Home-program-completed timeline failed: ${err.message}`);
+      }
+    },
+  });
+
   // ── Register all subscribers ───────────────────────────────────────
   let registered = 0;
   for (const sub of subscribers) {

--- a/backend/models/FamilyHomeProgram.js
+++ b/backend/models/FamilyHomeProgram.js
@@ -71,5 +71,47 @@ familyHomeProgramSchema.pre('validate', function validateInvariants(next) {
   return next();
 });
 
+// W1003 — surface home-program lifecycle on the unified-core timeline (shared
+// `home_program` domain across FamilyHomeProgram + HomeAssignment): a program
+// ASSIGNED (parent-administered home exercises — care extends home) and COMPLETED.
+// Fills the long-declared-but-producerless `home_program_assigned` CareTimeline
+// enum + a new `home_program_completed`. Native pre-compile hooks per the W970
+// pattern (modelEventBridge-is-dead workaround); guarded + fire-and-forget.
+// W954-SAFE signatures (post(doc) / 0-param) — the global legacy-hook shim only
+// wraps a sole param literally named `next`; the existing pre('validate', next)
+// is a different event + a genuine legacy callback, so no conflict. Reads
+// `beneficiary` OR `beneficiaryId` so the same hook works on both models.
+familyHomeProgramSchema.post('init', function () {
+  this.$__prevStatus = this.status;
+});
+familyHomeProgramSchema.pre('save', function () {
+  this.$__wasNew = this.isNew;
+});
+familyHomeProgramSchema.post('save', function (doc) {
+  try {
+    const { integrationBus } = require('../integration/systemIntegrationBus');
+    if (!integrationBus || typeof integrationBus.publish !== 'function') return;
+    const beneficiaryId = doc.beneficiary || doc.beneficiaryId;
+    if (!beneficiaryId) return;
+    const base = {
+      programId: String(doc._id),
+      beneficiaryId: String(beneficiaryId),
+      programType: 'family',
+      title: doc.title || '',
+    };
+    if (doc.$__wasNew) {
+      Promise.resolve(integrationBus.publish('home_program', 'home_program.assigned', base)).catch(
+        () => {}
+      );
+    } else if (doc.status === 'COMPLETED' && doc.$__prevStatus !== 'COMPLETED') {
+      Promise.resolve(integrationBus.publish('home_program', 'home_program.completed', base)).catch(
+        () => {}
+      );
+    }
+  } catch (_) {
+    /* bus not wired — never block persistence */
+  }
+});
+
 module.exports =
   mongoose.models.FamilyHomeProgram || mongoose.model('FamilyHomeProgram', familyHomeProgramSchema);

--- a/backend/models/HomeAssignment.js
+++ b/backend/models/HomeAssignment.js
@@ -34,5 +34,41 @@ homeAssignmentSchema.index({ beneficiary: 1, status: 1 });
 homeAssignmentSchema.index({ assignedBy: 1, status: 1 });
 homeAssignmentSchema.index({ status: 1, startDate: -1 });
 
+// W1003 — surface home-program lifecycle on the unified-core timeline (shared
+// `home_program` domain; companion to FamilyHomeProgram). assigned on create /
+// completed on status→COMPLETED. Native pre-compile W954-safe hooks (post(doc) /
+// 0-param); guarded + fire-and-forget. This model uses the `beneficiary` field.
+homeAssignmentSchema.post('init', function () {
+  this.$__prevStatus = this.status;
+});
+homeAssignmentSchema.pre('save', function () {
+  this.$__wasNew = this.isNew;
+});
+homeAssignmentSchema.post('save', function (doc) {
+  try {
+    const { integrationBus } = require('../integration/systemIntegrationBus');
+    if (!integrationBus || typeof integrationBus.publish !== 'function') return;
+    const beneficiaryId = doc.beneficiary || doc.beneficiaryId;
+    if (!beneficiaryId) return;
+    const base = {
+      programId: String(doc._id),
+      beneficiaryId: String(beneficiaryId),
+      programType: 'assignment',
+      title: doc.title || '',
+    };
+    if (doc.$__wasNew) {
+      Promise.resolve(integrationBus.publish('home_program', 'home_program.assigned', base)).catch(
+        () => {}
+      );
+    } else if (doc.status === 'COMPLETED' && doc.$__prevStatus !== 'COMPLETED') {
+      Promise.resolve(integrationBus.publish('home_program', 'home_program.completed', base)).catch(
+        () => {}
+      );
+    }
+  } catch (_) {
+    /* bus not wired — never block persistence */
+  }
+});
+
 module.exports =
   mongoose.models.HomeAssignment || mongoose.model('HomeAssignment', homeAssignmentSchema);

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -745,5 +745,6 @@ __tests__/insurance-claim-core-linkage-wave994.test.js
 __tests__/referrals-core-linkage-wave997.test.js
 __tests__/core-timeline-subscriber-shape-wave998.test.js
 __tests__/consent-core-linkage-wave1002.test.js
+__tests__/home-program-core-linkage-wave1003.test.js
 __tests__/legacy-hook-adapter-wave954.test.js
 __tests__/legacy-hook-no-hang-behavioral-wave954.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -56,6 +56,7 @@ Per-beneficiary timeline + dashboards react in real time to:
 - **Insurance claims** — approved / rejected (W994)
 - **Referrals** — accepted / completed / rejected across all 4 referral subsystems (W997)
 - **Consent (PDPL/CRPD)** — obtained / revoked (W1002)
+- **Home programs** — assigned / completed across FamilyHomeProgram + HomeAssignment (W1003)
 - **(env-gated, W974)** HR (hire/terminate/leave/salary/transfer), Finance
   (invoice/payment/expense/payroll), Medical (record/therapy/prescription/risk),
   Attendance (check-in/out), Notification (delivery_failed)
@@ -115,6 +116,7 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 | Referrals | `TherapyReferral` · `CommunityReferral` · `MedicalReferral` · `Referral` (FHIR portal) | `referral.accepted` / `.completed` / `.rejected` → `referral` (shared domain, `referralType` discriminator) | ✅ **W997** — wired all 4 subsystems to ONE shared `referral` vocabulary instead of forcing a consolidation. `ReferralTracking` left out (orthogonal CRM analytics, not beneficiary-keyed). A future ADR may still consolidate the 4 models. |
 | Follow-up cases | `PostRehabCase` | `followup.case.completed` / `.lost` → `followup_completed` / `followup_lost` | ✅ **W987** |
 | Follow-up visits | `FollowUpVisit` | `followup.visit.attended` / `.missed` → `followup_visit` | ✅ **W992** |
+| Home programs | `FamilyHomeProgram` · `HomeAssignment` | `home_program.assigned` / `.completed` → `home_program_assigned` / `home_program_completed` (shared domain, `programType` discriminator) | ✅ **W1003** — filled the long-declared but producerless `home_program_assigned` enum |
 
 ### Tier 2 — family / CRM visibility
 | Domain | Model | Event | Status |
@@ -153,12 +155,13 @@ persist to the EventStore — intended behaviour. It is a **prod behaviour chang
 
 ## 6. Coverage snapshot (updated 2026-06-08)
 
-- Real timeline/dashboard linkage: the **clinical spine** + 15 leaf domains wired
+- Real timeline/dashboard linkage: the **clinical spine** + 16 leaf domains wired
   since 2026-06-05 via native pre-compile hooks (W977 safety · W979 waitlist ·
   W980 screenings · W981 MAR · W982 beneficiary-status · W984 complaints ·
   W985 family-visits · W986 transitions · W987 post-rehab follow-up cases ·
   W992 follow-up visits · W994 insurance claims · W997 referrals (4 subsystems) ·
-  W1002 consent (PDPL/CRPD) — all merged to main). All shape-guarded by W998.
+  W1002 consent (PDPL/CRPD) · W1003 home programs — all merged to main). All
+  shape-guarded by W998.
 - + 21 LIVE-registry mappings, **wired but dormant behind the flag**.
 - ≈ **460 route files** still operate as standalone CRUD with no core emission.
 - The frozen V4 `services/core` is **not** consumed by the live UI and is out of


### PR DESCRIPTION
## W1003 — Home-program lifecycle on the unified-core timeline

Fills another gap the schema was designed for: the `home_program_assigned` CareTimeline enum has existed with **no producer**. Parent-administered home exercise programs (central to pediatric rehab — care extends into the home) now appear on the beneficiary timeline: **assigned** on create (info) + **completed** (success).

Shared `home_program` vocabulary across `FamilyHomeProgram` + `HomeAssignment` with a `programType` discriminator (the W997 referrals pattern) — uniform coverage without consolidating the two models.

### Producers
Native pre-compile hooks in both models: `post('init')` captures prevStatus; **0-param** `pre('save')` captures `isNew` (so a metadata re-save does **not** re-fire `assigned` — verified by a no-double-fire test); `post('save', function(doc))` fires `home_program.assigned` on create / `home_program.completed` on the `→COMPLETED` transition. Reads `beneficiary` **or** `beneficiaryId` (field-name varies between the two models).

### W954-safe — and tested through the *real* prod shim
All signatures are W954-safe (`function(doc)` / 0-param). The e2e test **installs the real legacy-hook shim** (`registerGlobalPlugins`) before requiring the models, so it (a) makes `FamilyHomeProgram`'s existing `pre('validate', function(next))` callback hook work under Mongoose 9, and (b) exercises my hooks through the **actual prod boot path** — the strongest verification in the core-linkage series, directly addressing the W974/W954 lesson that a plain MMS test does *not* replicate the prod shim.

### Rest of the slice
- `HOME_PROGRAM_EVENTS` contract group (assigned/completed [normal]) + aggregator (key `home_program` = the `domain` field) + export.
- W374: `home_program` domain + `home_program` prefix + `HOME_PROGRAM_EVENTS` export.
- CareTimeline enum: **reuses** `home_program_assigned` + adds `home_program_completed`.
- 2 subscribers → CareTimeline rows (clinical).

### Verification
- **Runtime e2e** (`home-program-core-linkage-wave1003.test.js`, 3 assertions, under the real shim): both models fire assigned-on-create + completed-on-transition across both field-name variants; metadata re-save → exactly one row.
- Guards green: **W374/W375/W389/W392** + **W998** shape-guard + **hook-style** (baseline unchanged) + sprint-hygiene.
- Ledger: Home-programs row (Tier-1) + spine list + snapshot (16 leaf domains).

### Risk
Additive. No env flag — subscribers already wired into the DDD bus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
