### PR TITLE
feat(careteam): W1005 wire care-team composition onto the unified-core timeline

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1276,6 +1276,8 @@ on:
       - 'backend/__tests__/home-program-core-linkage-wave1003.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/crisis-core-linkage-wave1004.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/careteam-core-linkage-wave1005.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2535,6 +2537,8 @@ on:
       - 'backend/__tests__/home-program-core-linkage-wave1003.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/crisis-core-linkage-wave1004.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/careteam-core-linkage-wave1005.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/careteam-core-linkage-wave1005.test.js
+++ b/backend/__tests__/careteam-core-linkage-wave1005.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+/**
+ * careteam-core-linkage-wave1005.test.js — W1005.
+ *
+ * Wires care-team composition onto the unified-core timeline. Care-team
+ * membership is an EMBEDDED `careTeam[]` array (+ `leadTherapistId`) inside
+ * EpisodeOfCare, so the producer DIFFS a post('init') snapshot vs the saved
+ * state. Fills the long-declared-but-producerless `team_member_added` /
+ * `team_member_removed` / `lead_changed` CareTimeline enum values. RUNTIME
+ * end-to-end against real in-memory Mongo + the real integration bus + real
+ * subscribers. Creation is skipped (episode.created covers the initial team).
+ *
+ * NOTE: `addTeamMember`/`removeTeamMember` are model methods that already
+ * `return this.save()` — `await` them (do NOT call save() again, or Mongoose
+ * throws ParallelSaveError).
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let EpisodeOfCare, CareTimeline;
+
+async function waitForTimeline(query, { timeout = 4000, interval = 25 } = {}) {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const row = await CareTimeline.findOne(query);
+    if (row) return row;
+    if (Date.now() - start > timeout) return null;
+    await new Promise(r => setTimeout(r, interval));
+  }
+}
+
+function newEpisode(extra = {}) {
+  return EpisodeOfCare.create({
+    beneficiaryId: new mongoose.Types.ObjectId(),
+    startDate: new Date(),
+    ...extra,
+  });
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w1005-careteam' } });
+  await mongoose.connect(mongod.getUri());
+  ({ EpisodeOfCare } = require('../domains/episodes/models/EpisodeOfCare'));
+  ({ CareTimeline } = require('../domains/timeline/models/CareTimeline'));
+  require('../models/Beneficiary');
+  const { integrationBus } = require('../integration/systemIntegrationBus');
+  const { initializeDDDSubscribers } = require('../integration/dddCrossModuleSubscribers');
+  initializeDDDSubscribers(integrationBus);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+afterEach(async () => {
+  await Promise.all([EpisodeOfCare.deleteMany({}), CareTimeline.deleteMany({})]);
+});
+
+describe('W1005 — care-team changes reach the unified-core timeline', () => {
+  it('creating an episode emits no care-team row; adding a member → team_member_added', async () => {
+    const ep = await newEpisode();
+    await new Promise(r => setTimeout(r, 150));
+    expect(await CareTimeline.countDocuments({ beneficiaryId: ep.beneficiaryId })).toBe(0);
+
+    const loaded = await EpisodeOfCare.findById(ep._id);
+    await loaded.addTeamMember({ userId: new mongoose.Types.ObjectId(), role: 'speech_therapist' });
+    const tl = await waitForTimeline({
+      beneficiaryId: ep.beneficiaryId,
+      eventType: 'team_member_added',
+    });
+    expect(tl).toBeTruthy();
+    expect(tl.category).toBe('clinical');
+  });
+
+  it('removing a member → team_member_removed', async () => {
+    const uid = new mongoose.Types.ObjectId();
+    const ep = await newEpisode();
+    let loaded = await EpisodeOfCare.findById(ep._id);
+    await loaded.addTeamMember({ userId: uid, role: 'psychologist' });
+    await waitForTimeline({ beneficiaryId: ep.beneficiaryId, eventType: 'team_member_added' });
+
+    loaded = await EpisodeOfCare.findById(ep._id);
+    await loaded.removeTeamMember(uid);
+    const tl = await waitForTimeline({
+      beneficiaryId: ep.beneficiaryId,
+      eventType: 'team_member_removed',
+    });
+    expect(tl).toBeTruthy();
+  });
+
+  it('changing the lead therapist → lead_changed', async () => {
+    const ep = await newEpisode();
+    const loaded = await EpisodeOfCare.findById(ep._id);
+    loaded.leadTherapistId = new mongoose.Types.ObjectId();
+    await loaded.save();
+    const tl = await waitForTimeline({
+      beneficiaryId: ep.beneficiaryId,
+      eventType: 'lead_changed',
+    });
+    expect(tl).toBeTruthy();
+    expect(tl.severity).toBe('info');
+  });
+});

--- a/backend/__tests__/ddd-event-contracts-wave374.test.js
+++ b/backend/__tests__/ddd-event-contracts-wave374.test.js
@@ -75,6 +75,7 @@ const EXPECTED_DOMAIN_GROUPS = Object.freeze([
   'consent', // W1002 — consent obtained / revoked (PDPL/CRPD) → core timeline
   'home_program', // W1003 — home program assigned / completed → core timeline
   'crisis', // W1004 — acute crisis reported / resolved → core timeline
+  'careteam', // W1005 — care-team member added/removed + lead changed → core timeline
 ]);
 
 // Allowed `eventType` prefixes. Most match W354 TIER domain names; a few are
@@ -124,6 +125,7 @@ const ALLOWED_EVENT_PREFIXES = Object.freeze(
     'consent', // W1002
     'home_program', // W1003
     'crisis', // W1004
+    'careteam', // W1005
   ])
 );
 
@@ -181,6 +183,7 @@ describe('W374 DDD event-contracts drift guard', () => {
         consent: 'CONSENT_EVENTS', // W1002
         home_program: 'HOME_PROGRAM_EVENTS', // W1003
         crisis: 'CRISIS_EVENTS', // W1004
+        careteam: 'CARETEAM_EVENTS', // W1005
       };
       for (const [group, exportName] of Object.entries(groupExportMap)) {
         expect(contracts[exportName]).toBe(contracts.DDD_CONTRACTS[group]);

--- a/backend/domains/episodes/models/EpisodeOfCare.js
+++ b/backend/domains/episodes/models/EpisodeOfCare.js
@@ -588,6 +588,54 @@ episodeOfCareSchema.statics.getStatistics = async function (branchId) {
   };
 };
 
+// W1005 — surface care-team composition on the unified-core timeline. Care-team
+// membership is an EMBEDDED `careTeam[]` array (+ a denormalized `leadTherapistId`)
+// — so a model-level post-save hook can't see a single sub-doc change; instead it
+// DIFFS a post('init') snapshot vs the saved state. Fills the long-declared but
+// producerless `team_member_added` / `team_member_removed` / `lead_changed`
+// CareTimeline enum values. Native pre-compile W954-safe hooks (post(doc) /
+// 0-param) — coexist with the existing async 0-param pre('save'). Creation is
+// skipped (the `episodes.episode.created` event already covers the initial team);
+// only subsequent /team mutations emit.
+episodeOfCareSchema.post('init', function () {
+  this.$__prevTeam = (this.careTeam || []).filter(m => m.isActive).map(m => String(m.userId));
+  this.$__prevLead = this.leadTherapistId ? String(this.leadTherapistId) : null;
+});
+episodeOfCareSchema.post('save', function (doc) {
+  try {
+    if (doc.$__prevTeam === undefined) return; // create — episode.created covers it
+    const { integrationBus } = require('../../../integration/systemIntegrationBus');
+    if (!integrationBus || typeof integrationBus.publish !== 'function') return;
+    if (!doc.beneficiaryId) return;
+    const base = { episodeId: String(doc._id), beneficiaryId: String(doc.beneficiaryId) };
+    const prevSet = new Set(doc.$__prevTeam);
+    const cur = (doc.careTeam || []).filter(m => m.isActive).map(m => String(m.userId));
+    const curSet = new Set(cur);
+    for (const uid of cur) {
+      if (!prevSet.has(uid)) {
+        Promise.resolve(
+          integrationBus.publish('careteam', 'careteam.member_added', { ...base, userId: uid })
+        ).catch(() => {});
+      }
+    }
+    for (const uid of doc.$__prevTeam) {
+      if (!curSet.has(uid)) {
+        Promise.resolve(
+          integrationBus.publish('careteam', 'careteam.member_removed', { ...base, userId: uid })
+        ).catch(() => {});
+      }
+    }
+    const curLead = doc.leadTherapistId ? String(doc.leadTherapistId) : null;
+    if (curLead && curLead !== doc.$__prevLead) {
+      Promise.resolve(
+        integrationBus.publish('careteam', 'careteam.lead_changed', { ...base, userId: curLead })
+      ).catch(() => {});
+    }
+  } catch (_) {
+    /* bus not wired — never block persistence */
+  }
+});
+
 // ─── Export ──────────────────────────────────────────────────────────────────
 
 const EpisodeOfCare =

