### PR TITLE
fix(security): W1191 — close 3 more anonymous safeMount aliases (dashboard/rehab)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1378,6 +1378,9 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/dashboard-saved-views-auth-wave1190.test.js'
       - 'backend/__tests__/dashboard-saved-views-auth-behavioral-wave1190.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/dashboard-rehab-safemount-auth-wave1191.test.js'
+      - 'backend/__tests__/dashboard-rehab-safemount-auth-behavioral-wave1191.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2739,6 +2742,9 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/dashboard-saved-views-auth-wave1190.test.js'
       - 'backend/__tests__/dashboard-saved-views-auth-behavioral-wave1190.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/dashboard-rehab-safemount-auth-wave1191.test.js'
+      - 'backend/__tests__/dashboard-rehab-safemount-auth-behavioral-wave1191.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/dashboard-rehab-safemount-auth-behavioral-wave1191.test.js
+++ b/backend/__tests__/dashboard-rehab-safemount-auth-behavioral-wave1191.test.js
@@ -1,0 +1,44 @@
+/**
+ * W1191 — behavioral counterpart: the three fixed routers reject anonymous
+ * requests on a BARE (auth-less) mount, proving the router-level gate fires.
+ *
+ * Reproduces the phases.registry `safeMount` path: mount each route's DEFAULT
+ * export (the exact instance safeMount `require()`s) at a prefix WITH NO injected
+ * auth, then assert anonymous requests get 401. `router.use(authenticate)` runs
+ * for every request entering the router (before route matching), so any path is
+ * rejected — no DB/token needed (authenticate 401s on a missing Bearer token
+ * before any handler).
+ */
+
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+
+// DEFAULT exports === the instances phases.registry safeMounts with no middleware.
+const rehabGoalSuggestions = require('../routes/rehab-goal-suggestions.routes');
+const dashboardAlerts = require('../routes/dashboard-alerts.routes');
+const dashboardsPlatform = require('../routes/dashboards-platform.routes');
+
+function bareMount(router) {
+  const app = express();
+  app.use('/x', router); // deliberately auth-less, mirroring safeMount(app, '/api/<slug>', …)
+  return app;
+}
+
+describe('W1191 safeMount-ed dashboard/rehab routers reject anonymous access (behavioral)', () => {
+  const cases = [
+    { name: 'rehab-goal-suggestions', app: bareMount(rehabGoalSuggestions), probes: [['get', '/x/goals'], ['get', '/x/interventions']] },
+    { name: 'dashboard-alerts', app: bareMount(dashboardAlerts), probes: [['get', '/x/'], ['post', '/x/somekey/ack'], ['post', '/x/somekey/mute']] },
+    { name: 'dashboards-platform', app: bareMount(dashboardsPlatform), probes: [['get', '/x/catalog'], ['get', '/x/anything']] },
+  ];
+
+  for (const c of cases) {
+    for (const [method, url] of c.probes) {
+      test(`${c.name}: ${method.toUpperCase()} ${url} → 401 without a token`, async () => {
+        const res = await request(c.app)[method](url);
+        expect(res.status).toBe(401);
+      });
+    }
+  }
+});

