### PR TITLE
fix(beneficiaries): correct $bucket default in /statistics progress distribution (prod 500)

### DIFF
--- a/backend/routes/beneficiaries.js
+++ b/backend/routes/beneficiaries.js
@@ -332,17 +332,25 @@ router.get('/statistics', async (req, res) => {
         $bucket: {
           groupBy: { $ifNull: ['$progress', 0] },
           boundaries: [0, 21, 41, 61, 81, 101],
-          default: 0,
+          // $bucket requires `default` to be < the lowest boundary OR >= the
+          // highest. `0` collided with boundary[0]=0, so any out-of-range
+          // progress (>100 or <0) routed to the default bucket made MongoDB
+          // throw "$bucket 'default' field must be less than the lowest
+          // boundary...". Use a non-numeric sentinel (sorts after all numbers
+          // in BSON order = valid) and drop it from the output below.
+          default: 'other',
           output: { count: { $sum: 1 } },
         },
       },
     ]);
 
     const progLabels = { 0: '0-20%', 21: '21-40%', 41: '41-60%', 61: '61-80%', 81: '81-100%' };
-    const progressDistFormatted = progDist.map(p => ({
-      range: progLabels[p._id] || '0-20%',
-      count: p.count,
-    }));
+    const progressDistFormatted = progDist
+      .filter(p => p._id !== 'other')
+      .map(p => ({
+        range: progLabels[p._id] || '0-20%',
+        count: p.count,
+      }));
 
     res.json({
       success: true,


### PR DESCRIPTION
## Real prod bug (found via error-log audit 2026-06-10)
`GET /beneficiaries/statistics` was throwing **500** intermittently (3× today in prod `error.log`):
> `The $bucket 'default' field must be less than the lowest boundary or greater than or equal to the highest boundary`

**Root cause:** the progress-distribution `$bucket` used `default: 0`, but MongoDB requires the `$bucket` default to be `< lowest boundary` OR `>= highest`. `0` equals `boundaries[0]`, so any beneficiary whose `progress` fell outside `[0,101)` routed to the default bucket and crashed the aggregation — failing the whole stats endpoint for affected branches. (The age `$bucket` just above correctly uses `default: 'unknown'`.)

**Fix:** use a non-numeric sentinel default (`'other'` — sorts after all numbers in BSON order = valid, mirroring the age bucket) and filter it out of the output (like the age distribution drops `'unknown'`) so anomalous out-of-range progress isn't mislabeled as '0-20%'.

Verified: syntax clean, `check:routes-load` green (558 routes), pre-push gates passed. Surgical 1-file change; not in any in-flight work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)