--- a/backend/events/contracts/dddEventContracts.js
+++ b/backend/events/contracts/dddEventContracts.js
@@ -1126,6 +1126,61 @@ const CRISIS_EVENTS = {
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
+//  Care-team Events — أحداث فريق الرعاية (W1005)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Who is responsible for the beneficiary's care: a team member added / removed
+// and a lead/primary-therapist change. Producer: native EpisodeOfCare post-save
+// hook (diffs the embedded `careTeam[]` array snapshot).
+
+const CARETEAM_EVENTS = {
+  MEMBER_ADDED: {
+    domain: 'careteam',
+    eventType: 'careteam.member_added',
+    version: 1,
+    description: 'إضافة عضو لفريق الرعاية — Care-team member added',
+    payload: {
+      episodeId: 'string',
+      beneficiaryId: 'string',
+      userId: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards'],
+  },
+
+  MEMBER_REMOVED: {
+    domain: 'careteam',
+    eventType: 'careteam.member_removed',
+    version: 1,
+    description: 'إزالة عضو من فريق الرعاية — Care-team member removed',
+    payload: {
+      episodeId: 'string',
+      beneficiaryId: 'string',
+      userId: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards'],
+  },
+
+  LEAD_CHANGED: {
+    domain: 'careteam',
+    eventType: 'careteam.lead_changed',
+    version: 1,
+    description: 'تغيير المعالج الرئيسي — Lead/primary therapist changed',
+    payload: {
+      episodeId: 'string',
+      beneficiaryId: 'string',
+      userId: 'string',
+    },
+    delivery: [DELIVERY.PERSIST, DELIVERY.BROADCAST, DELIVERY.REALTIME, DELIVERY.LOCAL],
+    priority: PRIORITY.NORMAL,
+    consumers: ['timeline', 'dashboards'],
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
 //  Aggregated Contracts Registry
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -1153,6 +1208,7 @@ const DDD_CONTRACTS = {
   consent: CONSENT_EVENTS,
   home_program: HOME_PROGRAM_EVENTS,
   crisis: CRISIS_EVENTS,
+  careteam: CARETEAM_EVENTS,
 };
 
 /**
@@ -1193,6 +1249,7 @@ module.exports = {
   CONSENT_EVENTS,
   HOME_PROGRAM_EVENTS,
   CRISIS_EVENTS,
+  CARETEAM_EVENTS,
   DDD_CONTRACTS,
   getDDDContractStats,
 };

--- a/backend/integration/dddCrossModuleSubscribers.js
+++ b/backend/integration/dddCrossModuleSubscribers.js
@@ -1542,6 +1542,84 @@ function initializeDDDSubscribers(integrationBus, _moduleConnector) {
     },
   });
 
+  // ─── Care-team → Timeline: member added (W1005) ───────────────────
+  subscribers.push({
+    name: 'careteam:member_added → timeline:record',
+    pattern: 'careteam.careteam.member_added',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            episodeId: event.payload.episodeId,
+            eventType: 'team_member_added',
+            category: 'clinical',
+            severity: 'info',
+            title: 'Care-team member added',
+            title_ar: 'إضافة عضو لفريق الرعاية',
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Careteam-member-added timeline failed: ${err.message}`);
+      }
+    },
+  });
+
+  // ─── Care-team → Timeline: member removed (W1005) ─────────────────
+  subscribers.push({
+    name: 'careteam:member_removed → timeline:record',
+    pattern: 'careteam.careteam.member_removed',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            episodeId: event.payload.episodeId,
+            eventType: 'team_member_removed',
+            category: 'clinical',
+            severity: 'info',
+            title: 'Care-team member removed',
+            title_ar: 'إزالة عضو من فريق الرعاية',
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Careteam-member-removed timeline failed: ${err.message}`);
+      }
+    },
+  });
+
+  // ─── Care-team → Timeline: lead changed (W1005) ───────────────────
+  subscribers.push({
+    name: 'careteam:lead_changed → timeline:record',
+    pattern: 'careteam.careteam.lead_changed',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            episodeId: event.payload.episodeId,
+            eventType: 'lead_changed',
+            category: 'clinical',
+            severity: 'info',
+            title: 'Lead therapist changed',
+            title_ar: 'تغيير المعالج الرئيسي',
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] Careteam-lead-changed timeline failed: ${err.message}`);
+      }
+    },
+  });
+
   // ── Register all subscribers ───────────────────────────────────────
   let registered = 0;
   for (const sub of subscribers) {

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -747,5 +747,6 @@ __tests__/core-timeline-subscriber-shape-wave998.test.js
 __tests__/consent-core-linkage-wave1002.test.js
 __tests__/home-program-core-linkage-wave1003.test.js
 __tests__/crisis-core-linkage-wave1004.test.js
+__tests__/careteam-core-linkage-wave1005.test.js
 __tests__/legacy-hook-adapter-wave954.test.js
 __tests__/legacy-hook-no-hang-behavioral-wave954.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -58,6 +58,7 @@ Per-beneficiary timeline + dashboards react in real time to:
 - **Consent (PDPL/CRPD)** — obtained / revoked (W1002)
 - **Home programs** — assigned / completed across FamilyHomeProgram + HomeAssignment (W1003)
 - **Acute crises** — reported / resolved (W1004)
+- **Care team** — member added / removed + lead changed (W1005)
 - **(env-gated, W974)** HR (hire/terminate/leave/salary/transfer), Finance
   (invoice/payment/expense/payroll), Medical (record/therapy/prescription/risk),
   Attendance (check-in/out), Notification (delivery_failed)
@@ -119,6 +120,7 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 | Follow-up cases | `PostRehabCase` | `followup.case.completed` / `.lost` → `followup_completed` / `followup_lost` | ✅ **W987** |
 | Follow-up visits | `FollowUpVisit` | `followup.visit.attended` / `.missed` → `followup_visit` | ✅ **W992** |
 | Home programs | `FamilyHomeProgram` · `HomeAssignment` | `home_program.assigned` / `.completed` → `home_program_assigned` / `home_program_completed` (shared domain, `programType` discriminator) | ✅ **W1003** — filled the long-declared but producerless `home_program_assigned` enum |
+| Care team | `EpisodeOfCare.careTeam[]` (embedded) | `careteam.member_added` / `.member_removed` / `.lead_changed` → `team_member_added` / `team_member_removed` / `lead_changed` | ✅ **W1005** — embedded-array DIFF (post-init snapshot vs save); filled 3 producerless enum values |
 
 ### Tier 2 — family / CRM visibility
 | Domain | Model | Event | Status |
@@ -157,13 +159,13 @@ persist to the EventStore — intended behaviour. It is a **prod behaviour chang
 
 ## 6. Coverage snapshot (updated 2026-06-08)
 
-- Real timeline/dashboard linkage: the **clinical spine** + 17 leaf domains wired
+- Real timeline/dashboard linkage: the **clinical spine** + 18 leaf domains wired
   since 2026-06-05 via native pre-compile hooks (W977 safety · W979 waitlist ·
   W980 screenings · W981 MAR · W982 beneficiary-status · W984 complaints ·
   W985 family-visits · W986 transitions · W987 post-rehab follow-up cases ·
   W992 follow-up visits · W994 insurance claims · W997 referrals (4 subsystems) ·
-  W1002 consent (PDPL/CRPD) · W1003 home programs · W1004 acute crises — all
-  merged to main). All shape-guarded by W998.
+  W1002 consent (PDPL/CRPD) · W1003 home programs · W1004 acute crises ·
+  W1005 care-team — all merged to main). All shape-guarded by W998.
 - + 21 LIVE-registry mappings, **wired but dormant behind the flag**.
 - ≈ **460 route files** still operate as standalone CRUD with no core emission.
 - The frozen V4 `services/core` is **not** consumed by the live UI and is out of


### PR DESCRIPTION
feat(careteam): W1005 wire care-team composition onto the unified-core timeline

Fills the LAST set of producerless CareTimeline enum values: team_member_added,
team_member_removed, lead_changed have existed for ages with no producer. Who is
responsible for a beneficiary's care (a team member added/removed, the lead/primary
therapist changed) now appears on their timeline.

Care-team membership is an EMBEDDED `careTeam[]` array (+ a denormalized
`leadTherapistId`) inside EpisodeOfCare — there is no standalone model — so a
model-level post-save hook can't see a single sub-doc change. The producer instead
DIFFS a post('init') snapshot (active userIds + leadTherapistId) vs the saved
state in post('save'), emitting careteam.member_added/.member_removed per delta and
.lead_changed on a lead change. Creation is skipped (episodes.episode.created
already covers the initial team); only subsequent /team mutations emit.

W954-SAFE signatures (post(doc) / 0-param post(init)) — coexist with the model's
existing async 0-param pre('save') (different event). No new CareTimeline enum
values needed (the 3 already existed — this is the producer they were waiting for).

- CARETEAM_EVENTS contract group (member_added/member_removed/lead_changed) +
  aggregator (key `careteam` = domain) + export
- W374 guard: careteam domain + 'careteam' prefix + CARETEAM_EVENTS export
- 3 subscribers -> CareTimeline rows (clinical, info), reusing the existing
  team_member_added / team_member_removed / lead_changed enum values
- Runtime e2e test (3 assertions): add → team_member_added, remove →
  team_member_removed, lead change → lead_changed; real Mongo + real bus + real
  subscribers. GOTCHA recorded: addTeamMember/removeTeamMember already
  `return this.save()` internally — await the method, never call save() again
  (else Mongoose ParallelSaveError on the versioned careTeam subdoc array).
- Ledger: Care-team row (Tier-1) + spine list + snapshot (18 leaf domains)

Guards green: W374/W375/W389/W392 + W998 shape-guard + hook-style + sprint hygiene.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
