### PR TITLE
feat(crisis): W1004 wire acute crisis incidents onto the unified-core timeline

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1274,6 +1274,8 @@ on:
       - 'backend/__tests__/consent-core-linkage-wave1002.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/home-program-core-linkage-wave1003.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/crisis-core-linkage-wave1004.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2531,6 +2533,8 @@ on:
       - 'backend/__tests__/consent-core-linkage-wave1002.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/home-program-core-linkage-wave1003.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/crisis-core-linkage-wave1004.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/crisis-core-linkage-wave1004.test.js
+++ b/backend/__tests__/crisis-core-linkage-wave1004.test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+/**
+ * crisis-core-linkage-wave1004.test.js — W1004.
+ *
+ * Wires acute crisis incidents onto the unified-core timeline: a crisis REPORTED
+ * (warning) and RESOLVED/closed (success). CrisisIncident has its own
+ * active→resolved/closed lifecycle, distinct from the W977 safety events and the
+ * W970 behavior incident. Producer: native CrisisIncident post-save hook (create
+ * → reported; status→resolved|closed → resolved). RUNTIME end-to-end against a
+ * real in-memory Mongo + the real integration bus + real subscribers. Coexists
+ * with the model's existing async `pre('save')` (resolvedAt/closedAt setter).
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let CrisisIncident, CareTimeline;
+
+async function waitForTimeline(query, { timeout = 4000, interval = 25 } = {}) {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const row = await CareTimeline.findOne(query);
+    if (row) return row;
+    if (Date.now() - start > timeout) return null;
+    await new Promise(r => setTimeout(r, interval));
+  }
+}
+
+function newActiveCrisis(extra = {}) {
+  return CrisisIncident.create({
+    beneficiaryId: new mongoose.Types.ObjectId(),
+    branchId: new mongoose.Types.ObjectId(),
+    crisisType: 'behavioral',
+    severity: 'urgent',
+    occurredAt: new Date(),
+    reportedBy: new mongoose.Types.ObjectId(),
+    status: 'active',
+    ...extra,
+  });
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w1004-crisis' } });
+  await mongoose.connect(mongod.getUri());
+  CrisisIncident = require('../models/CrisisIncident');
+  ({ CareTimeline } = require('../domains/timeline/models/CareTimeline'));
+  require('../models/Beneficiary');
+  const { integrationBus } = require('../integration/systemIntegrationBus');
+  const { initializeDDDSubscribers } = require('../integration/dddCrossModuleSubscribers');
+  initializeDDDSubscribers(integrationBus);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+afterEach(async () => {
+  await Promise.all([CrisisIncident.deleteMany({}), CareTimeline.deleteMany({})]);
+});
+
+describe('W1004 — acute crises reach the unified-core timeline', () => {
+  it('reporting a crisis lands a WARNING crisis_reported row', async () => {
+    const c = await newActiveCrisis();
+    const tl = await waitForTimeline({ beneficiaryId: c.beneficiaryId, eventType: 'crisis_reported' });
+    expect(tl).toBeTruthy();
+    expect(tl.category).toBe('clinical');
+    expect(tl.severity).toBe('warning');
+    expect(tl.metadata.crisisType).toBe('behavioral');
+  });
+
+  it('resolving a crisis lands a SUCCESS crisis_resolved row', async () => {
+    const c = await newActiveCrisis();
+    await waitForTimeline({ beneficiaryId: c.beneficiaryId, eventType: 'crisis_reported' });
+    const loaded = await CrisisIncident.findById(c._id);
+    loaded.status = 'resolved';
+    await loaded.save();
+    const tl = await waitForTimeline({ beneficiaryId: c.beneficiaryId, eventType: 'crisis_resolved' });
+    expect(tl).toBeTruthy();
+    expect(tl.severity).toBe('success');
+  });
+
+  it('a non-terminal transition (active → escalated) produces no resolved row', async () => {
+    const c = await newActiveCrisis();
+    await waitForTimeline({ beneficiaryId: c.beneficiaryId, eventType: 'crisis_reported' });
+    const loaded = await CrisisIncident.findById(c._id);
+    loaded.status = 'escalated';
+    await loaded.save();
+    await new Promise(r => setTimeout(r, 200));
+    expect(
+      await CareTimeline.countDocuments({
+        beneficiaryId: c.beneficiaryId,
+        eventType: 'crisis_resolved',
+      })
+    ).toBe(0);
+  });
+});

--- a/backend/__tests__/ddd-event-contracts-wave374.test.js
+++ b/backend/__tests__/ddd-event-contracts-wave374.test.js
@@ -74,6 +74,7 @@ const EXPECTED_DOMAIN_GROUPS = Object.freeze([
   'referral', // W997 — referral accepted / completed / rejected (shared across 4 models) → core timeline
   'consent', // W1002 — consent obtained / revoked (PDPL/CRPD) → core timeline
   'home_program', // W1003 — home program assigned / completed → core timeline
+  'crisis', // W1004 — acute crisis reported / resolved → core timeline
 ]);
 
 // Allowed `eventType` prefixes. Most match W354 TIER domain names; a few are
@@ -122,6 +123,7 @@ const ALLOWED_EVENT_PREFIXES = Object.freeze(
     'referral', // W997
     'consent', // W1002
     'home_program', // W1003
+    'crisis', // W1004
   ])
 );
 
@@ -178,6 +180,7 @@ describe('W374 DDD event-contracts drift guard', () => {
         referral: 'REFERRAL_EVENTS', // W997
         consent: 'CONSENT_EVENTS', // W1002
         home_program: 'HOME_PROGRAM_EVENTS', // W1003
+        crisis: 'CRISIS_EVENTS', // W1004
       };
       for (const [group, exportName] of Object.entries(groupExportMap)) {
         expect(contracts[exportName]).toBe(contracts.DDD_CONTRACTS[group]);

--- a/backend/domains/timeline/models/CareTimeline.js
+++ b/backend/domains/timeline/models/CareTimeline.js
@@ -89,6 +89,8 @@ const careTimelineSchema = new mongoose.Schema(
         'seizure_event',
         'safeguarding_concern',
         'restraint_applied',
+        'crisis_reported', // W1004 — acute crisis reported
+        'crisis_resolved', // W1004 — acute crisis resolved / closed
         // Family
         'family_contact',
         'family_meeting',

--- a/backend/events/contracts/dddEventContracts.js
+++ b/backend/events/contracts/dddEventContracts.js
@@ -1083,6 +1083,49 @@ const HOME_PROGRAM_EVENTS = {
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
+//  Crisis Events — أحداث الأزمات الحادة (W1004)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Acute crisis incidents (behavioral / psychiatric / medical / safeguarding) with
+// their own active→resolved/closed lifecycle — distinct from the W977 safety
+// events and the W970 behavior incident. Producer: native CrisisIncident
+// post-save hook.
+
+const CRISIS_EVENTS = {
+  REPORTED: {
+    domain: 'crisis',
+    eventType: 'crisis.reported',
+    version: 1,
+    description: 'الإبلاغ عن أزمة حادة — Acute crisis reported',
+    payload: {
+      crisisId: 'string',
+      beneficiaryId: 'string',
+      crisisType: 'string',
+      crisisSeverity: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.REALTIME, DELIVERY.LOCAL],
+    priority: PRIORITY.HIGH,
+    consumers: ['timeline', 'dashboards', 'ai-recommendations'],
+  },
+
+  RESOLVED: {
+    domain: 'crisis',
+    eventType: 'crisis.resolved',
+    version: 1,
+    description: 'حل أزمة حادة — Acute crisis resolved / closed',
+    payload: {
+      crisisId: 'string',
+      beneficiaryId: 'string',
+      crisisType: 'string',
+      crisisSeverity: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards'],
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
 //  Aggregated Contracts Registry
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -1109,6 +1152,7 @@ const DDD_CONTRACTS = {
   referral: REFERRAL_EVENTS,
   consent: CONSENT_EVENTS,
   home_program: HOME_PROGRAM_EVENTS,
+  crisis: CRISIS_EVENTS,
 };
 
 /**
@@ -1148,6 +1192,7 @@ module.exports = {
   REFERRAL_EVENTS,
   CONSENT_EVENTS,
   HOME_PROGRAM_EVENTS,
+  CRISIS_EVENTS,
   DDD_CONTRACTS,
   getDDDContractStats,
 };

--- a/backend/integration/dddCrossModuleSubscribers.js
+++ b/backend/integration/dddCrossModuleSubscribers.js
@@ -1492,6 +1492,56 @@ function initializeDDDSubscribers(integrationBus, _moduleConnector) {
     },
   });
 
+  // ─── Crisis → Timeline: reported (W1004, acute crisis) ────────────
+  subscribers.push({
+    name: 'crisis:reported → timeline:record',
+    pattern: 'crisis.crisis.reported',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'crisis_reported',
+            category: 'clinical',
+            severity: 'warning',
+            title: `Crisis reported (${event.payload.crisisType || ''}, ${event.payload.crisisSeverity || ''})`.trim(),
+            title_ar: `الإبلاغ عن أزمة (${event.payload.crisisType || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Crisis-reported timeline failed: ${err.message}`);
+      }
+    },
+  });
+
+  // ─── Crisis → Timeline: resolved (W1004) ──────────────────────────
+  subscribers.push({
+    name: 'crisis:resolved → timeline:record',
+    pattern: 'crisis.crisis.resolved',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'crisis_resolved',
+            category: 'clinical',
+            severity: 'success',
+            title: `Crisis resolved (${event.payload.crisisType || ''})`.trim(),
+            title_ar: `حل أزمة (${event.payload.crisisType || ''})`.trim(),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Crisis-resolved timeline failed: ${err.message}`);
+      }
+    },
+  });
+
   // ── Register all subscribers ───────────────────────────────────────
   let registered = 0;
   for (const sub of subscribers) {

--- a/backend/models/CrisisIncident.js
+++ b/backend/models/CrisisIncident.js
@@ -151,5 +151,43 @@ CrisisIncidentSchema.pre('save', async function () {
   }
 });
 
+// W1004 — surface acute crises on the unified-core timeline. A CrisisIncident
+// (acute behavioral/psychiatric/medical/safeguarding crisis with its own
+// active→resolved/closed lifecycle) is distinct from the W977 safety events
+// (seizure/safeguarding/restraint) and the W970 behavior incident — it needs its
+// own reported/resolved timeline entry. Native pre-compile hooks per the W970
+// pattern; guarded + fire-and-forget. W954-SAFE signatures (post(doc) / 0-param) —
+// coexist with the existing async 0-param pre('save') (different event). Create
+// is detected via post('init') NOT having run (a fresh instance) — CrisisIncident
+// is always created as a new instance (report route) and mutated via a hydrated
+// instance (escalate/close routes), so this is reliable here.
+CrisisIncidentSchema.post('init', function () {
+  this.$__prevStatus = this.status;
+});
+CrisisIncidentSchema.post('save', function (doc) {
+  try {
+    const { integrationBus } = require('../integration/systemIntegrationBus');
+    if (!integrationBus || typeof integrationBus.publish !== 'function') return;
+    if (!doc.beneficiaryId) return;
+    const base = {
+      crisisId: String(doc._id),
+      beneficiaryId: String(doc.beneficiaryId),
+      crisisType: doc.crisisType || '',
+      crisisSeverity: doc.severity || '',
+    };
+    const created = doc.$__prevStatus === undefined; // post('init') didn't run → new
+    const isTerminal = doc.status === 'resolved' || doc.status === 'closed';
+    const wasTerminal =
+      doc.$__prevStatus === 'resolved' || doc.$__prevStatus === 'closed';
+    if (created) {
+      Promise.resolve(integrationBus.publish('crisis', 'crisis.reported', base)).catch(() => {});
+    } else if (isTerminal && !wasTerminal) {
+      Promise.resolve(integrationBus.publish('crisis', 'crisis.resolved', base)).catch(() => {});
+    }
+  } catch (_) {
+    /* bus not wired — never block persistence */
+  }
+});
+
 module.exports =
   mongoose.models.CrisisIncident || mongoose.model('CrisisIncident', CrisisIncidentSchema);

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -746,5 +746,6 @@ __tests__/referrals-core-linkage-wave997.test.js
 __tests__/core-timeline-subscriber-shape-wave998.test.js
 __tests__/consent-core-linkage-wave1002.test.js
 __tests__/home-program-core-linkage-wave1003.test.js
