### PR TITLE
feat(alerts): W1009 fourth operational rule — service/vendor contract expired

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1311,6 +1311,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/maintenance-wo-overdue-rule-wave1007.test.js'
       - 'backend/__tests__/vehicle-document-expiry-rule-wave1008.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/contract-expired-rule-wave1009.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2605,6 +2607,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/maintenance-wo-overdue-rule-wave1007.test.js'
       - 'backend/__tests__/vehicle-document-expiry-rule-wave1008.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/contract-expired-rule-wave1009.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/alerts.engine.test.js
+++ b/backend/__tests__/alerts.engine.test.js
@@ -111,10 +111,10 @@ describe('buildEngine() with bundled rules', () => {
   // baseline of 5. Wave 5 (2026-05-16) added the EWMA anomaly
   // bridge. Pin the exact total so accidental rule removal shows
   // up as a test regression rather than a silent gap.
-  test('registers all 22 bundled rules (5 baseline + 13 wave-3 + 1 wave-5 + 3 operational W1006/W1007/W1008)', () => {
-    expect(rules.length).toBe(22);
+  test('registers all 23 bundled rules (5 baseline + 13 wave-3 + 1 wave-5 + 4 operational W1006-W1009)', () => {
+    expect(rules.length).toBe(23);
     const eng = buildEngine();
-    expect(eng.rules.size).toBe(22);
+    expect(eng.rules.size).toBe(23);
   });
 
   test('credential-expiry-30d fires on near-expiry records', async () => {

--- a/backend/__tests__/contract-expired-rule-wave1009.test.js
+++ b/backend/__tests__/contract-expired-rule-wave1009.test.js
@@ -1,0 +1,81 @@
+/**
+ * W1009 — contract-expired smart-alert rule.
+ *
+ * Fourth `category: 'operational'` rule (facilities/maintenance/fleet/contracts).
+ * Verifies the predicate (ACTIVE status + endDate past), the status filter, the
+ * `Contract.model` loader-key fallback, and the no-op guard. Same fake-finder
+ * harness the other rule tests use.
+ */
+
+'use strict';
+
+const { AlertsEngine } = require('../alerts');
+const rules = require('../alerts/rules');
+
+function finder(rows) {
+  return { find: async q => rows.filter(r => shallowMatch(r, q)) };
+}
+
+function shallowMatch(doc, q) {
+  return Object.entries(q).every(([k, v]) => {
+    const docVal = doc[k];
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      if ('$in' in v) return v.$in.includes(docVal);
+      if ('$nin' in v) return !v.$nin.includes(docVal);
+    }
+    return docVal === v;
+  });
+}
+
+function ruleById(id) {
+  const r = rules.find(x => x.id === id);
+  if (!r) throw new Error(`Rule ${id} not registered`);
+  return r;
+}
+
+async function runOne(models, now = new Date('2026-06-01')) {
+  const eng = new AlertsEngine({ now: () => now });
+  eng.register(ruleById('contract-expired'));
+  const result = await eng.runAll({ models, now });
+  return result.raised.filter(a => a.ruleId === 'contract-expired');
+}
+
+const PAST = new Date('2026-05-01');
+const FUTURE = new Date('2026-07-01');
+const BRANCH = '64b000000000000000000003';
+
+describe('contract-expired', () => {
+  test('is registered as an operational rule', () => {
+    const r = ruleById('contract-expired');
+    expect(r.category).toBe('operational');
+    expect(r.severity).toBe('high');
+  });
+
+  test('fires on an ACTIVE contract past its endDate; skips current + non-active', async () => {
+    const raised = await runOne({
+      'Contract.model': finder([
+        { _id: 'k1', title: 'Catering SLA', status: 'ACTIVE', endDate: PAST, branchId: BRANCH },
+        { _id: 'k2', title: 'Cleaning SLA', status: 'ACTIVE', endDate: FUTURE, branchId: BRANCH },
+        { _id: 'k3', title: 'Old SLA', status: 'EXPIRED', endDate: PAST, branchId: BRANCH },
+        { _id: 'k4', title: 'Draft SLA', status: 'DRAFT', endDate: PAST, branchId: BRANCH },
+      ]),
+    });
+    expect(raised).toHaveLength(1);
+    expect(raised[0].key).toBe('contract-expired:k1');
+    expect(raised[0].branchId).toBe(BRANCH);
+    expect(raised[0].category).toBe('operational');
+    expect(raised[0].message).toMatch(/expired/);
+  });
+
+  test('also resolves the model under the clean `Contract` key', async () => {
+    const raised = await runOne({
+      Contract: finder([{ _id: 'k5', status: 'ACTIVE', endDate: PAST, branchId: BRANCH }]),
+    });
+    expect(raised).toHaveLength(1);
+  });
+
+  test('no Contract model → defensive no-op', async () => {
+    const raised = await runOne({});
+    expect(raised).toHaveLength(0);
+  });
+});

--- a/backend/alerts/rules/contract-expired.js
+++ b/backend/alerts/rules/contract-expired.js
@@ -1,0 +1,44 @@
+/**
+ * Rule: a contract still marked ACTIVE whose end date has passed.
+ *
+ * Fourth `category: 'operational'` smart-alert rule (W1009), after facilities
+ * (W1006), maintenance (W1007) and fleet (W1008). A service/vendor/general
+ * contract that is still `ACTIVE` but past its `endDate` has lapsed without being
+ * renewed or closed — a governance gap (e.g. a `SERVICE_AGREEMENT` for cleaning /
+ * catering / maintenance silently expiring → service-continuity risk). Surfaced
+ * to the ops/admin team via the org-scoped `Alert` sink + /api/v1/dashboards/alerts.
+ *
+ * Distinct from the existing `employment-contract-*` rules (those cover HR/staff
+ * contracts on a separate model). `Contract` is loaded under the key
+ * `Contract.model` (its file is `models/Contract.model.js`), so the rule checks
+ * both keys defensively.
+ */
+
+'use strict';
+
+module.exports = {
+  id: 'contract-expired',
+  severity: 'high',
+  category: 'operational',
+  description: 'Contract still marked ACTIVE but past its end date',
+
+  async evaluate(ctx) {
+    const Contract = ctx.models && (ctx.models.Contract || ctx.models['Contract.model']);
+    if (!Contract) return [];
+    const now = ctx.now || new Date();
+    const rows = await Contract.find({ status: 'ACTIVE' });
+    const findings = [];
+    for (const c of rows) {
+      if (!c.endDate || new Date(c.endDate) >= now) continue;
+      const due = new Date(c.endDate).toISOString().slice(0, 10);
+      const label = c.title || c.contractNumber || c.name || c._id;
+      findings.push({
+        key: `contract-expired:${c._id}`,
+        subject: { type: 'Contract', id: c._id },
+        branchId: c.branchId,
+        message: `Contract ${label} marked ACTIVE but expired on ${due}`,
+      });
+    }
+    return findings;
+  },
+};

--- a/backend/alerts/rules/index.js
+++ b/backend/alerts/rules/index.js
@@ -69,4 +69,9 @@ module.exports = [
   // Active vehicle with expired registration / insurance / inspection.
   // Needs `Vehicle` in the app.js model loader to fire.
   require('./vehicle-document-expiry'),
+
+  // ── W1009 — operational / contracts (1) ─────────────────────
+  // Contract still ACTIVE but past endDate. Needs `Contract.model`
+  // in the app.js model loader to fire (file is Contract.model.js).
+  require('./contract-expired'),
 ];

--- a/backend/app.js
+++ b/backend/app.js
@@ -1472,6 +1472,7 @@ try {
       'FacilityAsset', // W1006 — operational PPM/inspection-overdue rule
       'MaintenanceWorkOrder', // W1007 — operational work-order-overdue rule
       'Vehicle', // W1008 — operational vehicle-document-expiry rule
+      'Contract.model', // W1009 — operational contract-expired rule (file: Contract.model.js)
     ];
     const liveModels = {};
     for (const name of modelNames) {

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -771,5 +771,6 @@ __tests__/infection-surveillance-behavioral-wave1042.test.js
 __tests__/facility-asset-overdue-rule-wave1006.test.js
 __tests__/maintenance-wo-overdue-rule-wave1007.test.js
 __tests__/vehicle-document-expiry-rule-wave1008.test.js
+__tests__/contract-expired-rule-wave1009.test.js
 __tests__/clinical-core-linkage-wave1046.test.js
 __tests__/clinical-core-linkage-guard-wave1046.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -138,7 +138,8 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 | Facilities — PPM / inspection overdue | `FacilityAsset` | smart-alert **rule** `facility-asset-ppm-overdue` (category `operational`) → `Alert` | ✅ **W1006** — first operational rule; org-scoped, NOT the beneficiary timeline |
 | Maintenance — work order overdue | `MaintenanceWorkOrder` | rule `maintenance-work-order-overdue` → `Alert` | ✅ **W1007** — open WO past `scheduledDate`; critical-priority → critical |
 | Fleet — vehicle document expiry | `Vehicle` | rule `vehicle-document-expiry` → `Alert` (platform-scoped) | ✅ **W1008** — active vehicle, expired registration/insurance/inspection; registration\|insurance → critical |
-| Inventory low-stock · vendor/license expiry | — | (add a `category:'operational'` rule in `alerts/rules/`) | Open — _inventory low-stock needs an `InventoryItem`+`InventoryStock` join (not single-model); `EmploymentContract` already has rules — add vendor/service `Contract` + license expiry next._ |
+| Contracts — service/vendor expired | `Contract` | rule `contract-expired` → `Alert` | ✅ **W1009** — ACTIVE contract past `endDate` (lapsed without renewal/close) |
+| Inventory low-stock | — | (add a `category:'operational'` rule) | Open — needs an `InventoryItem`+`InventoryStock` join (current qty is a separate model), so **not** a clean single-model rule like the four above |
 
 > **Two sinks, by scope (the W1006 lesson):** beneficiary-keyed events feed the
 > per-beneficiary **`CareTimeline`** (native model hook → `integrationBus` →


### PR DESCRIPTION
Completes a 4-domain operational sweep (facilities W1006 · maintenance W1007 · fleet W1008 · contracts W1009). A `Contract` still ACTIVE but past its `endDate` (lapsed without renewal/close — e.g. a SERVICE_AGREEMENT silently expiring) → org-scoped `Alert` + `/api/v1/dashboards/alerts`. Distinct from `employment-contract-*` (HR, separate model). Loads under key `Contract.model` (file Contract.model.js); rule resolves both keys. Test (4 assertions). Rule-count 22→23. routes-load + sprint hygiene green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)