### PR TITLE
fix(models): W1188 - W978-canonical save hooks (unblocks main deploy gate)

### DIFF
--- a/backend/models/Cheque.js
+++ b/backend/models/Cheque.js
@@ -104,9 +104,9 @@ const chequeSchema = new mongoose.Schema(
 );
 
 // Money-Type Migration (audit #5) — dual-write integer-halalas siblings.
-chequeSchema.pre('save', async function (next) {
+// W978 canonical form: async hooks must NOT declare `next` (Mongoose-9 throw class).
+chequeSchema.pre('save', async function () {
   require('../intelligence/money.lib').deriveHalalas(this, ['amount']);
-  next();
 });
 
 // W269 — derive branchId from the related invoice (best-effort; cheques without an

--- a/backend/models/nitaqat.models.js
+++ b/backend/models/nitaqat.models.js
@@ -129,9 +129,9 @@ wpsRecordSchema.index({ organization: 1, period: 1 }, { unique: true });
 // REMOVED DUPLICATE INDEX: wpsRecordSchema.index({ status: 1 });
 
 // Money-Type Migration (audit #5) — dual-write integer-halalas siblings (before compile).
-wpsRecordSchema.pre('save', async function (next) {
+// W978 canonical form: async hooks must NOT declare `next` (Mongoose-9 throw class).
+wpsRecordSchema.pre('save', async function () {
   require('../intelligence/money.lib').deriveHalalas(this, ['totalAmount', 'paidAmount']);
-  next();
 });
 
 const WpsRecord = mongoose.models.WpsRecord || mongoose.model('WpsRecord', wpsRecordSchema);
@@ -218,7 +218,8 @@ employmentContractSchema.index({ organization: 1, status: 1 });
 // Registered as `NitaqatEmploymentContract` to dodge the collision with
 // the canonical models/EmploymentContract.js + HR/EmploymentContract.js.
 // Money-Type Migration (audit #5) — dual-write integer-halalas siblings (before compile).
-employmentContractSchema.pre('save', async function (next) {
+// W978 canonical form: async hooks must NOT declare `next` (Mongoose-9 throw class).
+employmentContractSchema.pre('save', async function () {
   require('../intelligence/money.lib').deriveHalalas(this, [
     'basicSalary',
     'housingAllowance',
@@ -226,7 +227,6 @@ employmentContractSchema.pre('save', async function (next) {
     'otherAllowances',
     'totalSalary',
   ]);
-  next();
 });
 
 // W1159 — denormalize branchId from the employee (single-org, multi-branch


### PR DESCRIPTION
Main deploy gate is RED for everyone: #355 introduced `pre("save", async function (next))` hooks in `Cheque.js` + `nitaqat.models.js` (WpsRecord + NitaqatEmploymentContract) — the exact Mongoose-9 throw class the W978 guard blocks. Test shards 1+2 fail → **Deploy to VPS skipped** → prod silently stale since that merge (this is the W952-documented failure mode).

Fix: drop the `next` param + `next()` call from the 3 hooks (bodies are sync money-lib derives; the async fn resolution completes the hook).

Verified: `no-async-next-save-hooks-wave978` + `check-mongoose-hook-style-script` both green (29/29); gate script exits 0 with empty `newCallbackFiles`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)