+__tests__/crisis-core-linkage-wave1004.test.js
 __tests__/legacy-hook-adapter-wave954.test.js
 __tests__/legacy-hook-no-hang-behavioral-wave954.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -57,6 +57,7 @@ Per-beneficiary timeline + dashboards react in real time to:
 - **Referrals** — accepted / completed / rejected across all 4 referral subsystems (W997)
 - **Consent (PDPL/CRPD)** — obtained / revoked (W1002)
 - **Home programs** — assigned / completed across FamilyHomeProgram + HomeAssignment (W1003)
+- **Acute crises** — reported / resolved (W1004)
 - **(env-gated, W974)** HR (hire/terminate/leave/salary/transfer), Finance
   (invoice/payment/expense/payroll), Medical (record/therapy/prescription/risk),
   Attendance (check-in/out), Notification (delivery_failed)
@@ -110,6 +111,7 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 | --- | --- | --- | --- |
 | Waitlist → admission | `Waitlist` | `waitlist.*` → `waitlisted` / `waitlist_booked` | ✅ **W979** |
 | Safety events | `SeizureEvent` · `SafeguardingConcern` · `RestraintSeclusion` | `safety.*` → `seizure_event` / `safeguarding_concern` / `restraint_applied` | ✅ **W977** |
+| Acute crises | `CrisisIncident` | `crisis.reported` / `.resolved` → `crisis_reported` / `crisis_resolved` | ✅ **W1004** |
 | Screenings | `VisionScreening` · `HearingScreening` | `screening.completed` | ✅ **W980** |
 | Medication admin (MAR) | `MedicationAdministrationRecord` | `medication.administered` / `.not_given` | ✅ **W981** |
 | Discharge / transition | `TransitionPlan` | `lifecycle.transition.completed` / `.cancelled` → `care_transition` | ✅ **W986** |
