### PR TITLE
feat(alerts): W1006 first operational smart-alert rule — facility PPM/inspection overdue

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1303,6 +1303,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/infection-surveillance-wave1042.test.js'
       - 'backend/__tests__/infection-surveillance-behavioral-wave1042.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/facility-asset-overdue-rule-wave1006.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2589,6 +2591,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/infection-surveillance-wave1042.test.js'
       - 'backend/__tests__/infection-surveillance-behavioral-wave1042.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/facility-asset-overdue-rule-wave1006.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/alerts.engine.test.js
+++ b/backend/__tests__/alerts.engine.test.js
@@ -111,10 +111,10 @@ describe('buildEngine() with bundled rules', () => {
   // baseline of 5. Wave 5 (2026-05-16) added the EWMA anomaly
   // bridge. Pin the exact total so accidental rule removal shows
   // up as a test regression rather than a silent gap.
-  test('registers all 19 bundled rules (5 baseline + 13 wave-3 + 1 wave-5)', () => {
-    expect(rules.length).toBe(19);
+  test('registers all 20 bundled rules (5 baseline + 13 wave-3 + 1 wave-5 + 1 W1006 operational)', () => {
+    expect(rules.length).toBe(20);
     const eng = buildEngine();
-    expect(eng.rules.size).toBe(19);
+    expect(eng.rules.size).toBe(20);
   });
 
   test('credential-expiry-30d fires on near-expiry records', async () => {

--- a/backend/__tests__/facility-asset-overdue-rule-wave1006.test.js
+++ b/backend/__tests__/facility-asset-overdue-rule-wave1006.test.js
@@ -1,0 +1,125 @@
+/**
+ * W1006 — facility-asset-ppm-overdue smart-alert rule.
+ *
+ * The first `category: 'operational'` rule, extending the alerts engine from
+ * clinical/compliance/finance into facilities/ops. Verifies the predicate
+ * (maintenance OR inspection overdue on an in-service asset), the active-status
+ * filter, and the life-safety → critical severity escalation. Same fake-finder
+ * harness the other 19 rule tests use (no DB).
+ */
+
+'use strict';
+
+const { AlertsEngine } = require('../alerts');
+const rules = require('../alerts/rules');
+
+function finder(rows) {
+  return { find: async q => rows.filter(r => shallowMatch(r, q)) };
+}
+
+function shallowMatch(doc, q) {
+  return Object.entries(q).every(([k, v]) => {
+    const docVal = doc[k];
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      if ('$in' in v) return v.$in.includes(docVal);
+      if ('$nin' in v) return !v.$nin.includes(docVal);
+    }
+    return docVal === v;
+  });
+}
+
+function ruleById(id) {
+  const r = rules.find(x => x.id === id);
+  if (!r) throw new Error(`Rule ${id} not registered`);
+  return r;
+}
+
+async function runOne(models, now = new Date('2026-06-01')) {
+  const eng = new AlertsEngine({ now: () => now });
+  eng.register(ruleById('facility-asset-ppm-overdue'));
+  const result = await eng.runAll({ models, now });
+  return result.raised.filter(a => a.ruleId === 'facility-asset-ppm-overdue');
+}
+
+const PAST = new Date('2026-05-01');
+const FUTURE = new Date('2026-07-01');
+const BRANCH = '64b000000000000000000001';
+
+describe('facility-asset-ppm-overdue', () => {
+  test('is registered in the rules list with category=operational', () => {
+    const r = ruleById('facility-asset-ppm-overdue');
+    expect(r.category).toBe('operational');
+    expect(r.severity).toBe('high');
+  });
+
+  test('fires on an in-service asset with maintenance overdue; skips current ones', async () => {
+    const raised = await runOne({
+      FacilityAsset: finder([
+        {
+          _id: 'a1',
+          name: 'Hydrotherapy pump',
+          status: 'in_service',
+          branchId: BRANCH,
+          nextMaintenanceDue: PAST,
+          nextInspectionDue: FUTURE,
+          criticality: 'medium',
+        },
+        {
+          _id: 'a2',
+          name: 'Treadmill',
+          status: 'in_service',
+          nextMaintenanceDue: FUTURE,
+          nextInspectionDue: FUTURE,
+          criticality: 'low',
+        },
+      ]),
+    });
+    expect(raised).toHaveLength(1);
+    expect(raised[0].key).toBe('facility-asset-ppm-overdue:a1');
+    expect(raised[0].branchId).toBe(BRANCH);
+    expect(raised[0].category).toBe('operational');
+    expect(raised[0].severity).toBe('high');
+    expect(raised[0].message).toMatch(/maintenance/);
+  });
+
+  test('flags inspection overdue too (message names it)', async () => {
+    const raised = await runOne({
+      FacilityAsset: finder([
+        { _id: 'a3', name: 'Lift', status: 'in_service', nextInspectionDue: PAST, criticality: 'high' },
+      ]),
+    });
+    expect(raised).toHaveLength(1);
+    expect(raised[0].message).toMatch(/inspection/);
+  });
+
+  test('a life-safety asset overdue escalates to critical', async () => {
+    const raised = await runOne({
+      FacilityAsset: finder([
+        {
+          _id: 'a4',
+          name: 'Fire suppression',
+          status: 'in_service',
+          nextMaintenanceDue: PAST,
+          criticality: 'life_safety',
+        },
+      ]),
+    });
+    expect(raised).toHaveLength(1);
+    expect(raised[0].severity).toBe('critical');
+  });
+
+  test('retired / out-of-service assets are excluded even when overdue', async () => {
+    const raised = await runOne({
+      FacilityAsset: finder([
+        { _id: 'a5', status: 'retired', nextMaintenanceDue: PAST, criticality: 'high' },
+        { _id: 'a6', status: 'out_of_service', nextMaintenanceDue: PAST, criticality: 'high' },
+      ]),
+    });
+    expect(raised).toHaveLength(0);
+  });
+
+  test('no FacilityAsset model → defensive no-op', async () => {
+    const raised = await runOne({});
+    expect(raised).toHaveLength(0);
+  });
+});

--- a/backend/alerts/rules/facility-asset-ppm-overdue.js
+++ b/backend/alerts/rules/facility-asset-ppm-overdue.js
@@ -1,0 +1,56 @@
+/**
+ * Rule: facility asset preventive-maintenance (PPM) or regulatory inspection
+ * overdue.
+ *
+ * The first OPERATIONAL-category smart-alert rule (W1006) — it extends the
+ * alerts engine beyond clinical/compliance/finance into facilities/ops, feeding
+ * the same org-scoped `Alert` sink + `/api/v1/dashboards/alerts` dashboard the
+ * other 19 rules use. An asset whose `nextMaintenanceDue` or `nextInspectionDue`
+ * is in the past (and that is still in service) is surfaced to the ops team.
+ *
+ * Life-safety assets (fire suppression, medical gas, lifts, …) escalate the
+ * finding to `critical` — the engine spreads the per-finding fields over the
+ * rule defaults, so a `severity` on the finding overrides the rule's `high`.
+ *
+ * The DB query filters to active assets (cheap; status is indexed); the date
+ * comparison is done in JS so the predicate stays simple and the rule can flag
+ * maintenance + inspection in one pass.
+ */
+
+'use strict';
+
+const INACTIVE = ['retired', 'out_of_service'];
+
+module.exports = {
+  id: 'facility-asset-ppm-overdue',
+  severity: 'high',
+  category: 'operational',
+  description: 'Facility asset preventive maintenance or inspection overdue',
+
+  async evaluate(ctx) {
+    if (!ctx.models || !ctx.models.FacilityAsset) return [];
+    const now = ctx.now || new Date();
+    const rows = await ctx.models.FacilityAsset.find({
+      status: { $nin: INACTIVE },
+    });
+    const findings = [];
+    for (const a of rows) {
+      const maintOverdue = a.nextMaintenanceDue && new Date(a.nextMaintenanceDue) < now;
+      const inspOverdue = a.nextInspectionDue && new Date(a.nextInspectionDue) < now;
+      if (!maintOverdue && !inspOverdue) continue;
+      const which = [maintOverdue ? 'maintenance' : null, inspOverdue ? 'inspection' : null]
+        .filter(Boolean)
+        .join(' + ');
+      const finding = {
+        key: `facility-asset-ppm-overdue:${a._id}`,
+        subject: { type: 'FacilityAsset', id: a._id },
+        branchId: a.branchId,
+        message: `Facility asset ${a.name || a.assetTag || a._id} ${which} overdue`,
+      };
+      // Life-safety assets escalate the default `high` to `critical`.
+      if (a.criticality === 'life_safety') finding.severity = 'critical';
+      findings.push(finding);
+    }
+    return findings;
+  },
+};

--- a/backend/alerts/rules/index.js
+++ b/backend/alerts/rules/index.js
@@ -53,4 +53,10 @@ module.exports = [
   // no-op when the store isn't wired, so it's safe to ship now
   // and turn on later by registering the store in app.js.
   require('./kpi-anomaly-detected'),
+
+  // ── W1006 — operational / facilities (1) ────────────────────
+  // First `category: 'operational'` rule — facility PPM/inspection
+  // overdue. Needs `FacilityAsset` in the app.js model loader to fire
+  // (defensive no-op otherwise).
+  require('./facility-asset-ppm-overdue'),
 ];

--- a/backend/app.js
+++ b/backend/app.js
@@ -1469,6 +1469,7 @@ try {
       'Goal',
       'Vaccination',
       'EmploymentContract',
+      'FacilityAsset', // W1006 — operational PPM/inspection-overdue rule
     ];
     const liveModels = {};
     for (const name of modelNames) {

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -768,3 +768,4 @@ __tests__/medication-reconciliation-wave1041.test.js
 __tests__/medication-reconciliation-behavioral-wave1041.test.js
 __tests__/infection-surveillance-wave1042.test.js
 __tests__/infection-surveillance-behavioral-wave1042.test.js
+__tests__/facility-asset-overdue-rule-wave1006.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -134,8 +134,20 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 ### Tier 3 — operational / governance
 | Domain | Model | Event | Status |
 | --- | --- | --- | --- |
-| Insurance / NPHIES claims | `NphiesInsuranceClaim` | `insurance.claim.approved` / `.rejected` → `insurance_claim` | ✅ **W994** |
-| Inventory low-stock · maintenance overdue · contract/document expiry · transport incidents | — | — | Open — mostly **not** beneficiary-keyed, so they belong on dashboards/KPIs, not the per-beneficiary `CareTimeline` |
+| Insurance / NPHIES claims | `NphiesInsuranceClaim` | `insurance.claim.approved` / `.rejected` → `insurance_claim` | ✅ **W994** (per-beneficiary timeline) |
+| Facilities — PPM / inspection overdue | `FacilityAsset` | smart-alert **rule** `facility-asset-ppm-overdue` (category `operational`) → `Alert` | ✅ **W1006** — first operational rule; org-scoped, NOT the beneficiary timeline |
+| Inventory low-stock · contract/document expiry · transport incidents | — | (add a `category:'operational'` rule in `alerts/rules/`) | Open — **not** beneficiary-keyed → use the alerts rule-engine path below, not `CareTimeline` |
+
+> **Two sinks, by scope (the W1006 lesson):** beneficiary-keyed events feed the
+> per-beneficiary **`CareTimeline`** (native model hook → `integrationBus` →
+> `dddCrossModuleSubscribers`). **Org/operational** events (facilities, inventory,
+> finance thresholds, expiry) feed the org-scoped **`Alert`** model via the
+> **smart-alerts rule engine** (`alerts/rules/*` → `AlertDispatcher` tick →
+> `/api/v1/dashboards/alerts`). To add an operational signal: drop a
+> `{ id, severity, category:'operational', description, evaluate(ctx) }` rule in
+> `alerts/rules/`, `require` it in `alerts/rules/index.js`, and add its model to
+> the `modelNames` loader in `app.js` — no `CareTimeline` enum or DDD contract
+> needed. A finding may override the rule's `severity` (e.g. life-safety → critical).
 
 **Mechanism guidance:** prefer **native pre-compile model hooks (C)** for models
 created via many routes (path-agnostic, reliable). Use a **bridge MAPPING (A)**


### PR DESCRIPTION
feat(alerts): W1006 first OPERATIONAL smart-alert rule — facility PPM/inspection overdue

Extends the "linkage" program from the per-beneficiary CareTimeline into the
ORG/operational half: operational events (which are NOT beneficiary-keyed) feed
the org-scoped `Alert` model via the existing smart-alerts rule engine
(alerts/rules/* -> AlertDispatcher tick -> /api/v1/dashboards/alerts), the same
sink the other 19 clinical/compliance/finance rules use. This is the first
`category: 'operational'` rule.

Rule `facility-asset-ppm-overdue`: an in-service FacilityAsset whose
`nextMaintenanceDue` or `nextInspectionDue` is in the past is surfaced to the ops
team. DB query filters to active assets (status indexed, $nin retired/
out_of_service); the date comparison is in JS so one pass flags maintenance +
inspection. Life-safety assets escalate the default `high` to `critical` (the
engine spreads per-finding fields over the rule defaults, so a finding `severity`
overrides). Defensive no-op when `ctx.models.FacilityAsset` is absent.

- New rule `alerts/rules/facility-asset-ppm-overdue.js` + registered in
  `alerts/rules/index.js`
- `FacilityAsset` added to the `app.js` smart-alerts model loader (so the rule
  fires; without it the rule defensively yields [])
- Test (6 assertions, fake-finder harness like the other rule tests): fires on
  maintenance overdue, flags inspection overdue, life-safety→critical, excludes
  retired/out-of-service, no-op without the model, registered as operational
- Updated the engine's rule-count assertion 19 -> 20
- Ledger: documents the TWO sinks by scope (beneficiary→CareTimeline vs
  org/operational→Alert rule-engine) + the recipe to add an operational rule

NOTE: a pre-existing unrelated failure in alerts.engine.test.js
(`invoice-overdue-60d fires...` expects 1, gets 2) exists on origin/main
independent of this change (reproduced with this rule stashed) — a finance-rule
predicate drift, out of scope here. Neither alerts.engine.test.js nor
alerts.rules.wave3.test.js is in the sprint gate; the new rule test IS enumerated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
