### PR TITLE
fix(security): W1190 — close anonymous access to dashboard-saved-views

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1375,6 +1375,9 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/forms-approval-chain-wave1186.test.js'
       - 'backend/__tests__/forms-approval-chain-behavioral-wave1186.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/dashboard-saved-views-auth-wave1190.test.js'
+      - 'backend/__tests__/dashboard-saved-views-auth-behavioral-wave1190.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2733,6 +2736,9 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/forms-approval-chain-wave1186.test.js'
       - 'backend/__tests__/forms-approval-chain-behavioral-wave1186.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/dashboard-saved-views-auth-wave1190.test.js'
+      - 'backend/__tests__/dashboard-saved-views-auth-behavioral-wave1190.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/dashboard-saved-views-auth-behavioral-wave1190.test.js
+++ b/backend/__tests__/dashboard-saved-views-auth-behavioral-wave1190.test.js
@@ -1,0 +1,64 @@
+/**
+ * W1190 — behavioral counterpart: the router rejects anonymous requests on a
+ * bare (auth-less) mount, proving the router-level gate actually fires.
+ *
+ * This reproduces the phases.registry `safeMount` path: mount the route's
+ * DEFAULT export (the exact instance safeMount `require()`s) at a prefix WITHOUT
+ * injecting any auth middleware, then assert every verb returns 401 when no
+ * Authorization header is present. A static guard can confirm the source text;
+ * only this confirms the middleware truly runs and short-circuits before the
+ * handlers (W356–W384 static+behavioral pairing doctrine).
+ *
+ * No DB / no token needed — `authenticate` returns 401 on a missing Bearer token
+ * before any handler (and before `getStore`), so the saved-view store is never
+ * touched.
+ */
+
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+
+// The DEFAULT export === `buildRouter()` instance — the one phases.registry
+// safeMount mounts with NO middleware.
+const savedViewsRouter = require('../routes/dashboard-saved-views.routes');
+
+function bareApp() {
+  const app = express();
+  // Deliberately auth-less mount, mirroring safeMount(app, '/api/dashboard-saved-views', …)
+  app.use('/api/dashboard-saved-views', savedViewsRouter);
+  return app;
+}
+
+describe('W1190 dashboard-saved-views rejects anonymous access on a bare mount (behavioral)', () => {
+  const app = bareApp();
+
+  test('GET / (list) → 401 without a token', async () => {
+    const res = await request(app).get('/api/dashboard-saved-views/');
+    expect(res.status).toBe(401);
+  });
+
+  test('POST / (create) → 401 without a token (no owner-less view can be seeded)', async () => {
+    const res = await request(app)
+      .post('/api/dashboard-saved-views/')
+      .send({ dashboardId: 'd1', title: 'x' });
+    expect(res.status).toBe(401);
+  });
+
+  test('GET /:id → 401 without a token', async () => {
+    const res = await request(app).get('/api/dashboard-saved-views/anything');
+    expect(res.status).toBe(401);
+  });
+
+  test('PATCH /:id → 401 without a token (no anonymous tamper of owner-less views)', async () => {
+    const res = await request(app)
+      .patch('/api/dashboard-saved-views/anything')
+      .send({ title: 'hijack' });
+    expect(res.status).toBe(401);
+  });
+
+  test('DELETE /:id → 401 without a token', async () => {
+    const res = await request(app).delete('/api/dashboard-saved-views/anything');
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/__tests__/dashboard-saved-views-auth-wave1190.test.js
+++ b/backend/__tests__/dashboard-saved-views-auth-wave1190.test.js
@@ -1,0 +1,53 @@
+/**
+ * W1190 — static drift guard: dashboard-saved-views must self-authenticate.
+ *
+ * WHY: `routes/dashboard-saved-views.routes.js` is mounted TWICE —
+ *   (a) app.js `/api/v1/dashboards/saved-views` WITH an injected `authenticate`,
+ *   (b) phases.registry `safeMount(['/api/dashboard-saved-views', …])` which
+ *       injects NO middleware (safeMount === bare `app.use`, no auth variant).
+ * Before W1190 the router had no router-level gate, so mount (b) exposed the
+ * full list/create/update/delete surface to ANONYMOUS callers — and because the
+ * owner guards read `if (view.ownerUserId && …)`, an owner-less view (POSTed
+ * anonymously, ownerUserId → null) could be PATCHed/DELETEd by anyone.
+ *
+ * The fix is a router-level `router.use(authenticate)` inside buildRouter, which
+ * protects EVERY mount (current + future). This guard locks that in so a future
+ * edit can't silently drop it and re-open the hole. Pairs with the behavioral
+ * counterpart `dashboard-saved-views-auth-behavioral-wave1190.test.js`.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROUTE_FILE = path.join(__dirname, '..', 'routes', 'dashboard-saved-views.routes.js');
+const REGISTRY = path.join(__dirname, '..', 'routes', 'registries', 'phases.registry.js');
+
+describe('W1190 dashboard-saved-views self-authentication (static)', () => {
+  const src = fs.readFileSync(ROUTE_FILE, 'utf8');
+
+  test('imports `authenticate` from the canonical middleware/auth', () => {
+    expect(src).toMatch(/require\(\s*['"]\.\.\/middleware\/auth['"]\s*\)/);
+    expect(src).toMatch(/\bauthenticate\b/);
+  });
+
+  test('applies router.use(authenticate) at the router level', () => {
+    expect(src).toMatch(/router\.use\(\s*authenticate\s*\)/);
+  });
+
+  test('the auth gate precedes every route handler (no unguarded verb)', () => {
+    const gateIdx = src.search(/router\.use\(\s*authenticate\s*\)/);
+    const firstVerbIdx = src.search(/router\.(get|post|put|patch|delete)\(/);
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(firstVerbIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeLessThan(firstVerbIdx);
+  });
+
+  test('phases.registry still mounts it via auth-less safeMount (the reason the gate is load-bearing)', () => {
+    // If this mount is ever removed/changed, this assertion fails and prompts a
+    // re-confirmation that the self-auth is still the load-bearing protection.
+    const reg = fs.readFileSync(REGISTRY, 'utf8');
+    expect(reg).toMatch(/safeMount\([\s\S]{0,120}dashboard-saved-views\.routes/);
+  });
+});

--- a/backend/routes/dashboard-saved-views.routes.js
+++ b/backend/routes/dashboard-saved-views.routes.js
@@ -22,6 +22,16 @@
 'use strict';
 
 const express = require('express');
+// W1190 — self-authenticate at the router level. This file is mounted TWICE:
+// (a) app.js `/api/v1/dashboards/saved-views` WITH an injected `authenticate`,
+// and (b) phases.registry `safeMount` at `/api/dashboard-saved-views` (+v1)
+// which injects NO middleware (safeMount = bare `app.use`). Without a router-
+// level gate, mount (b) was reachable ANONYMOUSLY: an attacker could list views,
+// POST an owner-less view (pickUserId → null), then PATCH/DELETE it (the owner
+// guard `if (view.ownerUserId && …)` is skipped when ownerUserId is falsy).
+// `authenticate` here protects every current and future mount; the redundant
+// injection on mount (a) is a harmless idempotent re-validation of the JWT.
+const { authenticate } = require('../middleware/auth');
 
 function asyncWrap(fn) {
   return (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
@@ -56,6 +66,7 @@ function canSee(view, { userId, role }) {
 function buildRouter() {
   const router = express.Router();
   router.use(express.json());
+  router.use(authenticate); // W1190 — gate EVERY mount (see file header)
 
   router.get(
     '/',

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -816,3 +816,5 @@ __tests__/finance-cheques-branch-isolation-wave1172.test.js
 __tests__/finance-cheques-branch-isolation-behavioral-wave1172.test.js
 __tests__/forms-approval-chain-wave1186.test.js
 __tests__/forms-approval-chain-behavioral-wave1186.test.js
+__tests__/dashboard-saved-views-auth-wave1190.test.js
+__tests__/dashboard-saved-views-auth-behavioral-wave1190.test.js


### PR DESCRIPTION
## What

`routes/dashboard-saved-views.routes.js` is mounted **twice**, and one mount had **no authentication**:

| Mount | Path | Auth |
| --- | --- | --- |
| app.js | `/api/v1/dashboards/saved-views` | ✅ `authenticate` injected |
| phases.registry `safeMount` | `/api/dashboard-saved-views` (+`/api/v1/...`) | ❌ none — `safeMount` is a bare `app.use(path, handler)` |

The router had no router-level gate, so the `safeMount` path exposed the full **list / create / update / delete** surface to **anonymous** callers.

## Why it's exploitable (not just noise)

The owner guards read `if (view.ownerUserId && view.ownerUserId !== userId)` — which is **skipped when `ownerUserId` is falsy**. So an anonymous attacker could:

1. `POST /api/dashboard-saved-views` → create an **owner-less** view (`pickUserId(req)` → `null` with no `req.user`)
2. `PATCH` / `DELETE` that view anonymously — owner guard bypassed
3. `GET /` → enumerate all public/owner-less saved-view configs (filters, shared roles)

Not PHI, but a clear violation of the platform's *"everything authenticated except the login flow"* doctrine — the same class as **W471/W502**, which swept the `_registry.js` `dualMount` surface. This one slipped through because it's mounted via `safeMount`, which both the W502 sweep and the canonical `scripts/audit-unauthenticated-routes.js` classify as **"unknown mount"** (auditor reports `confirmedCount: 0` while this hole was live).

## Fix

One line: `router.use(authenticate)` inside `buildRouter` — protects **every** mount, current and future. Authenticated users are unaffected (they still see their owned/shared/public views); only **anonymous** access is closed. The `authenticate` already injected on the app.js mount becomes a harmless idempotent JWT re-validation.

## Guards — 9 assertions, both sprint-enumerated

- **`dashboard-saved-views-auth-wave1190`** (static): imports `authenticate`, applies `router.use(authenticate)` *before* any verb, and asserts the auth-less `safeMount` still exists (keeps the gate load-bearing).
- **`dashboard-saved-views-auth-behavioral-wave1190`** (supertest): mounts the default export on a **bare auth-less prefix** (reproducing `safeMount`) — every verb returns **401** without a token. No DB/token needed (`authenticate` 401s before any handler).

## Verified locally

`check:routes-load` (558 files clean) · `check:sprint-paths` in sync · `check:gitignored-sources` baseline · both guards green (9/9).

## Follow-up (not in this PR)

The canonical `audit-unauthenticated-routes.js` returns "unknown mount" for `safeMount`- / `app.js`- / bootstrap-mounted routes, so it can't *confirm* their auth. A future improvement: teach it to resolve those mount mechanisms (it would then catch this class automatically). Left out to keep this diff a focused security fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)