### PR TITLE
feat(alerts): W1070 fifth operational rule — inventory low-stock (two-model join)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1316,6 +1316,8 @@ on:
       - 'backend/__tests__/unified-core-linkage-coverage-wave1047.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/contract-expired-rule-wave1009.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/inventory-low-stock-rule-wave1070.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2615,6 +2617,8 @@ on:
       - 'backend/__tests__/unified-core-linkage-coverage-wave1047.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/contract-expired-rule-wave1009.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/inventory-low-stock-rule-wave1070.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/alerts.engine.test.js
+++ b/backend/__tests__/alerts.engine.test.js
@@ -111,10 +111,10 @@ describe('buildEngine() with bundled rules', () => {
   // baseline of 5. Wave 5 (2026-05-16) added the EWMA anomaly
   // bridge. Pin the exact total so accidental rule removal shows
   // up as a test regression rather than a silent gap.
-  test('registers all 23 bundled rules (5 baseline + 13 wave-3 + 1 wave-5 + 4 operational W1006-W1009)', () => {
-    expect(rules.length).toBe(23);
+  test('registers all 24 bundled rules (5 baseline + 13 wave-3 + 1 wave-5 + 5 operational W1006-W1009/W1070)', () => {
+    expect(rules.length).toBe(24);
     const eng = buildEngine();
-    expect(eng.rules.size).toBe(23);
+    expect(eng.rules.size).toBe(24);
   });
 
   test('credential-expiry-30d fires on near-expiry records', async () => {

--- a/backend/__tests__/inventory-low-stock-rule-wave1070.test.js
+++ b/backend/__tests__/inventory-low-stock-rule-wave1070.test.js
@@ -1,0 +1,107 @@
+/**
+ * W1070 — inventory-low-stock smart-alert rule.
+ *
+ * Fifth `category: 'operational'` rule, and the first TWO-MODEL join (stock
+ * quantities on `InventoryStock`, thresholds on `InventoryItem`). Verifies the
+ * join + predicate (available ≤ reorder point), the no-threshold skip, the
+ * out-of-stock → critical escalation, the object-export model resolution (and the
+ * direct-model fallback), and the no-op guard. Fake-finder harness (no DB).
+ */
+
+'use strict';
+
+const { AlertsEngine } = require('../alerts');
+const rules = require('../alerts/rules');
+
+function finder(rows) {
+  // find({}) returns all rows (low-stock loads the full item + stock sets)
+  return { find: async () => rows.slice() };
+}
+
+function ruleById(id) {
+  const r = rules.find(x => x.id === id);
+  if (!r) throw new Error(`Rule ${id} not registered`);
+  return r;
+}
+
+async function runOne(models) {
+  const eng = new AlertsEngine({ now: () => new Date('2026-06-01') });
+  eng.register(ruleById('inventory-low-stock'));
+  const result = await eng.runAll({ models });
+  return result.raised.filter(a => a.ruleId === 'inventory-low-stock');
+}
+
+// object-export shapes, matching how the app.js loader hands back the wrappers
+function items(rows) {
+  return { InventoryItem: finder(rows) };
+}
+function stock(rows) {
+  return { InventoryStock: finder(rows) };
+}
+
+describe('inventory-low-stock', () => {
+  test('is registered as an operational rule', () => {
+    const r = ruleById('inventory-low-stock');
+    expect(r.category).toBe('operational');
+    expect(r.severity).toBe('high');
+  });
+
+  test('fires when available ≤ reorder point; skips well-stocked + un-thresholded items', async () => {
+    const raised = await runOne({
+      InventoryItem: items([
+        { _id: 'i1', name: 'Gloves', reorderPoint: 50 },
+        { _id: 'i2', name: 'Wipes', reorderPoint: 20 },
+        { _id: 'i3', name: 'Misc', reorderPoint: 0 }, // no threshold configured
+      ]),
+      InventoryStock: stock([
+        { _id: 's1', itemId: 'i1', quantityOnHand: 40, quantityReserved: 0 }, // 40 ≤ 50 → low
+        { _id: 's2', itemId: 'i2', quantityOnHand: 100, quantityReserved: 0 }, // 100 > 20 → ok
+        { _id: 's3', itemId: 'i3', quantityOnHand: 0, quantityReserved: 0 }, // no threshold → skip
+      ]),
+    });
+    expect(raised).toHaveLength(1);
+    expect(raised[0].key).toBe('inventory-low-stock:s1');
+    expect(raised[0].category).toBe('operational');
+    expect(raised[0].severity).toBe('high');
+    expect(raised[0].message).toMatch(/Gloves/);
+    expect(raised[0].message).toMatch(/reorder point 50/);
+  });
+
+  test('reserved quantity counts against availability', async () => {
+    const raised = await runOne({
+      InventoryItem: items([{ _id: 'i1', name: 'Syringes', reorderPoint: 10 }]),
+      InventoryStock: stock([{ _id: 's1', itemId: 'i1', quantityOnHand: 15, quantityReserved: 8 }]), // avail 7 ≤ 10
+    });
+    expect(raised).toHaveLength(1);
+  });
+
+  test('out of stock escalates to critical', async () => {
+    const raised = await runOne({
+      InventoryItem: items([{ _id: 'i1', name: 'Masks', reorderPoint: 30 }]),
+      InventoryStock: stock([{ _id: 's1', itemId: 'i1', quantityOnHand: 0, quantityReserved: 0 }]),
+    });
+    expect(raised).toHaveLength(1);
+    expect(raised[0].severity).toBe('critical');
+  });
+
+  test('falls back to minStockLevel when reorderPoint is 0', async () => {
+    const raised = await runOne({
+      InventoryItem: items([{ _id: 'i1', name: 'Tape', reorderPoint: 0, minStockLevel: 5 }]),
+      InventoryStock: stock([{ _id: 's1', itemId: 'i1', quantityOnHand: 5, quantityReserved: 0 }]),
+    });
+    expect(raised).toHaveLength(1);
+  });
+
+  test('resolves direct-model exports too (not only object wrappers)', async () => {
+    const raised = await runOne({
+      InventoryItem: finder([{ _id: 'i1', name: 'Pads', reorderPoint: 10 }]),
+      InventoryStock: finder([{ _id: 's1', itemId: 'i1', quantityOnHand: 3, quantityReserved: 0 }]),
+    });
+    expect(raised).toHaveLength(1);
+  });
+
+  test('missing either model → defensive no-op', async () => {
+    expect(await runOne({})).toHaveLength(0);
+    expect(await runOne({ InventoryItem: items([{ _id: 'i1', reorderPoint: 10 }]) })).toHaveLength(0);
+  });
+});

--- a/backend/alerts/rules/index.js
+++ b/backend/alerts/rules/index.js
@@ -74,4 +74,9 @@ module.exports = [
   // Contract still ACTIVE but past endDate. Needs `Contract.model`
   // in the app.js model loader to fire (file is Contract.model.js).
   require('./contract-expired'),
+
+  // ── W1070 — operational / inventory (1) ─────────────────────
+  // Item at/below its reorder point (a TWO-model join across
+  // InventoryStock + InventoryItem). Needs both in the app.js loader.
+  require('./inventory-low-stock'),
 ];

--- a/backend/alerts/rules/inventory-low-stock.js
+++ b/backend/alerts/rules/inventory-low-stock.js
@@ -1,0 +1,78 @@
+/**
+ * Rule: an inventory item's available stock has dropped to or below its reorder
+ * point (supply-continuity risk — therapy / medical / facility consumables).
+ *
+ * Fifth `category: 'operational'` smart-alert rule (after facilities W1006,
+ * maintenance W1007, fleet W1008, contracts W1009). Unlike those single-model
+ * rules, low-stock is a TWO-MODEL join: `InventoryStock` holds the per-warehouse
+ * `quantityOnHand` / `quantityReserved`, while the threshold (`reorderPoint`)
+ * lives on `InventoryItem`. The rule loads the item thresholds into a Map, then
+ * scans stock rows. Surfaced to the ops team via the org-scoped `Alert` sink +
+ * /api/v1/dashboards/alerts.
+ *
+ * Both inventory models use object exports (`{ ItemCategory, InventoryItem }`,
+ * `{ InventoryStock, ... }`), so the app.js loader hands back the wrapper object;
+ * `resolveModel` digs the real model out (checks `.find`, then the named key).
+ *
+ * Stock rows are warehouse-scoped (no `branchId`), so these alerts are
+ * platform-scoped with the warehouse in the subject/metadata.
+ */
+
+'use strict';
+
+function resolveModel(loaded, name) {
+  if (!loaded) return null;
+  if (typeof loaded.find === 'function') return loaded; // direct model export
+  if (loaded[name] && typeof loaded[name].find === 'function') return loaded[name]; // object export
+  return null;
+}
+
+module.exports = {
+  id: 'inventory-low-stock',
+  severity: 'high',
+  category: 'operational',
+  description: 'Inventory item at or below its reorder point',
+
+  async evaluate(ctx) {
+    if (!ctx.models) return [];
+    const Stock = resolveModel(ctx.models.InventoryStock, 'InventoryStock');
+    const Item = resolveModel(ctx.models.InventoryItem, 'InventoryItem');
+    if (!Stock || !Item) return [];
+
+    // Item thresholds: id → { reorderPoint, minStockLevel, name }
+    const items = await Item.find({});
+    const threshold = new Map();
+    for (const it of items) {
+      threshold.set(String(it._id), {
+        reorderPoint: Number(it.reorderPoint) || 0,
+        minStockLevel: Number(it.minStockLevel) || 0,
+        name: it.name || it.nameAr || it.sku || String(it._id),
+      });
+    }
+
+    const rows = await Stock.find({});
+    const findings = [];
+    for (const s of rows) {
+      const t = threshold.get(String(s.itemId));
+      if (!t) continue;
+      const limit = t.reorderPoint > 0 ? t.reorderPoint : t.minStockLevel;
+      if (limit <= 0) continue; // no threshold configured → nothing to breach
+      const available =
+        typeof s.quantityAvailable === 'number'
+          ? s.quantityAvailable
+          : Math.max(0, (Number(s.quantityOnHand) || 0) - (Number(s.quantityReserved) || 0));
+      if (available > limit) continue;
+      const finding = {
+        // one alert per (item, warehouse) stock row
+        key: `inventory-low-stock:${s._id}`,
+        subject: { type: 'InventoryStock', id: s._id },
+        branchId: s.branchId, // usually undefined (warehouse-scoped) → platform alert
+        message: `Low stock: ${t.name} at ${available} (reorder point ${limit})`,
+      };
+      // Out of stock entirely is more urgent than merely at the reorder point.
+      if (available <= 0) finding.severity = 'critical';
+      findings.push(finding);
+    }
+    return findings;
+  },
+};

--- a/backend/app.js
+++ b/backend/app.js
@@ -1473,6 +1473,8 @@ try {
       'MaintenanceWorkOrder', // W1007 — operational work-order-overdue rule
       'Vehicle', // W1008 — operational vehicle-document-expiry rule
       'Contract.model', // W1009 — operational contract-expired rule (file: Contract.model.js)
+      'InventoryStock', // W1070 — operational inventory-low-stock rule (object export)
+      'InventoryItem', // W1070 — inventory-low-stock threshold source (object export)
     ];
     const liveModels = {};
     for (const name of modelNames) {

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -772,6 +772,7 @@ __tests__/facility-asset-overdue-rule-wave1006.test.js
 __tests__/maintenance-wo-overdue-rule-wave1007.test.js
 __tests__/vehicle-document-expiry-rule-wave1008.test.js
 __tests__/contract-expired-rule-wave1009.test.js
+__tests__/inventory-low-stock-rule-wave1070.test.js
 __tests__/clinical-core-linkage-wave1046.test.js
 __tests__/clinical-core-linkage-guard-wave1046.test.js
 __tests__/clinical-assessment-core-linkage-wave1047.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -139,7 +139,12 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 | Maintenance — work order overdue | `MaintenanceWorkOrder` | rule `maintenance-work-order-overdue` → `Alert` | ✅ **W1007** — open WO past `scheduledDate`; critical-priority → critical |
 | Fleet — vehicle document expiry | `Vehicle` | rule `vehicle-document-expiry` → `Alert` (platform-scoped) | ✅ **W1008** — active vehicle, expired registration/insurance/inspection; registration\|insurance → critical |
 | Contracts — service/vendor expired | `Contract` | rule `contract-expired` → `Alert` | ✅ **W1009** — ACTIVE contract past `endDate` (lapsed without renewal/close) |
-| Inventory low-stock | — | (add a `category:'operational'` rule) | Open — needs an `InventoryItem`+`InventoryStock` join (current qty is a separate model), so **not** a clean single-model rule like the four above |
+| Inventory — low stock | `InventoryStock` × `InventoryItem` | rule `inventory-low-stock` → `Alert` | ✅ **W1070** — first TWO-model join (stock qty vs item reorder point); out-of-stock → critical; both models are object-exports, resolved defensively |
+
+**Operational sweep: 5 rules (W1006–W1009 + W1070) covering facilities · maintenance ·
+fleet · contracts · inventory — the main org-operational signals are now on the
+`/api/v1/dashboards/alerts` dashboard.** Further rules (e.g. license expiry) follow
+the same recipe.
 
 > **Two sinks, by scope (the W1006 lesson):** beneficiary-keyed events feed the
 > per-beneficiary **`CareTimeline`** (native model hook → `integrationBus` →


### PR DESCRIPTION
Completes the org-operational alert sweep (facilities W1006 · maintenance W1007 · fleet W1008 · contracts W1009 · **inventory W1070**). An item whose available stock (onHand-reserved) is ≤ its reorder point → org-scoped `Alert` + `/api/v1/dashboards/alerts` (supply-continuity risk). First TWO-model join: thresholds on `InventoryItem`, qty on `InventoryStock`; both are object-exports, resolved defensively; out-of-stock → critical; warehouse-scoped → platform alert. Test (7 assertions). Rule-count 23→24. routes-load + sprint hygiene green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)