### PR TITLE
feat(alerts): W1008 third operational rule — vehicle document expiry (registration/insurance/inspection)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1308,6 +1308,9 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/clinical-core-linkage-wave1046.test.js'
       - 'backend/__tests__/clinical-core-linkage-guard-wave1046.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/maintenance-wo-overdue-rule-wave1007.test.js'
+      - 'backend/__tests__/vehicle-document-expiry-rule-wave1008.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2599,6 +2602,9 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/clinical-core-linkage-wave1046.test.js'
       - 'backend/__tests__/clinical-core-linkage-guard-wave1046.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/maintenance-wo-overdue-rule-wave1007.test.js'
+      - 'backend/__tests__/vehicle-document-expiry-rule-wave1008.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/alerts.engine.test.js
+++ b/backend/__tests__/alerts.engine.test.js
@@ -111,10 +111,10 @@ describe('buildEngine() with bundled rules', () => {
   // baseline of 5. Wave 5 (2026-05-16) added the EWMA anomaly
   // bridge. Pin the exact total so accidental rule removal shows
   // up as a test regression rather than a silent gap.
-  test('registers all 21 bundled rules (5 baseline + 13 wave-3 + 1 wave-5 + 2 operational W1006/W1007)', () => {
-    expect(rules.length).toBe(21);
+  test('registers all 22 bundled rules (5 baseline + 13 wave-3 + 1 wave-5 + 3 operational W1006/W1007/W1008)', () => {
+    expect(rules.length).toBe(22);
     const eng = buildEngine();
-    expect(eng.rules.size).toBe(21);
+    expect(eng.rules.size).toBe(22);
   });
 
   test('credential-expiry-30d fires on near-expiry records', async () => {

--- a/backend/__tests__/vehicle-document-expiry-rule-wave1008.test.js
+++ b/backend/__tests__/vehicle-document-expiry-rule-wave1008.test.js
@@ -1,0 +1,122 @@
+/**
+ * W1008 — vehicle-document-expiry smart-alert rule.
+ *
+ * Third `category: 'operational'` rule (after W1006 facility-asset + W1007
+ * maintenance-WO). Verifies the nested-date predicate (registration / insurance /
+ * inspection expiry on an active vehicle), the active-status filter, the
+ * registration|insurance → critical escalation, and the platform-scope (no branch
+ * field → branchId undefined). Same fake-finder harness the other rule tests use.
+ */
+
+'use strict';
+
+const { AlertsEngine } = require('../alerts');
+const rules = require('../alerts/rules');
+
+function finder(rows) {
+  return { find: async q => rows.filter(r => shallowMatch(r, q)) };
+}
+
+function shallowMatch(doc, q) {
+  return Object.entries(q).every(([k, v]) => {
+    const docVal = doc[k];
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      if ('$in' in v) return v.$in.includes(docVal);
+      if ('$nin' in v) return !v.$nin.includes(docVal);
+    }
+    return docVal === v;
+  });
+}
+
+function ruleById(id) {
+  const r = rules.find(x => x.id === id);
+  if (!r) throw new Error(`Rule ${id} not registered`);
+  return r;
+}
+
+async function runOne(models, now = new Date('2026-06-01')) {
+  const eng = new AlertsEngine({ now: () => now });
+  eng.register(ruleById('vehicle-document-expiry'));
+  const result = await eng.runAll({ models, now });
+  return result.raised.filter(a => a.ruleId === 'vehicle-document-expiry');
+}
+
+const PAST = new Date('2026-05-01');
+const FUTURE = new Date('2026-07-01');
+const ACTIVE = 'نشطة';
+const SOLD = 'مبيعة';
+
+describe('vehicle-document-expiry', () => {
+  test('is registered as an operational rule', () => {
+    const r = ruleById('vehicle-document-expiry');
+    expect(r.category).toBe('operational');
+    expect(r.severity).toBe('high');
+  });
+
+  test('an overdue inspection alone fires HIGH (platform-scoped: no branchId)', async () => {
+    const raised = await runOne({
+      Vehicle: finder([
+        {
+          _id: 'v1',
+          plateNumber: 'ABC-123',
+          status: ACTIVE,
+          registration: { expiryDate: FUTURE },
+          insurance: { policyExpiryDate: FUTURE },
+          inspection: { nextInspectionDate: PAST },
+        },
+      ]),
+    });
+    expect(raised).toHaveLength(1);
+    expect(raised[0].key).toBe('vehicle-doc-expiry:v1');
+    expect(raised[0].category).toBe('operational');
+    expect(raised[0].severity).toBe('high');
+    expect(raised[0].branchId).toBeUndefined();
+    expect(raised[0].message).toMatch(/inspection/);
+  });
+
+  test('expired registration or insurance escalates to critical', async () => {
+    const raised = await runOne({
+      Vehicle: finder([
+        {
+          _id: 'v2',
+          plateNumber: 'XYZ-789',
+          status: ACTIVE,
+          registration: { expiryDate: PAST },
+          insurance: { policyExpiryDate: FUTURE },
+        },
+      ]),
+    });
+    expect(raised).toHaveLength(1);
+    expect(raised[0].severity).toBe('critical');
+    expect(raised[0].message).toMatch(/registration/);
+  });
+
+  test('a fully-current active vehicle does not fire', async () => {
+    const raised = await runOne({
+      Vehicle: finder([
+        {
+          _id: 'v3',
+          status: ACTIVE,
+          registration: { expiryDate: FUTURE },
+          insurance: { policyExpiryDate: FUTURE },
+          inspection: { nextInspectionDate: FUTURE },
+        },
+      ]),
+    });
+    expect(raised).toHaveLength(0);
+  });
+
+  test('a sold/withdrawn vehicle is excluded even when expired', async () => {
+    const raised = await runOne({
+      Vehicle: finder([
+        { _id: 'v4', status: SOLD, registration: { expiryDate: PAST } },
+      ]),
+    });
+    expect(raised).toHaveLength(0);
+  });
+
+  test('no Vehicle model → defensive no-op', async () => {
+    const raised = await runOne({});
+    expect(raised).toHaveLength(0);
+  });
+});

--- a/backend/alerts/rules/index.js
+++ b/backend/alerts/rules/index.js
@@ -64,4 +64,9 @@ module.exports = [
   // Work order past its scheduled date and still open. Needs
   // `MaintenanceWorkOrder` in the app.js model loader to fire.
   require('./maintenance-work-order-overdue'),
+
+  // ── W1008 — operational / fleet (1) ─────────────────────────
+  // Active vehicle with expired registration / insurance / inspection.
+  // Needs `Vehicle` in the app.js model loader to fire.
+  require('./vehicle-document-expiry'),
 ];

--- a/backend/alerts/rules/vehicle-document-expiry.js
+++ b/backend/alerts/rules/vehicle-document-expiry.js
@@ -1,0 +1,60 @@
+/**
+ * Rule: an active fleet vehicle has an expired/expiring statutory document —
+ * registration, insurance, or periodic inspection.
+ *
+ * Third `category: 'operational'` smart-alert rule (W1008), after W1006
+ * (facility PPM) + W1007 (work-order overdue). Driving a beneficiary-transport
+ * vehicle with expired registration or insurance is a legal/safety exposure, so
+ * this surfaces it to the ops/fleet team via the org-scoped `Alert` sink +
+ * `/api/v1/dashboards/alerts`.
+ *
+ * `Vehicle` has no branch field, so these are platform-scoped alerts (branchId
+ * undefined — the Alert model supports a `platform` scope). The statutory dates
+ * are nested (`registration.expiryDate`, `insurance.policyExpiryDate`,
+ * `inspection.nextInspectionDate`), so the predicate runs in JS after a cheap
+ * active-status query. Expired registration OR insurance escalates the default
+ * `high` to `critical` (illegal to operate); an overdue inspection alone stays
+ * `high`.
+ */
+
+'use strict';
+
+const ACTIVE = 'نشطة'; // Vehicle.status enum: active
+
+module.exports = {
+  id: 'vehicle-document-expiry',
+  severity: 'high',
+  category: 'operational',
+  description: 'Active vehicle has expired registration / insurance / inspection',
+
+  async evaluate(ctx) {
+    if (!ctx.models || !ctx.models.Vehicle) return [];
+    const now = ctx.now || new Date();
+    const rows = await ctx.models.Vehicle.find({ status: ACTIVE });
+    const findings = [];
+    for (const v of rows) {
+      const regExp = v.registration && v.registration.expiryDate && new Date(v.registration.expiryDate) < now;
+      const insExp = v.insurance && v.insurance.policyExpiryDate && new Date(v.insurance.policyExpiryDate) < now;
+      const inspDue = v.inspection && v.inspection.nextInspectionDate && new Date(v.inspection.nextInspectionDate) < now;
+      if (!regExp && !insExp && !inspDue) continue;
+      const which = [
+        regExp ? 'registration' : null,
+        insExp ? 'insurance' : null,
+        inspDue ? 'inspection' : null,
+      ]
+        .filter(Boolean)
+        .join(' + ');
+      const label = v.plateNumber || v.registrationNumber || v._id;
+      const finding = {
+        key: `vehicle-doc-expiry:${v._id}`,
+        subject: { type: 'Vehicle', id: v._id },
+        branchId: v.branchId, // undefined → platform-scoped alert
+        message: `Vehicle ${label} ${which} expired/overdue`,
+      };
+      // Expired registration or insurance = illegal to operate → critical.
+      if (regExp || insExp) finding.severity = 'critical';
+      findings.push(finding);
+    }
+    return findings;
+  },
+};

--- a/backend/app.js
+++ b/backend/app.js
@@ -1471,6 +1471,7 @@ try {
       'EmploymentContract',
       'FacilityAsset', // W1006 — operational PPM/inspection-overdue rule
       'MaintenanceWorkOrder', // W1007 — operational work-order-overdue rule
+      'Vehicle', // W1008 — operational vehicle-document-expiry rule
     ];
     const liveModels = {};
     for (const name of modelNames) {

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -769,7 +769,7 @@ __tests__/medication-reconciliation-behavioral-wave1041.test.js
 __tests__/infection-surveillance-wave1042.test.js
 __tests__/infection-surveillance-behavioral-wave1042.test.js
 __tests__/facility-asset-overdue-rule-wave1006.test.js
-__tests__/clinical-core-linkage-wave1046.test.js
-__tests__/clinical-core-linkage-guard-wave1046.test.js
+__tests__/maintenance-wo-overdue-rule-wave1007.test.js
+__tests__/vehicle-document-expiry-rule-wave1008.test.js
 __tests__/clinical-core-linkage-wave1046.test.js
 __tests__/clinical-core-linkage-guard-wave1046.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -137,7 +137,8 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 | Insurance / NPHIES claims | `NphiesInsuranceClaim` | `insurance.claim.approved` / `.rejected` → `insurance_claim` | ✅ **W994** (per-beneficiary timeline) |
 | Facilities — PPM / inspection overdue | `FacilityAsset` | smart-alert **rule** `facility-asset-ppm-overdue` (category `operational`) → `Alert` | ✅ **W1006** — first operational rule; org-scoped, NOT the beneficiary timeline |
 | Maintenance — work order overdue | `MaintenanceWorkOrder` | rule `maintenance-work-order-overdue` → `Alert` | ✅ **W1007** — open WO past `scheduledDate`; critical-priority → critical |
-| Inventory low-stock · contract/document expiry · transport (vehicle) expiry | — | (add a `category:'operational'` rule in `alerts/rules/`) | Open — **not** beneficiary-keyed → alerts rule-engine path. _Inventory low-stock needs an `InventoryItem`+`InventoryStock` join (not single-model); `Vehicle` has no branch field (org-wide alert)._ |
+| Fleet — vehicle document expiry | `Vehicle` | rule `vehicle-document-expiry` → `Alert` (platform-scoped) | ✅ **W1008** — active vehicle, expired registration/insurance/inspection; registration\|insurance → critical |
+| Inventory low-stock · vendor/license expiry | — | (add a `category:'operational'` rule in `alerts/rules/`) | Open — _inventory low-stock needs an `InventoryItem`+`InventoryStock` join (not single-model); `EmploymentContract` already has rules — add vendor/service `Contract` + license expiry next._ |
 
 > **Two sinks, by scope (the W1006 lesson):** beneficiary-keyed events feed the
 > per-beneficiary **`CareTimeline`** (native model hook → `integrationBus` →


### PR DESCRIPTION
After W1006 (facility PPM) + W1007 (work-order overdue). An active fleet vehicle with expired registration/insurance or overdue inspection is surfaced to ops via the org-scoped `Alert` sink + `/api/v1/dashboards/alerts`. Registration|insurance expiry (illegal to operate a beneficiary-transport vehicle) → critical; inspection alone → high. Rule `vehicle-document-expiry`: query active vehicles (status='نشطة'), JS-filter nested statutory dates. Platform-scoped (Vehicle has no branch field; Alert supports a platform scope). Test (6 assertions). Rule-count 21→22. Also re-added W1007's sprint line + de-duped the W1046 entries that the parallel W1046 merge corrupted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)