### PR TITLE
feat(alerts): W1141 financial rule — budget overrun (≥90% consumed)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1340,6 +1340,8 @@ on:
       - 'backend/__tests__/training-compliance-overdue-rule-wave1135.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/supplier-scar-overdue-rule-wave1138.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/budget-overrun-rule-wave1141.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2663,6 +2665,8 @@ on:
       - 'backend/__tests__/training-compliance-overdue-rule-wave1135.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/supplier-scar-overdue-rule-wave1138.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/budget-overrun-rule-wave1141.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/alerts.engine.test.js
+++ b/backend/__tests__/alerts.engine.test.js
@@ -111,10 +111,10 @@ describe('buildEngine() with bundled rules', () => {
   // baseline of 5. Wave 5 (2026-05-16) added the EWMA anomaly
   // bridge. Pin the exact total so accidental rule removal shows
   // up as a test regression rather than a silent gap.
-  test('registers all 31 bundled rules (incl. 1 procurement W1132 + 1 training-compliance W1135 + 1 supplier-SCAR W1138)', () => {
-    expect(rules.length).toBe(31);
+  test('registers all 32 bundled rules (incl. procurement W1132 + training W1135 + SCAR W1138 + budget W1141)', () => {
+    expect(rules.length).toBe(32);
     const eng = buildEngine();
-    expect(eng.rules.size).toBe(31);
+    expect(eng.rules.size).toBe(32);
   });
 
   test('credential-expiry-30d fires on near-expiry records', async () => {

--- a/backend/__tests__/budget-overrun-rule-wave1141.test.js
+++ b/backend/__tests__/budget-overrun-rule-wave1141.test.js
@@ -1,0 +1,79 @@
+/**
+ * W1141 — budget-overrun smart-alert rule.
+ *
+ * `category: 'financial'` rule: an active budget consumed ≥90% of allocation
+ * (≥100% → critical). Self-loading, so the test ALWAYS injects the model.
+ * Fake-finder harness like the other rule tests.
+ */
+
+'use strict';
+
+const { AlertsEngine } = require('../alerts');
+const rules = require('../alerts/rules');
+
+function finder(rows) {
+  return { find: async q => rows.filter(r => shallowMatch(r, q)) };
+}
+
+function shallowMatch(doc, q) {
+  return Object.entries(q).every(([k, v]) => {
+    const docVal = doc[k];
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      if ('$in' in v) return v.$in.includes(docVal);
+      if ('$nin' in v) return !v.$nin.includes(docVal);
+    }
+    return docVal === v;
+  });
+}
+
+function ruleById(id) {
+  const r = rules.find(x => x.id === id);
+  if (!r) throw new Error(`Rule ${id} not registered`);
+  return r;
+}
+
+async function runOne(rows) {
+  const eng = new AlertsEngine({ now: () => new Date('2026-06-01') });
+  eng.register(ruleById('budget-overrun'));
+  const result = await eng.runAll({ models: { Budget: finder(rows) } });
+  return result.raised.filter(a => a.ruleId === 'budget-overrun');
+}
+
+describe('budget-overrun', () => {
+  test('is registered as a financial rule', () => {
+    const r = ruleById('budget-overrun');
+    expect(r.category).toBe('financial');
+    expect(r.severity).toBe('high');
+  });
+
+  test('fires at ≥90% (high) and ≥100% (critical); skips under-90% and non-active', async () => {
+    const raised = await runOne([
+      { _id: 'b1', name: 'OT supplies', status: 'active', totalBudgeted: 1000, totalSpent: 950 }, // 95% → high
+      { _id: 'b2', name: 'PT supplies', status: 'active', totalBudgeted: 1000, totalSpent: 1200 }, // 120% → critical
+      { _id: 'b3', name: 'Admin', status: 'active', totalBudgeted: 1000, totalSpent: 500 }, // 50% → skip
+      { _id: 'b4', name: 'Old', status: 'closed', totalBudgeted: 1000, totalSpent: 1500 }, // closed → skip
+      { _id: 'b5', name: 'Zero', status: 'active', totalBudgeted: 0, totalSpent: 100 }, // no allocation → skip
+    ]);
+    expect(raised).toHaveLength(2);
+    const byId = Object.fromEntries(raised.map(r => [r.key, r]));
+    expect(byId['budget-overrun:b1'].severity).toBe('high');
+    expect(byId['budget-overrun:b1'].category).toBe('financial');
+    expect(byId['budget-overrun:b1'].message).toMatch(/95%/);
+    expect(byId['budget-overrun:b2'].severity).toBe('critical');
+  });
+
+  test('an approved (not yet active) budget over threshold also fires', async () => {
+    const raised = await runOne([
+      { _id: 'b6', status: 'approved', totalBudgeted: 100, totalSpent: 100 },
+    ]);
+    expect(raised).toHaveLength(1);
+    expect(raised[0].severity).toBe('critical'); // exactly 100%
+  });
+
+  test('no Budget model → defensive no-op', async () => {
+    const eng = new AlertsEngine({ now: () => new Date('2026-06-01') });
+    eng.register(ruleById('budget-overrun'));
+    const result = await eng.runAll({ models: { Budget: { find: async () => [] } } });
+    expect(result.raised.filter(a => a.ruleId === 'budget-overrun')).toHaveLength(0);
+  });
+});

--- a/backend/alerts/rules/budget-overrun.js
+++ b/backend/alerts/rules/budget-overrun.js
@@ -1,0 +1,60 @@
+/**
+ * Rule: an active budget has consumed ≥90% of its allocation (over budget when
+ * ≥100%).
+ *
+ * `category: 'financial'` smart-alert rule (W1141). Distinct from the W401
+ * `budgetThresholdSweeper`, which *notifies* via the integration bus — this
+ * persists a trackable dashboard `Alert` (assignable, with a state machine) so the
+ * finance team can work it. Surfaced to the `Alert` sink + /api/v1/dashboards/alerts.
+ *
+ * `Budget` is org/fiscal-level (no branch field) → platform-scoped alerts. Two
+ * tiers: ≥100% consumed = over budget → `critical`; 90–100% = approaching limit →
+ * `high`. Self-loading (no app.js model-loader edit).
+ */
+
+'use strict';
+
+const ACTIVE = ['approved', 'active'];
+const WARN_RATIO = 0.9;
+
+function resolveModel(ctx) {
+  const m = ctx.models && ctx.models.Budget;
+  if (m && typeof m.find === 'function') return m;
+  try {
+    return require('../../models/Budget');
+  } catch (_) {
+    return null;
+  }
+}
+
+module.exports = {
+  id: 'budget-overrun',
+  severity: 'high',
+  category: 'financial',
+  description: 'Budget consumed ≥90% of its allocation (over budget at ≥100%)',
+
+  async evaluate(ctx = {}) {
+    const Budget = resolveModel(ctx);
+    if (!Budget) return [];
+    const rows = await Budget.find({ status: { $in: ACTIVE } });
+    const findings = [];
+    for (const b of rows) {
+      const budgeted = Number(b.totalBudgeted) || 0;
+      if (budgeted <= 0) continue;
+      const spent = Number(b.totalSpent) || 0;
+      const ratio = spent / budgeted;
+      if (ratio < WARN_RATIO) continue;
+      const pct = Math.round(ratio * 100);
+      const label = b.name || b.fiscalYear || b._id;
+      const finding = {
+        key: `budget-overrun:${b._id}`,
+        subject: { type: 'Budget', id: b._id },
+        branchId: b.branchId, // org/fiscal-level (usually undefined) → platform alert
+        message: `Budget ${label} at ${pct}% of allocation (${spent} / ${budgeted})`,
+      };
+      if (ratio >= 1) finding.severity = 'critical'; // over budget
+      findings.push(finding);
+    }
+    return findings;
+  },
+};

--- a/backend/alerts/rules/index.js
+++ b/backend/alerts/rules/index.js
@@ -109,4 +109,8 @@ module.exports = [
   // ── W1138 — quality / supplier (1) ──────────────────────────
   // Supplier corrective action (SCAR) response overdue. Self-loading.
   require('./supplier-scar-response-overdue'),
+
+  // ── W1141 — financial / budget (1) ──────────────────────────
+  // Active budget consumed ≥90% of allocation (≥100% = critical). Self-loading.
+  require('./budget-overrun'),
 ];

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -789,3 +789,4 @@ __tests__/staff-health-surveillance-overdue-rule-wave1126.test.js
 __tests__/po-delivery-overdue-rule-wave1132.test.js
 __tests__/training-compliance-overdue-rule-wave1135.test.js
 __tests__/supplier-scar-overdue-rule-wave1138.test.js
+__tests__/budget-overrun-rule-wave1141.test.js

--- a/docs/architecture/CORE_LINKAGE_LEDGER.md
+++ b/docs/architecture/CORE_LINKAGE_LEDGER.md
@@ -143,6 +143,7 @@ enabled) covers the 21 LIVE-registry mappings. The rest, by priority:
 | Procurement — PO delivery overdue | `InventoryModulePurchaseOrder` | rule `purchase-order-delivery-overdue` → `Alert` | ✅ **W1132** — committed PO (approved/sent/partial) past `expected_delivery_date`, not received; catches late *incoming* supply before it becomes a low-stock shortfall; self-loading (no app.js edit) |
 | Compliance — mandatory training overdue | `TrainingCompliance` | rule `training-compliance-overdue` (category `compliance`) → `Alert` | ✅ **W1135** — pending/overdue staff training past `dueDate` (fire-safety/infection-control/CPR); distinct from `credential-*` (professional licences); self-loading |
 | Quality — supplier SCAR response overdue | `SupplierScar` | rule `supplier-scar-response-overdue` (category `quality`) → `Alert` | ✅ **W1138** — SCAR awaiting supplier response (open/acknowledged/in_progress/rejected) past `responseDueBy` (ISO 9001 §8.4); critical → critical; self-loading |
+| Financial — budget overrun | `Budget` | rule `budget-overrun` (category `financial`) → `Alert` | ✅ **W1141** — active budget ≥90% consumed (≥100% → critical); a trackable dashboard Alert (distinct from the W401 budget sweeper's transient notification); platform-scoped; self-loading |
 
 **Operational sweep (growing): facilities · maintenance · fleet · contracts ·
 inventory · procurement (W1006–W1009 / W1070 / W1132), plus quality (CAPA +


### PR DESCRIPTION
An active budget ≥90% consumed → `Alert` + `/api/v1/dashboards/alerts` (category financial). Distinct from the W401 budget sweeper (transient notification) — this persists a trackable dashboard Alert. ≥100%→critical, 90-100%→high. Platform-scoped (Budget has no branch). Self-loading (no app.js edit). Test (4 assertions). Rule-count 31→32. routes-load + sprint hygiene green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)