### PR TITLE
feat(alerts): W1135 compliance rule — mandatory staff training overdue

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1336,6 +1336,8 @@ on:
       - 'backend/__tests__/staff-health-surveillance-overdue-rule-wave1126.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/po-delivery-overdue-rule-wave1132.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/training-compliance-overdue-rule-wave1135.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2655,6 +2657,8 @@ on:
       - 'backend/__tests__/staff-health-surveillance-overdue-rule-wave1126.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/po-delivery-overdue-rule-wave1132.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/training-compliance-overdue-rule-wave1135.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/alerts.engine.test.js
+++ b/backend/__tests__/alerts.engine.test.js
@@ -111,10 +111,10 @@ describe('buildEngine() with bundled rules', () => {
   // baseline of 5. Wave 5 (2026-05-16) added the EWMA anomaly
   // bridge. Pin the exact total so accidental rule removal shows
   // up as a test regression rather than a silent gap.
-  test('registers all 29 bundled rules (5 baseline + 13 wave-3 + 1 wave-5 + 5 operational + 2 quality W1121 + 1 waste W1124 + 1 occ-health W1126 + 1 procurement W1132)', () => {
-    expect(rules.length).toBe(29);
+  test('registers all 30 bundled rules (5 baseline + 13 wave-3 + 1 wave-5 + 5 operational + 2 quality + 1 waste + 1 occ-health + 1 procurement + 1 training-compliance W1135)', () => {
+    expect(rules.length).toBe(30);
     const eng = buildEngine();
-    expect(eng.rules.size).toBe(29);
+    expect(eng.rules.size).toBe(30);
   });
 
   test('credential-expiry-30d fires on near-expiry records', async () => {

--- a/backend/__tests__/training-compliance-overdue-rule-wave1135.test.js
+++ b/backend/__tests__/training-compliance-overdue-rule-wave1135.test.js
@@ -1,0 +1,73 @@
+/**
+ * W1135 — training-compliance-overdue smart-alert rule.
+ *
+ * `category: 'compliance'` rule: a staff member's mandatory training
+ * (`TrainingCompliance`) is `pending`/`overdue` with a past `dueDate`. Self-loading,
+ * so the test ALWAYS injects the model (the require fallback would buffer/hang
+ * without a DB). Fake-finder harness like the other rule tests.
+ */
+
+'use strict';
+
+const { AlertsEngine } = require('../alerts');
+const rules = require('../alerts/rules');
+
+function finder(rows) {
+  return { find: async q => rows.filter(r => shallowMatch(r, q)) };
+}
+
+function shallowMatch(doc, q) {
+  return Object.entries(q).every(([k, v]) => {
+    const docVal = doc[k];
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      if ('$in' in v) return v.$in.includes(docVal);
+      if ('$nin' in v) return !v.$nin.includes(docVal);
+    }
+    return docVal === v;
+  });
+}
+
+function ruleById(id) {
+  const r = rules.find(x => x.id === id);
+  if (!r) throw new Error(`Rule ${id} not registered`);
+  return r;
+}
+
+async function runOne(rows, now = new Date('2026-06-01')) {
+  const eng = new AlertsEngine({ now: () => now });
+  eng.register(ruleById('training-compliance-overdue'));
+  const result = await eng.runAll({ models: { TrainingCompliance: finder(rows) }, now });
+  return result.raised.filter(a => a.ruleId === 'training-compliance-overdue');
+}
+
+const PAST = new Date('2026-05-01');
+const FUTURE = new Date('2026-07-01');
+const BRANCH = '64b000000000000000000005';
+
+describe('training-compliance-overdue', () => {
+  test('is registered as a compliance rule', () => {
+    const r = ruleById('training-compliance-overdue');
+    expect(r.category).toBe('compliance');
+    expect(r.severity).toBe('high');
+  });
+
+  test('fires on pending/overdue records past due; skips future, completed, waived', async () => {
+    const raised = await runOne([
+      { _id: 't1', status: 'pending', dueDate: PAST, branchId: BRANCH, userId: 'u1', courseId: 'c1' },
+      { _id: 't2', status: 'overdue', dueDate: PAST, branchId: BRANCH, userId: 'u2', courseId: 'c2' },
+      { _id: 't3', status: 'pending', dueDate: FUTURE, branchId: BRANCH }, // not yet due
+      { _id: 't4', status: 'completed', dueDate: PAST, branchId: BRANCH },
+      { _id: 't5', status: 'waived', dueDate: PAST, branchId: BRANCH },
+    ]);
+    expect(raised).toHaveLength(2);
+    const keys = raised.map(r => r.key).sort();
+    expect(keys).toEqual(['training-compliance-overdue:t1', 'training-compliance-overdue:t2']);
+    expect(raised[0].category).toBe('compliance');
+    expect(raised.find(r => r.key.endsWith('t1')).branchId).toBe(BRANCH);
+  });
+
+  test('a pending record with no dueDate does not fire', async () => {
+    const raised = await runOne([{ _id: 't6', status: 'pending', branchId: BRANCH }]);
+    expect(raised).toHaveLength(0);
+  });
+});

--- a/backend/alerts/rules/index.js
+++ b/backend/alerts/rules/index.js
@@ -101,4 +101,8 @@ module.exports = [
   // Purchase order past its expected delivery date and not received.
   // Self-loading (no app.js edit).
   require('./purchase-order-delivery-overdue'),
+
+  // ── W1135 — compliance / training (1) ───────────────────────
+  // Staff mandatory training overdue (TrainingCompliance). Self-loading.
+  require('./training-compliance-overdue'),
 ];

--- a/backend/alerts/rules/training-compliance-overdue.js
+++ b/backend/alerts/rules/training-compliance-overdue.js
@@ -1,0 +1,54 @@
+/**
+ * Rule: a staff member's mandatory training is overdue.
+ *
+ * `category: 'compliance'` smart-alert rule (W1135). A `TrainingCompliance` record
+ * that is still `pending` (or already flagged `overdue`) with a `dueDate` in the
+ * past means a required course (fire-safety, infection-control, CPR, …) has
+ * lapsed — a CBAHI / patient-safety compliance gap. Distinct from the
+ * `credential-*` rules (professional licences) — this is recurring mandatory
+ * training. Feeds the same `Alert` sink + /api/v1/dashboards/alerts (routed to
+ * compliance recipients by category).
+ *
+ * Self-loading (no app.js model-loader edit): prefers the test-injectable
+ * `ctx.models` entry, falls back to a direct `require`.
+ */
+
+'use strict';
+
+const OPEN = ['pending', 'overdue']; // not completed / waived
+
+function resolveModel(ctx) {
+  const m = ctx.models && ctx.models.TrainingCompliance;
+  if (m && typeof m.find === 'function') return m;
+  try {
+    return require('../../models/TrainingCompliance');
+  } catch (_) {
+    return null;
+  }
+}
+
+module.exports = {
+  id: 'training-compliance-overdue',
+  severity: 'high',
+  category: 'compliance',
+  description: 'Staff mandatory training is overdue (past its due date, not completed)',
+
+  async evaluate(ctx = {}) {
+    const TC = resolveModel(ctx);
+    if (!TC) return [];
+    const now = ctx.now || new Date();
+    const rows = await TC.find({ status: { $in: OPEN } });
+    const findings = [];
+    for (const tc of rows) {
+      if (!tc.dueDate || new Date(tc.dueDate) >= now) continue;
+      const due = new Date(tc.dueDate).toISOString().slice(0, 10);
+      findings.push({
+        key: `training-compliance-overdue:${tc._id}`,
+        subject: { type: 'TrainingCompliance', id: tc._id },
+        branchId: tc.branchId,
+        message: `Mandatory training overdue since ${due} (user ${tc.userId || ''}, course ${tc.courseId || ''})`.trim(),
+      });
+    }
+    return findings;
+  },
+};

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -787,3 +787,4 @@ __tests__/staff-health-wave1125.test.js
 __tests__/staff-health-behavioral-wave1125.test.js
 __tests__/staff-health-surveillance-overdue-rule-wave1126.test.js
 __tests__/po-delivery-overdue-rule-wave1132.test.js
+__tests__/training-compliance-overdue-rule-wave1135.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -141,6 +141,7 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 | Contracts — service/vendor expired | `Contract` | rule `contract-expired` → `Alert` | ✅ **W1009** — ACTIVE contract past `endDate` (lapsed without renewal/close) |
 | Inventory — low stock | `InventoryStock` × `InventoryItem` | rule `inventory-low-stock` → `Alert` | ✅ **W1070** — first TWO-model join (stock qty vs item reorder point); out-of-stock → critical; both models are object-exports, resolved defensively |
 | Procurement — PO delivery overdue | `InventoryModulePurchaseOrder` | rule `purchase-order-delivery-overdue` → `Alert` | ✅ **W1132** — committed PO (approved/sent/partial) past `expected_delivery_date`, not received; catches late *incoming* supply before it becomes a low-stock shortfall; self-loading (no app.js edit) |
+| Compliance — mandatory training overdue | `TrainingCompliance` | rule `training-compliance-overdue` (category `compliance`) → `Alert` | ✅ **W1135** — pending/overdue staff training past `dueDate` (fire-safety/infection-control/CPR); distinct from `credential-*` (professional licences); self-loading |
 
 **Operational sweep (growing): facilities · maintenance · fleet · contracts ·
 inventory · procurement (W1006–W1009 / W1070 / W1132), plus quality (CAPA +


### PR DESCRIPTION
A `TrainingCompliance` record still pending/overdue with a past `dueDate` (fire-safety/infection-control/CPR lapsed) → `Alert` + `/api/v1/dashboards/alerts` (category compliance). Distinct from `credential-*` (professional licences) — recurring mandatory training. Self-loading (no app.js edit). Test (3 assertions). Rule-count 29→30. routes-load + sprint hygiene green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)