@@ -155,13 +157,13 @@ persist to the EventStore — intended behaviour. It is a **prod behaviour chang
 
 ## 6. Coverage snapshot (updated 2026-06-08)
 
-- Real timeline/dashboard linkage: the **clinical spine** + 16 leaf domains wired
+- Real timeline/dashboard linkage: the **clinical spine** + 17 leaf domains wired
   since 2026-06-05 via native pre-compile hooks (W977 safety · W979 waitlist ·
   W980 screenings · W981 MAR · W982 beneficiary-status · W984 complaints ·
   W985 family-visits · W986 transitions · W987 post-rehab follow-up cases ·
   W992 follow-up visits · W994 insurance claims · W997 referrals (4 subsystems) ·
-  W1002 consent (PDPL/CRPD) · W1003 home programs — all merged to main). All
-  shape-guarded by W998.
+  W1002 consent (PDPL/CRPD) · W1003 home programs · W1004 acute crises — all
+  merged to main). All shape-guarded by W998.
 - + 21 LIVE-registry mappings, **wired but dormant behind the flag**.
 - ≈ **460 route files** still operate as standalone CRUD with no core emission.
 - The frozen V4 `services/core` is **not** consumed by the live UI and is out of


### PR DESCRIPTION
feat(crisis): W1004 wire acute crisis incidents onto the unified-core timeline

