### PR TITLE
feat(alerts): W1138 quality rule — supplier SCAR response overdue (ISO 9001 §8.4)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1338,6 +1338,8 @@ on:
       - 'backend/__tests__/po-delivery-overdue-rule-wave1132.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/training-compliance-overdue-rule-wave1135.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/supplier-scar-overdue-rule-wave1138.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2659,6 +2661,8 @@ on:
       - 'backend/__tests__/po-delivery-overdue-rule-wave1132.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/training-compliance-overdue-rule-wave1135.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/supplier-scar-overdue-rule-wave1138.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/alerts.engine.test.js
+++ b/backend/__tests__/alerts.engine.test.js
@@ -111,10 +111,10 @@ describe('buildEngine() with bundled rules', () => {
   // baseline of 5. Wave 5 (2026-05-16) added the EWMA anomaly
   // bridge. Pin the exact total so accidental rule removal shows
   // up as a test regression rather than a silent gap.
-  test('registers all 30 bundled rules (5 baseline + 13 wave-3 + 1 wave-5 + 5 operational + 2 quality + 1 waste + 1 occ-health + 1 procurement + 1 training-compliance W1135)', () => {
-    expect(rules.length).toBe(30);
+  test('registers all 31 bundled rules (incl. 1 procurement W1132 + 1 training-compliance W1135 + 1 supplier-SCAR W1138)', () => {
+    expect(rules.length).toBe(31);
     const eng = buildEngine();
-    expect(eng.rules.size).toBe(30);
+    expect(eng.rules.size).toBe(31);
   });
 
   test('credential-expiry-30d fires on near-expiry records', async () => {

--- a/backend/__tests__/supplier-scar-overdue-rule-wave1138.test.js
+++ b/backend/__tests__/supplier-scar-overdue-rule-wave1138.test.js
@@ -1,0 +1,80 @@
+/**
+ * W1138 — supplier-scar-response-overdue smart-alert rule.
+ *
+ * `category: 'quality'` rule: a SCAR awaiting supplier response (open/acknowledged/
+ * in_progress/rejected) past its `responseDueBy`. Self-loading → the test ALWAYS
+ * injects the model. Fake-finder harness like the other rule tests.
+ */
+
+'use strict';
+
+const { AlertsEngine } = require('../alerts');
+const rules = require('../alerts/rules');
+
+function finder(rows) {
+  return { find: async q => rows.filter(r => shallowMatch(r, q)) };
+}
+
+function shallowMatch(doc, q) {
+  return Object.entries(q).every(([k, v]) => {
+    const docVal = doc[k];
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      if ('$in' in v) return v.$in.includes(docVal);
+      if ('$nin' in v) return !v.$nin.includes(docVal);
+    }
+    return docVal === v;
+  });
+}
+
+function ruleById(id) {
+  const r = rules.find(x => x.id === id);
+  if (!r) throw new Error(`Rule ${id} not registered`);
+  return r;
+}
+
+async function runOne(rows, now = new Date('2026-06-01')) {
+  const eng = new AlertsEngine({ now: () => now });
+  eng.register(ruleById('supplier-scar-response-overdue'));
+  const result = await eng.runAll({ models: { SupplierScar: finder(rows) }, now });
+  return result.raised.filter(a => a.ruleId === 'supplier-scar-response-overdue');
+}
+
+const PAST = new Date('2026-05-01');
+const FUTURE = new Date('2026-07-01');
+const BRANCH = '64b000000000000000000006';
+
+describe('supplier-scar-response-overdue', () => {
+  test('is registered as a quality rule', () => {
+    const r = ruleById('supplier-scar-response-overdue');
+    expect(r.category).toBe('quality');
+    expect(r.severity).toBe('high');
+  });
+
+  test('fires on awaiting-response SCARs past due; skips future + responded + closed', async () => {
+    const raised = await runOne([
+      { _id: 'q1', scarNumber: 'SCAR-1', status: 'open', responseDueBy: PAST, severity: 'major', branchId: BRANCH },
+      { _id: 'q2', scarNumber: 'SCAR-2', status: 'in_progress', responseDueBy: FUTURE, severity: 'minor', branchId: BRANCH },
+      { _id: 'q3', scarNumber: 'SCAR-3', status: 'response_received', responseDueBy: PAST, severity: 'major', branchId: BRANCH },
+      { _id: 'q4', scarNumber: 'SCAR-4', status: 'closed', responseDueBy: PAST, severity: 'major', branchId: BRANCH },
+    ]);
+    expect(raised).toHaveLength(1);
+    expect(raised[0].key).toBe('supplier-scar-response-overdue:q1');
+    expect(raised[0].branchId).toBe(BRANCH);
+    expect(raised[0].category).toBe('quality');
+    expect(raised[0].severity).toBe('high');
+    expect(raised[0].message).toMatch(/overdue/);
+  });
+
+  test('a critical SCAR overdue escalates to critical', async () => {
+    const raised = await runOne([
+      { _id: 'q5', scarNumber: 'SCAR-5', status: 'acknowledged', responseDueBy: PAST, severity: 'critical', branchId: BRANCH },
+    ]);
+    expect(raised).toHaveLength(1);
+    expect(raised[0].severity).toBe('critical');
+  });
+
+  test('a SCAR with no responseDueBy does not fire', async () => {
+    const raised = await runOne([{ _id: 'q6', status: 'open', severity: 'major', branchId: BRANCH }]);
+    expect(raised).toHaveLength(0);
+  });
+});

--- a/backend/alerts/rules/index.js
+++ b/backend/alerts/rules/index.js
@@ -105,4 +105,8 @@ module.exports = [
   // ── W1135 — compliance / training (1) ───────────────────────
   // Staff mandatory training overdue (TrainingCompliance). Self-loading.
   require('./training-compliance-overdue'),
+
+  // ── W1138 — quality / supplier (1) ──────────────────────────
+  // Supplier corrective action (SCAR) response overdue. Self-loading.
+  require('./supplier-scar-response-overdue'),
 ];

--- a/backend/alerts/rules/supplier-scar-response-overdue.js
+++ b/backend/alerts/rules/supplier-scar-response-overdue.js
@@ -1,0 +1,58 @@
+/**
+ * Rule: a Supplier Corrective Action Request (SCAR) is past its response due date
+ * with the supplier still owing a response.
+ *
+ * `category: 'quality'` smart-alert rule (W1138). Under ISO 9001 §8.4 a SCAR that
+ * sits `open`/`acknowledged`/`in_progress`/`rejected` past its `responseDueBy`
+ * means the supplier has not returned a root-cause + countermeasure on time — a
+ * supplier-quality risk. Once `response_received`/`verifying`/`verified`/`closed`
+ * the supplier has responded; `cancelled` is dropped. Critical-severity SCARs
+ * escalate the default `high` to `critical`.
+ *
+ * Self-loading (no app.js model-loader edit): prefers `ctx.models`, falls back to
+ * a direct `require`. Model: `SupplierScar` at `models/quality/SupplierScar.model.js`.
+ */
+
+'use strict';
+
+// states where the supplier still owes a response (excludes response_received /
+// verifying / verified / closed / cancelled)
+const AWAITING_RESPONSE = ['open', 'acknowledged', 'in_progress', 'rejected'];
+
+function resolveModel(ctx) {
+  const m = ctx.models && ctx.models.SupplierScar;
+  if (m && typeof m.find === 'function') return m;
+  try {
+    return require('../../models/quality/SupplierScar.model');
+  } catch (_) {
+    return null;
+  }
+}
+
+module.exports = {
+  id: 'supplier-scar-response-overdue',
+  severity: 'high',
+  category: 'quality',
+  description: 'Supplier corrective action (SCAR) response overdue',
+
+  async evaluate(ctx = {}) {
+    const Scar = resolveModel(ctx);
+    if (!Scar) return [];
+    const now = ctx.now || new Date();
+    const rows = await Scar.find({ status: { $in: AWAITING_RESPONSE } });
+    const findings = [];
+    for (const s of rows) {
+      if (!s.responseDueBy || new Date(s.responseDueBy) >= now) continue;
+      const due = new Date(s.responseDueBy).toISOString().slice(0, 10);
+      const finding = {
+        key: `supplier-scar-response-overdue:${s._id}`,
+        subject: { type: 'SupplierScar', id: s._id },
+        branchId: s.branchId,
+        message: `Supplier SCAR ${s.scarNumber || s._id} response overdue since ${due} (status: ${s.status})`,
+      };
+      if (s.severity === 'critical') finding.severity = 'critical';
+      findings.push(finding);
+    }
+    return findings;
+  },
+};

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -788,3 +788,4 @@ __tests__/staff-health-behavioral-wave1125.test.js
 __tests__/staff-health-surveillance-overdue-rule-wave1126.test.js
 __tests__/po-delivery-overdue-rule-wave1132.test.js
 __tests__/training-compliance-overdue-rule-wave1135.test.js
+__tests__/supplier-scar-overdue-rule-wave1138.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -142,6 +142,7 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 | Inventory — low stock | `InventoryStock` × `InventoryItem` | rule `inventory-low-stock` → `Alert` | ✅ **W1070** — first TWO-model join (stock qty vs item reorder point); out-of-stock → critical; both models are object-exports, resolved defensively |
 | Procurement — PO delivery overdue | `InventoryModulePurchaseOrder` | rule `purchase-order-delivery-overdue` → `Alert` | ✅ **W1132** — committed PO (approved/sent/partial) past `expected_delivery_date`, not received; catches late *incoming* supply before it becomes a low-stock shortfall; self-loading (no app.js edit) |
 | Compliance — mandatory training overdue | `TrainingCompliance` | rule `training-compliance-overdue` (category `compliance`) → `Alert` | ✅ **W1135** — pending/overdue staff training past `dueDate` (fire-safety/infection-control/CPR); distinct from `credential-*` (professional licences); self-loading |
+| Quality — supplier SCAR response overdue | `SupplierScar` | rule `supplier-scar-response-overdue` (category `quality`) → `Alert` | ✅ **W1138** — SCAR awaiting supplier response (open/acknowledged/in_progress/rejected) past `responseDueBy` (ISO 9001 §8.4); critical → critical; self-loading |
 
 **Operational sweep (growing): facilities · maintenance · fleet · contracts ·
 inventory · procurement (W1006–W1009 / W1070 / W1132), plus quality (CAPA +


### PR DESCRIPTION
A SCAR still awaiting supplier response (open/acknowledged/in_progress/rejected) past `responseDueBy` → `Alert` + `/api/v1/dashboards/alerts` (category quality). Supplier ignoring a corrective-action request = supplier-quality risk. Critical→critical. Self-loading (no app.js edit). Test (4 assertions). Rule-count 30→31. routes-load + sprint hygiene green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)