### PR TITLE
fix(models): Mongoose-9 async-no-next hooks in Cheque + nitaqat (unblocks prod deploy)

### DIFF
--- a/backend/models/Cheque.js
+++ b/backend/models/Cheque.js
@@ -104,9 +104,8 @@ const chequeSchema = new mongoose.Schema(
 );
 
 // Money-Type Migration (audit #5) — dual-write integer-halalas siblings.
-chequeSchema.pre('save', async function (next) {
+chequeSchema.pre('save', async function () {
   require('../intelligence/money.lib').deriveHalalas(this, ['amount']);
-  next();
 });
 
 // W269 — derive branchId from the related invoice (best-effort; cheques without an

--- a/backend/models/nitaqat.models.js
+++ b/backend/models/nitaqat.models.js
@@ -129,9 +129,8 @@ wpsRecordSchema.index({ organization: 1, period: 1 }, { unique: true });
 // REMOVED DUPLICATE INDEX: wpsRecordSchema.index({ status: 1 });
 
 // Money-Type Migration (audit #5) — dual-write integer-halalas siblings (before compile).
-wpsRecordSchema.pre('save', async function (next) {
+wpsRecordSchema.pre('save', async function () {
   require('../intelligence/money.lib').deriveHalalas(this, ['totalAmount', 'paidAmount']);
-  next();
 });
 
 const WpsRecord = mongoose.models.WpsRecord || mongoose.model('WpsRecord', wpsRecordSchema);
@@ -218,7 +217,7 @@ employmentContractSchema.index({ organization: 1, status: 1 });
 // Registered as `NitaqatEmploymentContract` to dodge the collision with
 // the canonical models/EmploymentContract.js + HR/EmploymentContract.js.
 // Money-Type Migration (audit #5) — dual-write integer-halalas siblings (before compile).
-employmentContractSchema.pre('save', async function (next) {
+employmentContractSchema.pre('save', async function () {
   require('../intelligence/money.lib').deriveHalalas(this, [
     'basicSalary',
     'housingAllowance',
@@ -226,7 +225,6 @@ employmentContractSchema.pre('save', async function (next) {
     'otherAllowances',
     'totalSalary',
   ]);
-  next();
 });
 
 // W1159 — denormalize branchId from the employee (single-org, multi-branch


### PR DESCRIPTION
## Two bugs, one fix

**1. Real data bug:** `models/Cheque.js` + `models/nitaqat.models.js` (WpsRecord, EmploymentContract) had `pre('save', async function (next) { … next() })`. Under Mongoose 9, `next` is undefined in an async hook → `next()` throws *"next is not a function"* on **every `.save()`** (W954 class). Those documents couldn't be saved.

**2. Prod-deploy outage:** the gate-4 drift guard (`check-mongoose-hook-style-script.test.js`) flagged these 2 files → failed the sharded deploy-test gate (shards 1/4 + 2/4) → "Deploy to Production" was **SKIPPED**, so **no main merge reached prod since ≥#355** (this was the *only* failing suite: `Tests: 2 failed, 3796 passed`).

**Fix:** drop the `next` param + `next()` call (async hook resolves via its promise). Verified: `check:hook-style` green (baseline 3/3 in sync), syntax clean, pre-push gates passed.

Merging this should turn the deploy gate green and unblock the backed-up prod pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)