### PR TITLE
refactor(mongoose): W955 — convert 5 global plugin pre-hooks to async (drop shim dependency)

### DIFF
--- a/backend/database/audit-trail.js
+++ b/backend/database/audit-trail.js
@@ -536,14 +536,15 @@ class AuditTrail {
       const modelName = pluginOptions.modelName || 'Unknown';
 
       // Track saves (create/update)
-      schema.pre('save', function (next) {
+      // W955 — async (Mongoose-9 native); no longer depends on the
+      // config/mongoose.plugins legacy-hook shim to supply `next`.
+      schema.pre('save', async function () {
         if (this.isNew) {
           this._auditAction = 'create';
         } else {
           this._auditAction = 'update';
           this._auditBefore = this._original || {};
         }
-        next();
       });
 
       schema.post('save', function (doc) {

--- a/backend/database/multi-tenant-isolator.js
+++ b/backend/database/multi-tenant-isolator.js
@@ -116,12 +116,12 @@ class MultiTenantIsolator {
       }
 
       // ── Pre-save: auto-inject tenantId ──
-      schema.pre('save', function (next) {
+      // W955 — async (Mongoose-9 native); no longer depends on the legacy-hook shim.
+      schema.pre('save', async function () {
         const ctx = self.getCurrentTenant();
         if (ctx && ctx.tenantId && !this[self._tenantField]) {
           this[self._tenantField] = ctx.tenantId;
         }
-        next();
       });
 
       // ── Pre-find: auto-scope queries ──

--- a/backend/database/plugins/field-encryption.js
+++ b/backend/database/plugins/field-encryption.js
@@ -233,54 +233,46 @@ function encryptedFieldsPlugin(schema, options = {}) {
   }
 
   // ── Encrypt on save ──
-  schema.pre('save', function (next) {
-    try {
-      for (const fieldPath of fields) {
-        const value = this.get(fieldPath);
-        if (value && typeof value === 'string' && !value.startsWith(ENCRYPTION_PREFIX)) {
-          // Encrypt the value
-          this.set(fieldPath, encrypt(value));
+  // W955 — async (Mongoose-9 native); a throw rejects the save exactly as
+  // next(err) did. No longer depends on the legacy-hook shim.
+  schema.pre('save', async function () {
+    for (const fieldPath of fields) {
+      const value = this.get(fieldPath);
+      if (value && typeof value === 'string' && !value.startsWith(ENCRYPTION_PREFIX)) {
+        // Encrypt the value
+        this.set(fieldPath, encrypt(value));
 
-          // Update search hash if searchable
-          if (searchable.includes(fieldPath)) {
-            const hashField = `_hash_${fieldPath.replace(/\./g, '_')}`;
-            this.set(hashField, deterministicHash(value, fieldPath));
-          }
+        // Update search hash if searchable
+        if (searchable.includes(fieldPath)) {
+          const hashField = `_hash_${fieldPath.replace(/\./g, '_')}`;
+          this.set(hashField, deterministicHash(value, fieldPath));
         }
       }
-      next();
-    } catch (err) {
-      next(err);
     }
   });
 
   // ── Encrypt on update ──
-  schema.pre(['updateOne', 'findOneAndUpdate', 'updateMany'], function (next) {
-    try {
-      const update = this.getUpdate();
-      if (!update) return next();
+  // W955 — async (Mongoose-9 native); no longer depends on the legacy-hook shim.
+  schema.pre(['updateOne', 'findOneAndUpdate', 'updateMany'], async function () {
+    const update = this.getUpdate();
+    if (!update) return;
 
-      const processObj = obj => {
-        for (const fieldPath of fields) {
-          const value = obj[fieldPath];
-          if (value && typeof value === 'string' && !value.startsWith(ENCRYPTION_PREFIX)) {
-            obj[fieldPath] = encrypt(value);
+    const processObj = obj => {
+      for (const fieldPath of fields) {
+        const value = obj[fieldPath];
+        if (value && typeof value === 'string' && !value.startsWith(ENCRYPTION_PREFIX)) {
+          obj[fieldPath] = encrypt(value);
 
-            if (searchable.includes(fieldPath)) {
-              const hashField = `_hash_${fieldPath.replace(/\./g, '_')}`;
-              obj[hashField] = deterministicHash(value, fieldPath);
-            }
+          if (searchable.includes(fieldPath)) {
+            const hashField = `_hash_${fieldPath.replace(/\./g, '_')}`;
+            obj[hashField] = deterministicHash(value, fieldPath);
           }
         }
-      };
+      }
+    };
 
-      processObj(update);
-      if (update.$set) processObj(update.$set);
-
-      next();
-    } catch (err) {
-      next(err);
-    }
+    processObj(update);
+    if (update.$set) processObj(update.$set);
   });
 
   // ── Decrypt after find ──

--- a/backend/database/plugins/mongoose-plugins.js
+++ b/backend/database/plugins/mongoose-plugins.js
@@ -19,14 +19,13 @@ function timestampsPlugin(schema) {
     updatedAt: { type: Date, default: Date.now },
   });
 
-  schema.pre('save', function (next) {
+  // W955 — async (Mongoose-9 native); no longer depends on the legacy-hook shim.
+  schema.pre('save', async function () {
     if (!this.isNew) this.updatedAt = new Date();
-    next();
   });
 
-  schema.pre(['updateOne', 'findOneAndUpdate', 'updateMany'], function (next) {
+  schema.pre(['updateOne', 'findOneAndUpdate', 'updateMany'], async function () {
     this.set({ updatedAt: new Date() });
-    next();
   });
 
   // Virtual: age in days since creation

--- a/backend/database/query-governor.js
+++ b/backend/database/query-governor.js
@@ -89,14 +89,15 @@ class QueryGovernor {
       }
 
       // ── Writes ──
-      schema.pre('save', function (next) {
-        if (!self._enabled) return next();
+      // W955 — async (Mongoose-9 native); throwing rejects the save exactly as
+      // next(err) did. No longer depends on the legacy-hook shim.
+      schema.pre('save', async function () {
+        if (!self._enabled) return;
         const ctx = self._getContext();
         if (ctx && !self._checkWriteBudget(ctx.userId, ctx.role)) {
-          return next(new Error('Write rate limit exceeded. Please try again later.'));
+          throw new Error('Write rate limit exceeded. Please try again later.');
         }
         self._trackMetric(modelName, 'write');
-        next();
       });
 
       const writeHooks = ['updateMany', 'deleteMany', 'insertMany'];


### PR DESCRIPTION
## متابعة تصليب لـW954

أعلى طبقة blast-radius في مسار الحفظ — **الإضافات العامّة** المُطبَّقة على كل المخطّطات (audit-trail · query-governor · timestamps · field-encryption · multi-tenant-isolator) — كانت لا تزال بنمط `pre('save', function (next) {…})` القديم، تعمل **فقط** لأن الشيم في `config/mongoose.plugins.js` يُنقذها. فكان مسار الحفظ العام كلّه مُتدلّياً من band-aid واحد. W954 صحّح الشيم؛ وهذا يُقلّل الاعتماد عليه.

حوّلتُ **7 خطّافات `function(next)`** في هذه الملفّات الخمسة إلى `async function () {}` (صيغة W948): الأجسام المتزامنة تُسقط `next()`؛ واللذان كانا يُمرّران خطأً (سقف الكتابة + التشفير) يرميان الآن — وهو ما يرفض الحفظ تماماً كـ`next(err)`. السلوك دون تغيير، والشيم خارج مسار الإضافات العامّة.

### التحقّق
- **69 اختباراً** أخضر يُمرّن الإضافات المُحوّلة (care-plan-e2e + side-effects-audit + audit-trail-coverage الذي يغطّي خطّافي pre **و** post)
- `node --check` نظيف على الخمسة · `check:hook-style` (بوّابة 4) أخضر · صفر `function(next)` متبقٍّ

### ملاحظة (نقطة عمياء في بوّابة 4، ظهرت هنا)
`HOOK_RE` يشترط متغيّراً `\w+(?:Schema|schema)` و`function\s*\(` — فلا يُمسك المتغيّر `schema` المجرّد ولا التعابير الدالّية المُسمّاة (`function preSave(next)`). لذا كانت هذه الخطّافات خفيّة عنها. خطّافات `function(next)` متبقّية لم تُمَسّ: `modelEventBridge.js` (منطقة core-linkage ساخنة) + 5 ملفّات نماذج + `auditLog.model.js` المحروس. تشديد regex البوّابة + تحويل الباقي = متابعة مُوثّقة.

🤖 Generated with [Claude Code](https://claude.com/claude-code)