### PR TITLE
refactor(mongoose): W956 — 4 model hooks async + close gate-4 callback blind spot

### DIFF
--- a/backend/models/ClinicalPathwayPlan.js
+++ b/backend/models/ClinicalPathwayPlan.js
@@ -74,11 +74,11 @@ const clinicalPathwayPlanSchema = new mongoose.Schema(
 clinicalPathwayPlanSchema.index({ branchId: 1, status: 1, createdAt: -1 });
 clinicalPathwayPlanSchema.index({ beneficiaryId: 1, pathwayType: 1, status: 1 });
 
-clinicalPathwayPlanSchema.pre('validate', function validateInvariants(next) {
+// W956 — async (Mongoose-9 native); no longer depends on the legacy-hook shim.
+clinicalPathwayPlanSchema.pre('validate', async function validateInvariants() {
   if (this.targetEndDate && this.startDate && this.targetEndDate < this.startDate) {
     this.invalidate('targetEndDate', 'targetEndDate must be greater than or equal to startDate');
   }
-  next();
 });
 
 module.exports =

--- a/backend/models/SchedulerHealthSnapshot.js
+++ b/backend/models/SchedulerHealthSnapshot.js
@@ -27,9 +27,9 @@ const SchedulerHealthSnapshotSchema = new mongoose.Schema(
   { collection: 'scheduler_health_snapshots' }
 );
 
-SchedulerHealthSnapshotSchema.pre('save', function preSave(next) {
+// W956 — async (Mongoose-9 native); no longer depends on the legacy-hook shim.
+SchedulerHealthSnapshotSchema.pre('save', async function preSave() {
   this.updatedAt = new Date();
-  next();
 });
 
 module.exports =

--- a/backend/models/SelfAdvocacyTrainingPlan.js
+++ b/backend/models/SelfAdvocacyTrainingPlan.js
@@ -98,7 +98,9 @@ SelfAdvocacyTrainingPlanSchema.index({ branchId: 1, status: 1 });
 SelfAdvocacyTrainingPlanSchema.index({ beneficiaryId: 1, status: 1 });
 
 // W462 Wave-18 invariants
-SelfAdvocacyTrainingPlanSchema.pre('save', function (next) {
+// W956 — async (Mongoose-9 native); a throw rejects the save exactly as
+// next(err) did. No longer depends on the legacy-hook shim.
+SelfAdvocacyTrainingPlanSchema.pre('save', async function () {
   // Refresh completion percentage via lib
   const curriculum = require('../intelligence/self-advocacy-curriculum.lib');
   const completedCodes = (this.modules || [])
@@ -115,15 +117,11 @@ SelfAdvocacyTrainingPlanSchema.pre('save', function (next) {
   // skipped status requires skipReason
   for (const m of this.modules || []) {
     if (m.status === 'skipped' && (!m.skipReason || m.skipReason.trim().length < 5)) {
-      return next(
-        new Error(
-          `SelfAdvocacyTrainingPlan: module '${m.rightCode}' marked skipped requires skipReason (≥5 chars)`
-        )
+      throw new Error(
+        `SelfAdvocacyTrainingPlan: module '${m.rightCode}' marked skipped requires skipReason (≥5 chars)`
       );
     }
   }
-
-  next();
 });
 
 module.exports =

--- a/backend/models/WhatsAppDlq.js
+++ b/backend/models/WhatsAppDlq.js
@@ -83,9 +83,9 @@ const WhatsAppDlqSchema = new mongoose.Schema(
   { collection: 'whatsapp_dlq' }
 );
 
-WhatsAppDlqSchema.pre('save', function preSave(next) {
+// W956 — async (Mongoose-9 native); no longer depends on the legacy-hook shim.
+WhatsAppDlqSchema.pre('save', async function preSave() {
   this.updatedAt = new Date();
-  next();
 });
 
 WhatsAppDlqSchema.index({ status: 1, nextRetryAt: 1 });

--- a/backend/scripts/check-mongoose-hook-style.js
+++ b/backend/scripts/check-mongoose-hook-style.js
@@ -60,8 +60,17 @@ const SKIP_DIR_NAMES = new Set([
 // Match `<Schema>.pre('event', <opts?>, <fn>)` or .post(...). Capture
 // event name + signature start. We need to read forward to see whether
 // the function is `async function` / `function (next)` / arrow.
+//
+// W956 — closed two blind spots that hid the W946/W954 callback class:
+//   (a) `\w*(?:Schema|schema)` (was `\w+…`) now matches a BARE `schema` /
+//       `Schema` var (the universal plugin-function param name), not just
+//       `fooSchema`. A bare 6-char `schema` failed the old `\w+…` (needed ≥7).
+//   (b) `function\s*\w*\s*\(` (was `function\s*\(`) now matches a NAMED
+//       function expression — `function preSave(next)` — not just anonymous.
+// Residual (not yet covered): array-event hooks `pre(['a','b'], fn)` still need
+// a string event literal here, so they remain invisible — documented follow-up.
 const HOOK_RE =
-  /(\w+(?:Schema|schema))\s*\.\s*(pre|post)\s*\(\s*['"]([a-zA-Z]+)['"]\s*(?:,\s*\{[^}]*\}\s*)?,\s*(async\s+)?function\s*\(([^)]*)\)/g;
+  /(\w*(?:Schema|schema))\s*\.\s*(pre|post)\s*\(\s*['"]([a-zA-Z]+)['"]\s*(?:,\s*\{[^}]*\}\s*)?,\s*(async\s+)?function\s*\w*\s*\(([^)]*)\)/g;
 
 // W494 baseline (2026-05-27): files with at least one pure callback-
 // style pre/post hook. Under Mongoose 9, EVERY callback hook throws
@@ -86,6 +95,16 @@ const KNOWN_CALLBACK_HOOK_BASELINE = new Set([
   // `typeof next === 'function'`, so they are Mongoose-9-safe). All real
   // callback hooks (async+next W946, sync W948, next(arg) W949) are converted.
   "models/auditLog.model.js",
+  // W956 — surfaced ONLY after the regex was tightened to catch bare-`Schema`
+  // vars + named function expressions (these were invisible to the old regex,
+  // so they were never in the baseline). Both are in the parallel agent's
+  // active core-linkage hot-zone (modelEventBridge had commits this session;
+  // FamilyHomeProgram was edited ~26 min before W956), so converting them now
+  // would collide. They WORK today via the (now-correct, W954) shim; ratchet
+  // each to `async function () {}` + prune from this set once the hot-zone
+  // settles. The W955 global plugins + 4 W956 model files are already converted.
+  "integration/modelEventBridge.js",
+  "models/FamilyHomeProgram.js",
 ]);
 
 function listSchemaFiles(roots) {


### PR DESCRIPTION
## إتمام قوس W954/W955 (إزالة التدلّي من الشيم)

حوّلتُ الخطّافات الأربعة الآمنة المتبقّية `pre(..., function(next))` في النماذج إلى async (صيغة W948): ClinicalPathwayPlan · SchedulerHealthSnapshot · SelfAdvocacyTrainingPlan (حارس skipReason يرمي الآن = next(err)) · WhatsAppDlq. لم تعد تعتمد على الشيم.

كما أغلقتُ **نقطتين عمياوين** في `check-mongoose-hook-style.js` (بوّابة 4) كانتا تُخفيان فئة W946/W954 بأكملها:
- `\w+(?:Schema|schema)` → `\w*(?:…)`: المتغيّر المجرّد `schema`/`Schema` (6 أحرف) كان يفشل في `\w+` (يحتاج ≥7). الآن يُطابَق.
- `function\s*\(` → `function\s*\w*\s*\(`: التعابير الدالّية المُسمّاة (`function preSave(next)`) تُطابَق الآن.

بعد التشديد، تكشف البوّابة **ملفّين فقط** بنمط callback — `modelEventBridge.js` + `FamilyHomeProgram.js` — كلاهما منطقة core-linkage الساخنة للوكيل المُوازي (تعديلات هذه الجلسة / قبل ~26 دقيقة)، فالتحويل الآن يتصادم. أُضيفا للـbaseline مع ملاحظة تأجيل (يعملان عبر شيم W954 الصحيح، ويُحوّلان حين تهدأ المنطقة). متبقٍّ غير مُغطّى: خطّافات الأحداث المصفوفية `pre(['a','b'], fn)`.

### التحقّق
node --check نظيف · `check:hook-style` أخضر (baseline متزامن، 3 ملفّات) · اختبار البوّابة الذاتي أخضر (23) · **56 اختباراً أخضر** (clinical-pathway-routes + self-advocacy behavioral/routes يُمرّن مسار throw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)