### PR TITLE
feat(alerts): W1007 second operational smart-alert rule — maintenance work order overdue

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1305,6 +1305,8 @@ on:
       - 'backend/__tests__/infection-surveillance-behavioral-wave1042.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/facility-asset-overdue-rule-wave1006.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/maintenance-wo-overdue-rule-wave1007.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2593,6 +2595,8 @@ on:
       - 'backend/__tests__/infection-surveillance-behavioral-wave1042.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/facility-asset-overdue-rule-wave1006.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/maintenance-wo-overdue-rule-wave1007.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/alerts.engine.test.js
+++ b/backend/__tests__/alerts.engine.test.js
@@ -111,10 +111,10 @@ describe('buildEngine() with bundled rules', () => {
   // baseline of 5. Wave 5 (2026-05-16) added the EWMA anomaly
   // bridge. Pin the exact total so accidental rule removal shows
   // up as a test regression rather than a silent gap.
-  test('registers all 20 bundled rules (5 baseline + 13 wave-3 + 1 wave-5 + 1 W1006 operational)', () => {
-    expect(rules.length).toBe(20);
+  test('registers all 21 bundled rules (5 baseline + 13 wave-3 + 1 wave-5 + 2 operational W1006/W1007)', () => {
+    expect(rules.length).toBe(21);
     const eng = buildEngine();
-    expect(eng.rules.size).toBe(20);
+    expect(eng.rules.size).toBe(21);
   });
 
   test('credential-expiry-30d fires on near-expiry records', async () => {

--- a/backend/__tests__/maintenance-wo-overdue-rule-wave1007.test.js
+++ b/backend/__tests__/maintenance-wo-overdue-rule-wave1007.test.js
@@ -1,0 +1,87 @@
+/**
+ * W1007 — maintenance-work-order-overdue smart-alert rule.
+ *
+ * Second `category: 'operational'` rule (companion to W1006 facility-asset).
+ * Verifies the predicate (scheduledDate in the past, status still open), the
+ * excluded-state filter (draft + the terminals), and the critical-priority →
+ * critical severity escalation. Same fake-finder harness the other rule tests
+ * use (no DB).
+ */
+
+'use strict';
+
+const { AlertsEngine } = require('../alerts');
+const rules = require('../alerts/rules');
+
+function finder(rows) {
+  return { find: async q => rows.filter(r => shallowMatch(r, q)) };
+}
+
+function shallowMatch(doc, q) {
+  return Object.entries(q).every(([k, v]) => {
+    const docVal = doc[k];
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      if ('$in' in v) return v.$in.includes(docVal);
+      if ('$nin' in v) return !v.$nin.includes(docVal);
+    }
+    return docVal === v;
+  });
+}
+
+function ruleById(id) {
+  const r = rules.find(x => x.id === id);
+  if (!r) throw new Error(`Rule ${id} not registered`);
+  return r;
+}
+
+async function runOne(models, now = new Date('2026-06-01')) {
+  const eng = new AlertsEngine({ now: () => now });
+  eng.register(ruleById('maintenance-work-order-overdue'));
+  const result = await eng.runAll({ models, now });
+  return result.raised.filter(a => a.ruleId === 'maintenance-work-order-overdue');
+}
+
+const PAST = new Date('2026-05-01');
+const FUTURE = new Date('2026-07-01');
+const BRANCH = '64b000000000000000000002';
+
+describe('maintenance-work-order-overdue', () => {
+  test('is registered as an operational rule', () => {
+    const r = ruleById('maintenance-work-order-overdue');
+    expect(r.category).toBe('operational');
+    expect(r.severity).toBe('high');
+  });
+
+  test('fires on an open WO past its scheduled date; skips current and terminal ones', async () => {
+    const raised = await runOne({
+      MaintenanceWorkOrder: finder([
+        { _id: 'w1', title: 'Replace HVAC filter', status: 'in_progress', scheduledDate: PAST, branchId: BRANCH },
+        { _id: 'w2', title: 'Paint hallway', status: 'scheduled', scheduledDate: FUTURE, branchId: BRANCH },
+        { _id: 'w3', title: 'Old job', status: 'completed', scheduledDate: PAST, branchId: BRANCH },
+        { _id: 'w4', title: 'Draft idea', status: 'draft', scheduledDate: PAST, branchId: BRANCH },
+        { _id: 'w5', title: 'Cancelled job', status: 'cancelled', scheduledDate: PAST, branchId: BRANCH },
+      ]),
+    });
+    expect(raised).toHaveLength(1);
+    expect(raised[0].key).toBe('maintenance-wo-overdue:w1');
+    expect(raised[0].branchId).toBe(BRANCH);
+    expect(raised[0].category).toBe('operational');
+    expect(raised[0].severity).toBe('high');
+    expect(raised[0].message).toMatch(/overdue/);
+  });
+
+  test('a critical-priority overdue WO escalates to critical', async () => {
+    const raised = await runOne({
+      MaintenanceWorkOrder: finder([
+        { _id: 'w6', title: 'Boiler fault', status: 'approved', scheduledDate: PAST, priority: 'critical', branchId: BRANCH },
+      ]),
+    });
+    expect(raised).toHaveLength(1);
+    expect(raised[0].severity).toBe('critical');
+  });
+
+  test('no MaintenanceWorkOrder model → defensive no-op', async () => {
+    const raised = await runOne({});
+    expect(raised).toHaveLength(0);
+  });
+});

--- a/backend/alerts/rules/index.js
+++ b/backend/alerts/rules/index.js
@@ -59,4 +59,9 @@ module.exports = [
   // overdue. Needs `FacilityAsset` in the app.js model loader to fire
   // (defensive no-op otherwise).
   require('./facility-asset-ppm-overdue'),
+
+  // ── W1007 — operational / maintenance (1) ───────────────────
+  // Work order past its scheduled date and still open. Needs
+  // `MaintenanceWorkOrder` in the app.js model loader to fire.
+  require('./maintenance-work-order-overdue'),
 ];

--- a/backend/alerts/rules/maintenance-work-order-overdue.js
+++ b/backend/alerts/rules/maintenance-work-order-overdue.js
@@ -1,0 +1,48 @@
+/**
+ * Rule: maintenance work order past its scheduled date and still open.
+ *
+ * Second `category: 'operational'` smart-alert rule (W1007), companion to
+ * `facility-asset-ppm-overdue` (W1006). Feeds the same org-scoped `Alert` sink +
+ * `/api/v1/dashboards/alerts` dashboard. A committed work order whose
+ * `scheduledDate` is in the past and that has NOT reached a terminal/closed state
+ * is surfaced to the maintenance/ops team — facilities falling behind on planned
+ * work.
+ *
+ * Excluded states: `draft` (not committed) + the terminals `rejected` /
+ * `completed` / `verified` / `closed` / `cancelled`. Critical-priority work
+ * orders escalate the default `high` to `critical` (a per-finding `severity`
+ * overrides the rule default via the engine's `...finding` spread).
+ */
+
+'use strict';
+
+const EXCLUDED_STATES = ['draft', 'rejected', 'completed', 'verified', 'closed', 'cancelled'];
+
+module.exports = {
+  id: 'maintenance-work-order-overdue',
+  severity: 'high',
+  category: 'operational',
+  description: 'Maintenance work order overdue (past scheduled date, still open)',
+
+  async evaluate(ctx) {
+    if (!ctx.models || !ctx.models.MaintenanceWorkOrder) return [];
+    const now = ctx.now || new Date();
+    const rows = await ctx.models.MaintenanceWorkOrder.find({
+      status: { $nin: EXCLUDED_STATES },
+    });
+    const findings = [];
+    for (const wo of rows) {
+      if (!wo.scheduledDate || new Date(wo.scheduledDate) >= now) continue;
+      const due = new Date(wo.scheduledDate).toISOString().slice(0, 10);
+      const finding = {
+        key: `maintenance-wo-overdue:${wo._id}`,
+        subject: { type: 'MaintenanceWorkOrder', id: wo._id },
+        branchId: wo.branchId,
+        message: `Work order ${wo.title || wo._id} overdue since ${due} (status: ${wo.status})`,
+      };
+      if (wo.priority === 'critical') finding.severity = 'critical';
+      findings.push(finding);
+    }
+    return findings;
+  },
+};

--- a/backend/app.js
+++ b/backend/app.js
@@ -1470,6 +1470,7 @@ try {
       'Vaccination',
       'EmploymentContract',
       'FacilityAsset', // W1006 — operational PPM/inspection-overdue rule
+      'MaintenanceWorkOrder', // W1007 — operational work-order-overdue rule
     ];
     const liveModels = {};
     for (const name of modelNames) {

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -769,3 +769,4 @@ __tests__/medication-reconciliation-behavioral-wave1041.test.js
 __tests__/infection-surveillance-wave1042.test.js
 __tests__/infection-surveillance-behavioral-wave1042.test.js
 __tests__/facility-asset-overdue-rule-wave1006.test.js
+__tests__/maintenance-wo-overdue-rule-wave1007.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -136,7 +136,8 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 | --- | --- | --- | --- |
 | Insurance / NPHIES claims | `NphiesInsuranceClaim` | `insurance.claim.approved` / `.rejected` → `insurance_claim` | ✅ **W994** (per-beneficiary timeline) |
 | Facilities — PPM / inspection overdue | `FacilityAsset` | smart-alert **rule** `facility-asset-ppm-overdue` (category `operational`) → `Alert` | ✅ **W1006** — first operational rule; org-scoped, NOT the beneficiary timeline |
-| Inventory low-stock · contract/document expiry · transport incidents | — | (add a `category:'operational'` rule in `alerts/rules/`) | Open — **not** beneficiary-keyed → use the alerts rule-engine path below, not `CareTimeline` |
+| Maintenance — work order overdue | `MaintenanceWorkOrder` | rule `maintenance-work-order-overdue` → `Alert` | ✅ **W1007** — open WO past `scheduledDate`; critical-priority → critical |
+| Inventory low-stock · contract/document expiry · transport (vehicle) expiry | — | (add a `category:'operational'` rule in `alerts/rules/`) | Open — **not** beneficiary-keyed → alerts rule-engine path. _Inventory low-stock needs an `InventoryItem`+`InventoryStock` join (not single-model); `Vehicle` has no branch field (org-wide alert)._ |
 
 > **Two sinks, by scope (the W1006 lesson):** beneficiary-keyed events feed the
 > per-beneficiary **`CareTimeline`** (native model hook → `integrationBus` →


### PR DESCRIPTION
Companion to W1006. A committed `MaintenanceWorkOrder` past its `scheduledDate` and still open is surfaced to ops via the org-scoped `Alert` sink + `/api/v1/dashboards/alerts`. Rule `maintenance-work-order-overdue` (category operational): query open WOs (status $nin terminal+draft) then JS-filter scheduledDate < now; critical-priority → critical. Test (4 assertions, fake-finder harness). Rule-count 20→21. Ledger Tier-3 updated. routes-load + sprint hygiene green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)