### PR TITLE
fix(security): W959 — close remaining cross-branch leaks across reports-analytics handlers

### DIFF
--- a/backend/routes/reports-analytics-module.routes.js
+++ b/backend/routes/reports-analytics-module.routes.js
@@ -523,7 +523,9 @@ router.get('/analytics/executive', authenticate, requireBranchAccess, async (req
     const monthlyRegistrations = await db
       .collection('beneficiaries')
       .aggregate([
-        { $match: { deleted_at: null, createdAt: { $gte: sixMonthsAgo } } },
+        // W959 — was raw `{ deleted_at: null }` (cross-branch leak); reuse the
+        // handler's own branch-scoped buildMatch (beneficiaries carries branch_id).
+        { $match: buildMatch({ createdAt: { $gte: sixMonthsAgo } }) },
         {
           $group: {
             _id: {
@@ -547,7 +549,7 @@ router.get('/analytics/executive', authenticate, requireBranchAccess, async (req
     const revenueAgg = await db
       .collection('invoices')
       .aggregate([
-        { $match: { deleted_at: null, status: 'paid' } },
+        { $match: buildMatch({ status: 'paid' }) }, // W959 branch-scope (was raw leak)
         { $group: { _id: null, total: { $sum: '$total_amount' } } },
       ])
       .toArray();
@@ -734,7 +736,7 @@ router.get('/analytics/clinical', authenticate, requireBranchAccess, async (req,
       db
         .collection('rehab_goals')
         .aggregate([
-          { $match: { deleted_at: null } },
+          { $match: matchBase }, // W959 branch-scope (was raw leak; reuse handler matchBase)
           {
             $group: {
               _id: '$status',
@@ -960,6 +962,11 @@ router.get('/analytics/hr', authenticate, requireBranchAccess, async (req, res) 
     const matchHR = { deleted_at: null, is_active: true };
     applyRawBranchScope(matchHR, req, branch_id);
 
+    // W959 — branch-only scope (no is_active) for leave_requests / attendance_records,
+    // which previously matched raw `{ deleted_at: null }` and leaked across branches.
+    const hrBranchOnly = {};
+    applyRawBranchScope(hrBranchOnly, req, branch_id);
+
     const [
       headcountByDept,
       headcountByNationality,
@@ -986,14 +993,14 @@ router.get('/analytics/hr', authenticate, requireBranchAccess, async (req, res) 
       // الإجازات حسب النوع
       db
         .collection('leave_requests')
-        .aggregate([{ $match: { deleted_at: null } }, ...groupByField('leave_type')])
+        .aggregate([{ $match: { ...hrBranchOnly, deleted_at: null } }, ...groupByField('leave_type')]) // W959 branch-scope
         .toArray(),
 
       // متوسط نسبة الحضور
       db
         .collection('attendance_records')
         .aggregate([
-          { $match: { deleted_at: null } },
+          { $match: { ...hrBranchOnly, deleted_at: null } }, // W959 branch-scope (was raw leak)
           {
             $group: {
               _id: '$employee_id',
@@ -1189,7 +1196,7 @@ router.get('/analytics/quality', authenticate, requireBranchAccess, async (req, 
       db
         .collection('quality_measurements')
         .aggregate([
-          { $match: { deleted_at: null } },
+          { $match: matchBase }, // W959 branch-scope (was raw leak; reuse handler matchBase)
           { $sort: { measurement_date: -1 } },
           {
             $group: {
@@ -1632,6 +1639,10 @@ router.get('/built-in/financial-summary', authenticate, requireBranchAccess, asy
     }
     applyRawBranchScope(matchInv, req, branch_id);
 
+    // W959 — finance_payments + expenses carry no branch field (see W958); gate the
+    // cross-branch breakdowns to HQ callers, [] for a restricted caller (fail-closed).
+    const hqOnly = effectiveBranchScope(req) == null;
+
     const [invoices, payments, expenses] = await Promise.all([
       db
         .collection('invoices')
@@ -1657,37 +1668,41 @@ router.get('/built-in/financial-summary', authenticate, requireBranchAccess, asy
         ])
         .toArray(),
 
-      db
-        .collection('finance_payments')
-        .aggregate([
-          { $match: { deleted_at: null } },
-          {
-            $group: {
-              _id: '$payment_method',
-              total: { $sum: '$amount' },
-              count: { $sum: 1 },
-            },
-          },
-          {
-            $project: {
-              _id: 0,
-              method: '$_id',
-              total: { $round: ['$total', 2] },
-              count: 1,
-            },
-          },
-        ])
-        .toArray(),
+      hqOnly // W959 — unscopable (no branch field); HQ-only, [] for restricted
+        ? db
+            .collection('finance_payments')
+            .aggregate([
+              { $match: { deleted_at: null } },
+              {
+                $group: {
+                  _id: '$payment_method',
+                  total: { $sum: '$amount' },
+                  count: { $sum: 1 },
+                },
+              },
+              {
+                $project: {
+                  _id: 0,
+                  method: '$_id',
+                  total: { $round: ['$total', 2] },
+                  count: 1,
+                },
+              },
+            ])
+            .toArray()
+        : Promise.resolve([]),
 
-      db
-        .collection('expenses')
-        .aggregate([
-          { $match: { deleted_at: null } },
-          { $group: { _id: '$category', total: { $sum: '$amount' }, count: { $sum: 1 } } },
-          { $project: { _id: 0, category: '$_id', total: { $round: ['$total', 2] }, count: 1 } },
-          { $sort: { total: -1 } },
-        ])
-        .toArray(),
+      hqOnly // W959 — unscopable (no branch field); HQ-only, [] for restricted
+        ? db
+            .collection('expenses')
+            .aggregate([
+              { $match: { deleted_at: null } },
+              { $group: { _id: '$category', total: { $sum: '$amount' }, count: { $sum: 1 } } },
+              { $project: { _id: 0, category: '$_id', total: { $round: ['$total', 2] }, count: 1 } },
+              { $sort: { total: -1 } },
+            ])
+            .toArray()
+        : Promise.resolve([]),
     ]);
 
     res.json({


### PR DESCRIPTION
## إتمام كنس reports-analytics (بعد W957/W958)

نفس النمط (match مُسكوب واحد + تجميعات شقيقة خام) تكرّر في 5 معالجات أخرى. كلٌّ أُصلح بسكوب معالجه المُثبَت (fail-closed-safe):

- **/analytics/executive**: beneficiaries (التسجيلات الشهرية) + invoices (الإيرادات) → `buildMatch()`
- **/analytics/clinical**: rehab_goals → `matchBase`
- **/analytics/hr**: leave_requests + attendance_records → `hrBranchOnly` جديد (matchHR فيه is_active لا ينطبق)
- **/analytics/quality**: quality_measurements → `matchBase`
- **/built-in/financial-summary**: finance_payments + expenses (بلا حقل فرع) → HQ-gate مثل W958

تُرِك بحقّ: `/stats` `ReportJob.aggregate` (تيليمتري نظام التقارير، ليس PII فرعياً). يبقى مُتتبَّعاً: تأكيد أن مجموعات التحليلات snake_case تُعبّئ branch_id فعلاً (وإلا fail-closed آمن).

### التحقّق
node --check نظيف · raw-branch-scope-c3a + wave944 أخضران (10؛ raw=68 ثابت، untenanted 767 تحت سقف 820) · كل تعديل يُعيد استخدام آليّة سكوب مُثبَتة على مجموعة شقيقة في نفس المعالج.

🤖 Generated with [Claude Code](https://claude.com/claude-code)