An acute CrisisIncident (behavioral / psychiatric / medical / safeguarding /
environmental crisis with its own active→resolved/closed lifecycle) is distinct
from the W977 safety events (seizure/safeguarding/restraint) and the W970 behavior
incident — it warrants its own reported/resolved timeline entry that a care team
can see and act on. A crisis REPORTED (warning) and RESOLVED/closed (success) now
appear on the beneficiary timeline.

Producer: native pre-compile hooks in models/CrisisIncident.js. post('init')
captures prevStatus; post('save', function(doc)) fires crisis.reported on create
(detected via post('init') not having run — CrisisIncident is always created as a
fresh instance and mutated via a hydrated one) / crisis.resolved on the
→resolved|closed transition. W954-SAFE signatures (post(doc) / 0-param) — coexist
with the model's existing async 0-param pre('save') resolvedAt/closedAt setter
(different event, no hook-style clash).

- CRISIS_EVENTS contract group (crisis.reported [HIGH, +ai-recommendations],
  crisis.resolved [normal]) + aggregator + export
- W374 guard: crisis domain + 'crisis' prefix + CRISIS_EVENTS export
- CareTimeline enum: new 'crisis_reported' + 'crisis_resolved' (Safety section)
- 2 subscribers -> CareTimeline rows (clinical; reported=warning with the clinical
  crisisType+crisisSeverity in metadata, resolved=success)
- Runtime e2e test (3 assertions): report -> warning row, resolve -> success row,
  a non-terminal transition (active→escalated) -> no resolved row; real Mongo +
  real bus + real subscribers
- Ledger: Acute-crises row (Tier-1 safety) + spine list + snapshot (17 leaf domains)

Guards green: W374/W375/W389/W392 + W998 shape-guard + hook-style + sprint hygiene.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