--- a/backend/__tests__/dashboard-rehab-safemount-auth-wave1191.test.js
+++ b/backend/__tests__/dashboard-rehab-safemount-auth-wave1191.test.js
@@ -1,0 +1,131 @@
+/**
+ * W1191 — static drift guard: every `safeMount`-ed route is authenticated.
+ *
+ * ROOT CAUSE (the class W1190 was the first instance of): the registries expose
+ * THREE mount helpers — `dualMountAuth` (injects `authenticate`), `dualMount`
+ * (none), and `safeMount` (none — and there is NO `safeMountAuth`). `safeMount`
+ * is a bare `app.use(path, handler)`, so a route mounted that way is authenticated
+ * ONLY if the route file applies its own auth gate. Several dashboard/rehab routes
+ * documented "auth is the mount-site's job" yet were `safeMount`-ed → reachable
+ * ANONYMOUSLY on their `/api/<slug>` aliases (their app.js mounts DO inject
+ * `authenticate`, which is why this hid, and why the canonical
+ * `audit-unauthenticated-routes.js` reported confirmedCount:0 — it can't resolve
+ * safeMount / app.js / bootstrap mounts).
+ *
+ * This guard scans EVERY registry for `safeMount(app, …, '<module>')` and asserts
+ * the resolved route file is auth-bearing — a router-level OR per-route auth
+ * identifier, OR it delegates to self-authenticating sub-routers — unless the slug
+ * is in PUBLIC_ALLOWLIST (login flows / health probes / signed webhooks / stateless
+ * utilities / deliberately-optional-auth reads). New unauth safeMounts AND stale
+ * allowlist entries both fail (ratchet-down, W325c/W340 lineage).
+ *
+ * Pairs with the behavioral counterpart (bare-mount → 401) for the 3 W1191 fixes.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const BK = path.join(__dirname, '..');
+const REGDIR = path.join(BK, 'routes', 'registries');
+const REG_FILES = [
+  path.join(BK, 'routes', '_registry.js'),
+  ...fs.readdirSync(REGDIR).filter(f => f.endsWith('.js')).map(f => path.join(REGDIR, f)),
+];
+
+const SAFEMOUNT_RE = /safeMount\s*\(\s*app\s*,\s*([\s\S]*?),\s*['"]([^'"]+)['"]\s*\)/g;
+
+// Any recognized auth/identity middleware, applied at router-level (`router.use(X)`)
+// OR per-route (`'path', X,`). Includes the portal-specific + branch/role guards
+// seen across the codebase's diverse auth styles.
+const AUTH_NAMES =
+  'authenticate|authenticateToken|authMiddleware|authGuard|auth|protect|requireAuth|verifyToken|' +
+  'parentAuth|studentAuth|guardianAuth|portalAuth|requireRole|requireMfa|loadMfaActor|' +
+  'requireBranchAccess|bodyScopedBeneficiaryGuard|requireAuthOrApiKey|apiKeyAuth';
+const APPLIES_AUTH = new RegExp(`router\\.use\\(\\s*(?:${AUTH_NAMES})\\b|\\b(?:${AUTH_NAMES})\\s*,`);
+// `router.use('/', require('./x.routes'))` — an orchestrator delegating to
+// sub-routers that each self-authenticate (e.g. workflowEnhanced → 10 subs).
+const DELEGATES = /router\.use\(\s*['"]\/?['"]\s*,\s*require\(/;
+
+// Public BY DESIGN — login/visitor flows, health probes, signed webhooks,
+// stateless utilities, deliberately-optional-auth reads, and pure delegators.
+// Each MUST stay public; if its mount disappears the entry goes stale → fails.
+const PUBLIC_ALLOWLIST = new Set([
+  'health.routes',
+  'build-info.routes',
+  'otp-auth.routes',
+  'dateConverterRoutes',
+  'integrations-metrics.routes',
+  'integrations-health.routes',
+  'blockchain-public.routes',
+  'reports-webhooks.routes',
+  'nphies-webhook.routes',
+  'public-forms.routes',
+  'public-uploads.routes',
+  'visitor-auth.routes',
+  'openapi-integration.routes',
+  'push.routes', // device-token register; auth optional by design
+  'dashboard.stats', // GET-only aggregate stats, optionalAuth by design
+  'workflowEnhanced.routes', // pure delegator → 10 self-authenticating sub-routers
+]);
+
+function resolveModule(regFile, mod) {
+  return [
+    path.resolve(path.join(BK, 'routes'), mod),
+    path.resolve(path.dirname(regFile), mod),
+  ]
+    .map(p => (p.endsWith('.js') ? p : p + '.js'))
+    .find(p => fs.existsSync(p)) || null;
+}
+
+const slugOf = mod => mod.replace(/^.*\//, '');
+
+// Collect every safeMount target across all registries.
+const targets = [];
+for (const rf of REG_FILES) {
+  const src = fs.readFileSync(rf, 'utf8');
+  let m;
+  while ((m = SAFEMOUNT_RE.exec(src))) {
+    const mod = m[2];
+    if (!mod.startsWith('../routes/') && !mod.startsWith('./')) continue;
+    targets.push({ registry: path.basename(rf), mod, slug: slugOf(mod), file: resolveModule(rf, mod) });
+  }
+}
+
+describe('W1191 every safeMount-ed route is authenticated (or explicitly public)', () => {
+  test('the scan found a meaningful number of safeMount targets (sanity)', () => {
+    expect(targets.length).toBeGreaterThan(100);
+  });
+
+  test('no NON-public safeMount target lacks an auth gate', () => {
+    const holes = targets
+      .filter(t => t.file && !PUBLIC_ALLOWLIST.has(t.slug))
+      .filter(t => {
+        const src = fs.readFileSync(t.file, 'utf8');
+        return !(APPLIES_AUTH.test(src) || DELEGATES.test(src));
+      })
+      .map(t => `${t.mod}  [${t.registry}]`);
+    expect([...new Set(holes)]).toEqual([]);
+  });
+
+  test('PUBLIC_ALLOWLIST has no stale entry (every entry is still safeMount-ed)', () => {
+    const mountedSlugs = new Set(targets.map(t => t.slug));
+    const stale = [...PUBLIC_ALLOWLIST].filter(s => !mountedSlugs.has(s));
+    expect(stale).toEqual([]);
+  });
+});
+
+describe('W1191 the three fixed routes self-authenticate at the router level', () => {
+  for (const slug of [
+    'rehab-goal-suggestions.routes',
+    'dashboard-alerts.routes',
+    'dashboards-platform.routes',
+  ]) {
+    test(`${slug} applies router.use(authenticate)`, () => {
+      const src = fs.readFileSync(path.join(BK, 'routes', `${slug}.js`), 'utf8');
+      expect(src).toMatch(/require\(\s*['"]\.\.\/middleware\/auth['"]\s*\)/);
+      expect(src).toMatch(/router\.use\(\s*authenticate\s*\)/);
+    });
+  }
+});

--- a/backend/routes/dashboard-alerts.routes.js
+++ b/backend/routes/dashboard-alerts.routes.js
@@ -26,6 +26,12 @@
 const express = require('express');
 
 const { POLICIES, ESCALATION_LADDERS } = require('../config/alert.registry');
+// W1191 — self-authenticate. Header says endpoints "expect req.user to be
+// populated by the upstream authenticate middleware", but phases.registry mounts
+// this via `safeMount` (bare app.use, NO injected auth) → the
+// `/api/(v1/)?dashboard-alerts` alias accepted anonymous ack/snooze/mute writes.
+// The app.js mount already injects authenticate; this gates EVERY mount.
+const { authenticate } = require('../middleware/auth');
 
 function asyncWrap(fn) {
   return (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
@@ -44,6 +50,7 @@ function getCoordinator(req) {
 
 function buildRouter() {
   const router = express.Router();
+  router.use(authenticate); // W1191 — gate EVERY mount (incl. the auth-less safeMount alias)
 
   router.get(
     '/',

--- a/backend/routes/dashboards-platform.routes.js
+++ b/backend/routes/dashboards-platform.routes.js
@@ -42,6 +42,14 @@
 
 const express = require('express');
 
+// W1191 — self-authenticate. The header says auth "is enforced by the caller
+// (authenticate is mounted upstream in app.js)", but phases.registry ALSO mounts
+// this via `safeMount` (bare app.use, NO injected auth), so the
+// `/api/(v1/)?dashboards-platform` alias exposed the role-gated dashboard payloads
+// to anonymous callers (req.user undefined → role checks operate on no identity).
+// This router-level gate protects EVERY mount; the app.js one re-validates idempotently.
+const { authenticate } = require('../middleware/auth');
+
 const dashboardRegistry = require('../config/dashboard.registry');
 const kpiRegistry = require('../config/kpi.registry');
 const widgetCatalog = require('../config/widget.catalog');
@@ -89,6 +97,7 @@ function defaultKpiResolver() {
  */
 function buildRouter({ kpiResolver, narrativeService } = {}) {
   const router = express.Router();
+  router.use(authenticate); // W1191 — gate EVERY mount (incl. the auth-less safeMount alias)
   const resolver = typeof kpiResolver === 'function' ? kpiResolver : defaultKpiResolver;
 
   router.get(

--- a/backend/routes/rehab-goal-suggestions.routes.js
+++ b/backend/routes/rehab-goal-suggestions.routes.js
@@ -11,6 +11,13 @@
 
 const express = require('express');
 const suggestionService = require('../services/goalSuggestionService');
+// W1191 — self-authenticate. The header says "behind authenticate; authorisation
+// is the mount-site's job", but phases.registry mounts this via `safeMount`
+// (bare app.use, NO injected auth), so the `/api/(v1/)?rehab-goal-suggestions`
+// alias was reachable anonymously. The app.js mount already injects authenticate;
+// this router-level gate protects EVERY mount (the app.js one re-validates the
+// JWT idempotently). See dashboard-saved-views W1190 for the same class.
+const { authenticate } = require('../middleware/auth');
 
 function asyncHandler(fn) {
   return (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
@@ -28,6 +35,7 @@ function parseCsv(value) {
 function createRehabGoalSuggestionsRouter() {
   const router = express.Router();
   router.use(express.json());
+  router.use(authenticate); // W1191 — gate EVERY mount (incl. the auth-less safeMount alias)
 
   // GET /goals?discipline_ids=a,b&age_months=24&exclude=CODE1,CODE2&limit=10
   router.get(

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -818,3 +818,5 @@ __tests__/forms-approval-chain-wave1186.test.js
 __tests__/forms-approval-chain-behavioral-wave1186.test.js
 __tests__/dashboard-saved-views-auth-wave1190.test.js
 __tests__/dashboard-saved-views-auth-behavioral-wave1190.test.js
+__tests__/dashboard-rehab-safemount-auth-wave1191.test.js
+__tests__/dashboard-rehab-safemount-auth-behavioral-wave1191.test.js


### PR DESCRIPTION
## What — root-cause sweep after #359 (W1190)

W1190 fixed `dashboard-saved-views`, an unauthenticated `safeMount` alias. This PR is the **root-cause sweep**: I audited **every `safeMount` target across all 14 registries** and found **3 more routes with the exact same shape** — mounted in app.js WITH `authenticate` AND via `phases.registry` `safeMount` WITHOUT, while the router applied no auth of its own (each documented *"auth is the mount-site's job"*):

| Route | Anonymous alias | Exposure |
| --- | --- | --- |
| `rehab-goal-suggestions.routes` | `/api/(v1/)?rehab-goal-suggestions` | read SMART-goal / intervention engine |
| `dashboard-alerts.routes` | `/api/(v1/)?dashboard-alerts` | **ack / snooze / mute writes** — anonymous tamper |
| `dashboards-platform.routes` | `/api/(v1/)?dashboards-platform` | role-gated dashboard payloads served to anonymous |

Background: the registries have **three** mount helpers — `dualMountAuth` (injects `authenticate`), `dualMount` (none), and `safeMount` (none — and there is **no** `safeMountAuth`; it's a bare `app.use`). W471/W502 swept the `dualMount` surface; the `safeMount` surface was never swept.

## Fix

`router.use(authenticate)` in each router (same as W1190) — protects every mount; the app.js mounts' already-injected `authenticate` becomes a harmless idempotent re-validate. Authenticated users unchanged; only anonymous access closed.

## Audit also confirmed-safe (no change)

`phase37` · `rehabilitationPlan` · `dashboardWidget` (per-route auth) · `workflowEnhanced` (delegates to 10 self-authenticating sub-routers) · `parent-portal-v1` / `student-portal` / `payment-gateway` (portal / per-route auth). Intentionally public (unchanged): public-forms/uploads, visitor-auth, openapi, push, `dashboard.stats` (optionalAuth), health/build-info/webhooks/nafath/otp.

## Guards — 22 assertions, both sprint-enumerated

- **`dashboard-rehab-safemount-auth-wave1191`** (static): scans **every** registry's `safeMount` targets and fails on any non-allowlisted route lacking an auth gate (router-level OR per-route OR delegator), with a **ratchet-down `PUBLIC_ALLOWLIST`** + targeted `router.use(authenticate)` checks on the 3 fixes. **Locks the whole class** against new unauth `safeMount`s.
- **`dashboard-rehab-safemount-auth-behavioral-wave1191`** (supertest): each fixed router on a bare auth-less mount → every probe **401** without a token.

## Verified locally

`check:routes-load` (558 clean) · `check:sprint-paths` in sync · `check:gitignored-sources` baseline · W1191 13/13 + W1190 9/9 green.

## Follow-up (not in this PR)

Teach `scripts/audit-unauthenticated-routes.js` to resolve `safeMount` / app.js / bootstrap mounts so this class is caught automatically — it currently classifies them "unknown mount" and reported `confirmedCount: 0` while these were live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)