### PR TITLE
feat(alerts): W1132 operational rule — purchase-order delivery overdue (procurement)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1334,6 +1334,8 @@ on:
       - 'backend/__tests__/staff-health-behavioral-wave1125.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/staff-health-surveillance-overdue-rule-wave1126.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/po-delivery-overdue-rule-wave1132.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2651,6 +2653,8 @@ on:
       - 'backend/__tests__/staff-health-behavioral-wave1125.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/staff-health-surveillance-overdue-rule-wave1126.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/po-delivery-overdue-rule-wave1132.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/alerts.engine.test.js
+++ b/backend/__tests__/alerts.engine.test.js
@@ -111,10 +111,10 @@ describe('buildEngine() with bundled rules', () => {
   // baseline of 5. Wave 5 (2026-05-16) added the EWMA anomaly
   // bridge. Pin the exact total so accidental rule removal shows
   // up as a test regression rather than a silent gap.
-  test('registers all 28 bundled rules (5 baseline + 13 wave-3 + 1 wave-5 + 5 operational + 2 quality W1121 + 1 waste W1124 + 1 occ-health W1126)', () => {
-    expect(rules.length).toBe(28);
+  test('registers all 29 bundled rules (5 baseline + 13 wave-3 + 1 wave-5 + 5 operational + 2 quality W1121 + 1 waste W1124 + 1 occ-health W1126 + 1 procurement W1132)', () => {
+    expect(rules.length).toBe(29);
     const eng = buildEngine();
-    expect(eng.rules.size).toBe(28);
+    expect(eng.rules.size).toBe(29);
   });
 
   test('credential-expiry-30d fires on near-expiry records', async () => {

--- a/backend/__tests__/po-delivery-overdue-rule-wave1132.test.js
+++ b/backend/__tests__/po-delivery-overdue-rule-wave1132.test.js
@@ -1,0 +1,85 @@
+/**
+ * W1132 — purchase-order-delivery-overdue smart-alert rule.
+ *
+ * `category: 'operational'` procurement rule. A committed PO (approved/sent/
+ * partial) past its `expected_delivery_date` and not yet received is surfaced to
+ * ops — the *incoming* supply is late (before it becomes a low-stock shortfall).
+ *
+ * The rule is self-loading (prefers `ctx.models`, falls back to `require`), so the
+ * test ALWAYS injects the model — letting the require fallback run would hit the
+ * real model with no DB connection and buffer/hang. Uses the same fake-finder
+ * harness as the other rule tests.
+ */
+
+'use strict';
+
+const { AlertsEngine } = require('../alerts');
+const rules = require('../alerts/rules');
+
+function finder(rows) {
+  return { find: async q => rows.filter(r => shallowMatch(r, q)) };
+}
+
+function shallowMatch(doc, q) {
+  return Object.entries(q).every(([k, v]) => {
+    const docVal = doc[k];
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      if ('$in' in v) return v.$in.includes(docVal);
+      if ('$nin' in v) return !v.$nin.includes(docVal);
+    }
+    return docVal === v;
+  });
+}
+
+function ruleById(id) {
+  const r = rules.find(x => x.id === id);
+  if (!r) throw new Error(`Rule ${id} not registered`);
+  return r;
+}
+
+async function runOne(rows, now = new Date('2026-06-01')) {
+  const eng = new AlertsEngine({ now: () => now });
+  eng.register(ruleById('purchase-order-delivery-overdue'));
+  // inject under the canonical model name so the require fallback never runs
+  const result = await eng.runAll({ models: { InventoryModulePurchaseOrder: finder(rows) }, now });
+  return result.raised.filter(a => a.ruleId === 'purchase-order-delivery-overdue');
+}
+
+const PAST = new Date('2026-05-01');
+const FUTURE = new Date('2026-07-01');
+const BRANCH = '64b000000000000000000004';
+
+describe('purchase-order-delivery-overdue', () => {
+  test('is registered as an operational rule', () => {
+    const r = ruleById('purchase-order-delivery-overdue');
+    expect(r.category).toBe('operational');
+    expect(r.severity).toBe('high');
+  });
+
+  test('fires on a committed PO past expected delivery; skips on-time, delivered, and uncommitted', async () => {
+    const raised = await runOne([
+      { _id: 'p1', po_number: 'PO-1', status: 'sent', expected_delivery_date: PAST, branch_id: BRANCH },
+      { _id: 'p2', po_number: 'PO-2', status: 'approved', expected_delivery_date: FUTURE, branch_id: BRANCH },
+      { _id: 'p3', po_number: 'PO-3', status: 'partial', expected_delivery_date: PAST, actual_delivery_date: PAST, branch_id: BRANCH },
+      { _id: 'p4', po_number: 'PO-4', status: 'draft', expected_delivery_date: PAST, branch_id: BRANCH },
+      { _id: 'p5', po_number: 'PO-5', status: 'received', expected_delivery_date: PAST, branch_id: BRANCH },
+    ]);
+    expect(raised).toHaveLength(1);
+    expect(raised[0].key).toBe('po-delivery-overdue:p1');
+    expect(raised[0].branchId).toBe(BRANCH);
+    expect(raised[0].category).toBe('operational');
+    expect(raised[0].message).toMatch(/overdue/);
+  });
+
+  test('a partially-received PO past its date (not fully delivered) still fires', async () => {
+    const raised = await runOne([
+      { _id: 'p6', po_number: 'PO-6', status: 'partial', expected_delivery_date: PAST, branch_id: BRANCH },
+    ]);
+    expect(raised).toHaveLength(1);
+  });
+
+  test('a PO with no expected_delivery_date does not fire', async () => {
+    const raised = await runOne([{ _id: 'p7', status: 'sent', branch_id: BRANCH }]);
+    expect(raised).toHaveLength(0);
+  });
+});

--- a/backend/alerts/rules/index.js
+++ b/backend/alerts/rules/index.js
@@ -96,4 +96,9 @@ module.exports = [
   // ── W1126 — operational / occupational health (1) ───────────
   // Staff occ-health surveillance overdue (links the W1125 system). Self-loading.
   require('./staff-health-surveillance-overdue'),
+
+  // ── W1132 — operational / procurement (1) ───────────────────
+  // Purchase order past its expected delivery date and not received.
+  // Self-loading (no app.js edit).
+  require('./purchase-order-delivery-overdue'),
 ];

--- a/backend/alerts/rules/purchase-order-delivery-overdue.js
+++ b/backend/alerts/rules/purchase-order-delivery-overdue.js
@@ -1,0 +1,60 @@
+/**
+ * Rule: a committed purchase order is past its expected delivery date and has
+ * not been received — a procurement / supply-continuity signal (supplier late →
+ * potential stockout).
+ *
+ * `category: 'operational'` smart-alert rule (W1132). Distinct from
+ * `inventory-low-stock` (current shortfall) — this catches the *incoming* supply
+ * being late before it becomes a shortfall. Feeds the same org-scoped `Alert`
+ * sink + /api/v1/dashboards/alerts.
+ *
+ * Uses the SELF-LOADING pattern (no app.js model-loader edit): it prefers the
+ * test-injectable `ctx.models` entry but falls back to a direct `require`, so it
+ * fires in prod with zero change to app.js (kept tiny on purpose — app.js is a
+ * parallel-work hot zone). The model is registered as `InventoryModulePurchaseOrder`
+ * and uses snake_case fields (`expected_delivery_date`, `branch_id`, `po_number`).
+ */
+
+'use strict';
+
+// committed, delivery not yet complete (excludes draft / pending_approval /
+// received / cancelled / closed)
+const AWAITING = ['approved', 'sent', 'partial'];
+
+function resolvePOModel(ctx) {
+  const m =
+    ctx.models && (ctx.models.InventoryModulePurchaseOrder || ctx.models.PurchaseOrder);
+  if (m && typeof m.find === 'function') return m;
+  try {
+    return require('../../models/inventory/PurchaseOrder');
+  } catch (_) {
+    return null;
+  }
+}
+
+module.exports = {
+  id: 'purchase-order-delivery-overdue',
+  severity: 'high',
+  category: 'operational',
+  description: 'Purchase order past its expected delivery date and not yet received',
+
+  async evaluate(ctx = {}) {
+    const PO = resolvePOModel(ctx);
+    if (!PO) return [];
+    const now = ctx.now || new Date();
+    const rows = await PO.find({ status: { $in: AWAITING } });
+    const findings = [];
+    for (const po of rows) {
+      if (po.actual_delivery_date) continue; // already delivered
+      if (!po.expected_delivery_date || new Date(po.expected_delivery_date) >= now) continue;
+      const due = new Date(po.expected_delivery_date).toISOString().slice(0, 10);
+      findings.push({
+        key: `po-delivery-overdue:${po._id}`,
+        subject: { type: 'PurchaseOrder', id: po._id },
+        branchId: po.branch_id,
+        message: `Purchase order ${po.po_number || po._id} delivery overdue since ${due} (status: ${po.status})`,
+      });
+    }
+    return findings;
+  },
+};

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -786,3 +786,4 @@ __tests__/biomedical-waste-storage-overdue-rule-wave1124.test.js
 __tests__/staff-health-wave1125.test.js
 __tests__/staff-health-behavioral-wave1125.test.js
 __tests__/staff-health-surveillance-overdue-rule-wave1126.test.js
+__tests__/po-delivery-overdue-rule-wave1132.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -140,11 +140,15 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 | Fleet — vehicle document expiry | `Vehicle` | rule `vehicle-document-expiry` → `Alert` (platform-scoped) | ✅ **W1008** — active vehicle, expired registration/insurance/inspection; registration\|insurance → critical |
 | Contracts — service/vendor expired | `Contract` | rule `contract-expired` → `Alert` | ✅ **W1009** — ACTIVE contract past `endDate` (lapsed without renewal/close) |
 | Inventory — low stock | `InventoryStock` × `InventoryItem` | rule `inventory-low-stock` → `Alert` | ✅ **W1070** — first TWO-model join (stock qty vs item reorder point); out-of-stock → critical; both models are object-exports, resolved defensively |
+| Procurement — PO delivery overdue | `InventoryModulePurchaseOrder` | rule `purchase-order-delivery-overdue` → `Alert` | ✅ **W1132** — committed PO (approved/sent/partial) past `expected_delivery_date`, not received; catches late *incoming* supply before it becomes a low-stock shortfall; self-loading (no app.js edit) |
 
-**Operational sweep: 5 rules (W1006–W1009 + W1070) covering facilities · maintenance ·
-fleet · contracts · inventory — the main org-operational signals are now on the
-`/api/v1/dashboards/alerts` dashboard.** Further rules (e.g. license expiry) follow
-the same recipe.
+**Operational sweep (growing): facilities · maintenance · fleet · contracts ·
+inventory · procurement (W1006–W1009 / W1070 / W1132), plus quality (CAPA +
+calibration, W1121), waste (W1124) and occupational-health surveillance (W1126)
+rules added by the clinical-systems work — the main org-operational signals are
+now on the `/api/v1/dashboards/alerts` dashboard.** Newer rules use the
+**self-loading pattern** (`ctx.models.X || require('../../models/.../X')`) to avoid
+editing the app.js model loader (a parallel-work hot zone).
 
 > **Two sinks, by scope (the W1006 lesson):** beneficiary-keyed events feed the
 > per-beneficiary **`CareTimeline`** (native model hook → `integrationBus` →


### PR DESCRIPTION
A committed PO (approved/sent/partial) past its `expected_delivery_date` and not received → org-scoped `Alert` + `/api/v1/dashboards/alerts`. Distinct from inventory-low-stock: catches the *incoming* supply being late before it becomes a shortfall. Model `InventoryModulePurchaseOrder` (snake_case fields). **Self-loading pattern → NO app.js edit** (minimal merge surface vs the active parallel work). Test (4 assertions). Rule-count 28→29. routes-load + sprint hygiene green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)