### PR TITLE
feat(alerts): W1151 — staff-certification expiry alerting on the UI-backed model

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1346,6 +1346,8 @@ on:
       - 'backend/__tests__/model-event-bridge-mapping-models-exist-wave1148.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/alert-engine-model-availability-wave1149.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/staff-certification-rules-wave1151.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2675,6 +2677,8 @@ on:
       - 'backend/__tests__/model-event-bridge-mapping-models-exist-wave1148.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/alert-engine-model-availability-wave1149.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/staff-certification-rules-wave1151.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/alerts.engine.test.js
+++ b/backend/__tests__/alerts.engine.test.js
@@ -111,10 +111,10 @@ describe('buildEngine() with bundled rules', () => {
   // baseline of 5. Wave 5 (2026-05-16) added the EWMA anomaly
   // bridge. Pin the exact total so accidental rule removal shows
   // up as a test regression rather than a silent gap.
-  test('registers all 31 bundled rules (W1150 removed orphan irp-overdue-approval)', () => {
-    expect(rules.length).toBe(31);
+  test('registers all 33 bundled rules (W1151 added staff-certification expiry pair)', () => {
+    expect(rules.length).toBe(33);
     const eng = buildEngine();
-    expect(eng.rules.size).toBe(31);
+    expect(eng.rules.size).toBe(33);
   });
 
   test('credential-expiry-30d fires on near-expiry records', async () => {

--- a/backend/__tests__/staff-certification-rules-wave1151.test.js
+++ b/backend/__tests__/staff-certification-rules-wave1151.test.js
@@ -1,0 +1,130 @@
+/**
+ * W1151 — staff-certification expiry alert rules.
+ *
+ * Covers the credential model the web-admin `staff-certifications` UI actually
+ * writes to (`StaffCertification`, via /api/v1/rehabilitation-advanced/...) —
+ * distinct from `EmployeeCredential` (the W1147 credential-* rules). Without
+ * these, expiry alerting would never fire on the org's onboarded credential
+ * data because it lands in StaffCertification, not EmployeeCredential.
+ *
+ * Direct `evaluate(ctx)` tests with an injected fake finder (no Mongo). The
+ * finder supports nested dotted keys (expiry is at certification_info.expiry_date)
+ * plus the $in/$nin/$lt/$gte/$lte operators the rules use.
+ */
+
+'use strict';
+
+const rules = require('../alerts/rules');
+const expiredRule = require('../alerts/rules/staff-certification-expired');
+const expiry30dRule = require('../alerts/rules/staff-certification-expiry-30d');
+
+function shallowMatch(doc, q) {
+  return Object.entries(q).every(([k, v]) => {
+    const docVal = k.includes('.')
+      ? k.split('.').reduce((o, p) => (o ? o[p] : undefined), doc)
+      : doc[k];
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      if ('$in' in v) return v.$in.includes(docVal);
+      if ('$nin' in v) return !v.$nin.includes(docVal);
+      if ('$lt' in v || '$gt' in v || '$gte' in v || '$lte' in v) {
+        if (docVal == null) return false;
+        const d = docVal instanceof Date ? docVal.getTime() : docVal;
+        if (v.$gte != null) {
+          const g = v.$gte instanceof Date ? v.$gte.getTime() : v.$gte;
+          if (d < g) return false;
+        }
+        if (v.$lte != null) {
+          const l = v.$lte instanceof Date ? v.$lte.getTime() : v.$lte;
+          if (d > l) return false;
+        }
+        if (v.$lt != null) {
+          const lt = v.$lt instanceof Date ? v.$lt.getTime() : v.$lt;
+          if (d >= lt) return false;
+        }
+        if (v.$gt != null) {
+          const gt = v.$gt instanceof Date ? v.$gt.getTime() : v.$gt;
+          if (d <= gt) return false;
+        }
+        return true;
+      }
+      return false;
+    }
+    return docVal === v;
+  });
+}
+
+function finder(rows) {
+  return { find: async q => rows.filter(r => shallowMatch(r, q)) };
+}
+
+const cert = (id, over = {}) => ({
+  _id: id,
+  staff_id: 'u-' + id,
+  is_lifetime: false,
+  status: 'active',
+  certification_info: {
+    certification_name: 'Cert ' + id,
+    certification_type: 'professional',
+    expiry_date: new Date('2026-05-01'),
+    ...(over.certification_info || {}),
+  },
+  ...over,
+});
+
+describe('W1151 — staff-certification-expired', () => {
+  test('fires on past-expiry certs; skips future/lifetime/revoked; severity per type', async () => {
+    const now = new Date('2026-06-10');
+    const StaffCertification = finder([
+      cert('sc1', {
+        certification_info: {
+          certification_name: 'SCFHS License',
+          certification_type: 'license',
+          expiry_date: new Date('2026-05-01'),
+        },
+      }), // expired license → fires (critical)
+      cert('sc2', { certification_info: { expiry_date: new Date('2026-12-01') } }), // future → skip
+      cert('sc3', { is_lifetime: true }), // lifetime → skip even though expiry past
+      cert('sc4', { status: 'revoked' }), // revoked → skip
+    ]);
+    const out = await expiredRule.evaluate({ models: { StaffCertification }, now });
+    expect(out).toHaveLength(1);
+    expect(out[0].subject.id).toBe('sc1');
+    expect(out[0].subject.type).toBe('StaffCertification');
+    expect(out[0].severity).toBe('critical'); // license
+    expect(out[0].message).toContain('SCFHS License');
+  });
+
+  test('returns [] when the model is not injectable (graceful)', async () => {
+    const out = await expiredRule.evaluate({ models: {}, now: new Date('2026-06-10') });
+    expect(out).toEqual([]);
+  });
+});
+
+describe('W1151 — staff-certification-expiry-30d', () => {
+  test('fires only within the 30-day window; skips already-expired/far-future', async () => {
+    const now = new Date('2026-06-10');
+    const StaffCertification = finder([
+      cert('sc1', { certification_info: { expiry_date: new Date('2026-06-20') } }), // ~10d → fires
+      cert('sc2', { certification_info: { expiry_date: new Date('2026-09-01') } }), // >30d → skip
+      cert('sc3', { status: 'expired', certification_info: { expiry_date: new Date('2026-06-20') } }), // already expired → skip
+    ]);
+    const out = await expiry30dRule.evaluate({ models: { StaffCertification }, now });
+    expect(out).toHaveLength(1);
+    expect(out[0].subject.id).toBe('sc1');
+    expect(out[0].message).toContain('expires on');
+  });
+});
+
+describe('W1151 — registration', () => {
+  test('both rules are in the bundled registry with valid shape', () => {
+    const found = rules.filter(r =>
+      ['staff-certification-expired', 'staff-certification-expiry-30d'].includes(r.id)
+    );
+    expect(found).toHaveLength(2);
+    for (const r of found) {
+      expect(['info', 'warning', 'high', 'critical']).toContain(r.severity);
+      expect(r.category).toBe('hr');
+      expect(typeof r.evaluate).toBe('function');
+    }
+  });
+});

--- a/backend/alerts/rules/index.js
+++ b/backend/alerts/rules/index.js
@@ -40,6 +40,9 @@ module.exports = [
 
   // ── Wave 3 — HR escalations (3) ─────────────────────────────
   require('./credential-expired'),
+  // ── W1151 — staff certification expiry (the UI-backed credential model) ──
+  require('./staff-certification-expired'),
+  require('./staff-certification-expiry-30d'),
   require('./employment-contract-expiring-60d'),
   require('./employment-contract-expired'),
 

--- a/backend/alerts/rules/staff-certification-expired.js
+++ b/backend/alerts/rules/staff-certification-expired.js
@@ -1,0 +1,72 @@
+/**
+ * Rule: staff professional certification past its expiry date.
+ *
+ * Companion to `staff-certification-expiry-30d`. Fires the moment a staff
+ * certification lapses. This targets `StaffCertification` — the model the
+ * web-admin `staff-certifications` UI actually writes to (via
+ * `POST /api/v1/rehabilitation-advanced/staff-certifications`). It is DISTINCT
+ * from `EmployeeCredential` (the `credential-expired` rule): that model is
+ * purpose-built but has no data-entry UI, so on a live deployment credential
+ * data lands in StaffCertification. W1151 covers BOTH so expiry alerting fires
+ * regardless of which credential model the org populates.
+ *
+ * Self-loading: the smart-alerts loader does not inject this model. Tests MUST
+ * inject it (a bare require() with no DB connection would buffer find() forever).
+ * Expiry is NESTED at `certification_info.expiry_date`; `is_lifetime` certs have
+ * no expiry and are skipped.
+ */
+
+'use strict';
+
+// Allowed severities are info|warning|high|critical (no 'medium').
+const SEVERITY_BY_TYPE = Object.freeze({
+  license: 'critical', // can't practice without a valid license
+  professional: 'high',
+  specialty: 'high',
+  accreditation: 'high',
+  continuing_education: 'warning',
+});
+
+function resolveModel(ctx) {
+  const injected = ctx.models && ctx.models.StaffCertification;
+  if (injected) return injected;
+  try {
+    return require('../../models/rehab-advanced/StaffCertification.model');
+  } catch (_) {
+    return null;
+  }
+}
+
+module.exports = {
+  id: 'staff-certification-expired',
+  severity: 'high',
+  category: 'hr',
+  description: 'Staff professional certification has expired',
+
+  async evaluate(ctx) {
+    const Cert = resolveModel(ctx);
+    if (!Cert || typeof Cert.find !== 'function') return [];
+    const now = ctx.now || new Date();
+    const rows = await Cert.find({
+      'certification_info.expiry_date': { $lt: now },
+      // exclude already-handled states (revoked/inactive) + in-flight renewal
+      status: { $nin: ['revoked', 'inactive', 'pending_renewal'] },
+    });
+    return rows
+      .filter(c => !c.is_lifetime && c.certification_info && c.certification_info.expiry_date)
+      .map(c => {
+        const info = c.certification_info || {};
+        return {
+          key: `staff-cert-expired:${c._id}`,
+          subject: {
+            type: 'StaffCertification',
+            id: c._id,
+            staffId: c.staff_id,
+            certType: info.certification_type,
+          },
+          severity: SEVERITY_BY_TYPE[info.certification_type] || 'high',
+          message: `${info.certification_name || c.certification_id || c._id} EXPIRED on ${new Date(info.expiry_date).toISOString().slice(0, 10)}`,
+        };
+      });
+  },
+};

--- a/backend/alerts/rules/staff-certification-expiry-30d.js
+++ b/backend/alerts/rules/staff-certification-expiry-30d.js
@@ -1,0 +1,55 @@
+/**
+ * Rule: staff professional certification expiring within 30 days.
+ *
+ * 30-day heads-up companion to `staff-certification-expired`. Targets the
+ * UI-backed `StaffCertification` model (see that file for the EmployeeCredential
+ * rationale). Uniform `warning` severity (a renewal nudge, not yet a breach).
+ * Self-loading; tests MUST inject the model. Expiry is nested at
+ * `certification_info.expiry_date`; `is_lifetime` certs are skipped.
+ */
+
+'use strict';
+
+function resolveModel(ctx) {
+  const injected = ctx.models && ctx.models.StaffCertification;
+  if (injected) return injected;
+  try {
+    return require('../../models/rehab-advanced/StaffCertification.model');
+  } catch (_) {
+    return null;
+  }
+}
+
+module.exports = {
+  id: 'staff-certification-expiry-30d',
+  severity: 'warning',
+  category: 'hr',
+  description: 'Staff professional certification expires within 30 days',
+
+  async evaluate(ctx) {
+    const Cert = resolveModel(ctx);
+    if (!Cert || typeof Cert.find !== 'function') return [];
+    const now = ctx.now || new Date();
+    const horizon = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+    const rows = await Cert.find({
+      'certification_info.expiry_date': { $gte: now, $lte: horizon },
+      // not already expired / revoked / inactive / mid-renewal
+      status: { $nin: ['revoked', 'inactive', 'expired', 'pending_renewal'] },
+    });
+    return rows
+      .filter(c => !c.is_lifetime && c.certification_info && c.certification_info.expiry_date)
+      .map(c => {
+        const info = c.certification_info || {};
+        return {
+          key: `staff-cert:${c._id}`,
+          subject: {
+            type: 'StaffCertification',
+            id: c._id,
+            staffId: c.staff_id,
+            certType: info.certification_type,
+          },
+          message: `${info.certification_name || c.certification_id || c._id} expires on ${new Date(info.expiry_date).toISOString().slice(0, 10)}`,
+        };
+      });
+  },
+};

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -792,3 +792,4 @@ __tests__/supplier-scar-overdue-rule-wave1138.test.js
 __tests__/budget-overrun-rule-wave1141.test.js
 __tests__/model-event-bridge-mapping-models-exist-wave1148.test.js
 __tests__/alert-engine-model-availability-wave1149.test.js
+__tests__/staff-certification-rules-wave1151.test.js


### PR DESCRIPTION
## What

An **onboarding-readiness** fix, found by tracing the credential data path on the freshly-deployed (un-onboarded) production.

The web-admin **`staff-certifications`** UI writes credentials to the **`StaffCertification`** model (`POST /api/v1/rehabilitation-advanced/staff-certifications`). But the W1147 credential-expiry rules read **`EmployeeCredential`** — a purpose-built model with **no data-entry UI**. So the moment the org onboards real staff certifications, expiry alerting would **never fire** (wrong, always-empty model). The credential domain is fragmented (~19 cert/license models); `StaffCertification` is the one the UI actually populates.

## Change

Adds **two self-loading rules** on `StaffCertification` — **additive**, so it doesn't touch the W1147 `EmployeeCredential` rules and **both** credential models are now covered:

- `staff-certification-expired` — per-type severity (`license`=critical, `professional`/`specialty`/`accreditation`=high, `continuing_education`=warning)
- `staff-certification-expiry-30d` — `warning` heads-up

Both query the **nested** `certification_info.expiry_date`, skip `is_lifetime` certs and already-handled states (`revoked`/`inactive`/`pending_renewal`; the 30-day rule also skips `expired`). Org-scoped (model is `staff_id`-keyed, no own `branchId`). Rule count **31 → 33**. The W1149 model-availability guard confirms the self-load `require()` path resolves.

## Severity / urgency

**Not urgent** — prod currently has 0 credential records (un-onboarded). This is *readiness*: it makes credential-expiry alerting actually fire the moment real certifications are entered, rather than silently watching an empty model.

## Tests

`34/34` green across the new W1151 rule test (direct `evaluate()` with an injected nested-key finder) + `alerts.engine` (count) + `alerts.rules.wave3` (registry shape) + the W1149 guard. Full pre-push gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)