### PR TITLE
fix(security): W1192 — auditor models ../routes safeMounts (close the blind spot)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1383,6 +1383,8 @@ on:
       - 'backend/__tests__/dashboard-rehab-safemount-auth-behavioral-wave1191.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/check-phantom-schema-writes-script.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/auditor-safemount-coverage-wave1192.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2749,6 +2751,8 @@ on:
       - 'backend/__tests__/dashboard-rehab-safemount-auth-behavioral-wave1191.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/check-phantom-schema-writes-script.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/auditor-safemount-coverage-wave1192.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/auditor-safemount-coverage-wave1192.test.js
+++ b/backend/__tests__/auditor-safemount-coverage-wave1192.test.js
@@ -1,0 +1,50 @@
+/**
+ * W1192 — locks the canonical auditor's `../routes` safeMount coverage.
+ *
+ * `scripts/audit-unauthenticated-routes.js` models per-mount auth so it can flag
+ * routes mounted with no auth and no in-file gate. It modelled `dualMount(Auth)`,
+ * `app.use`, and `safeMount(app, …, './X.routes')` — but NOT the dominant
+ * `safeMount(app, paths, '../routes/X.routes')` spelling the registries actually
+ * use. That blind spot is exactly why the W1190/W1191 anonymous dashboard/rehab
+ * `safeMount` aliases reported `confirmedCount: 0` while they were live.
+ *
+ * W1192 adds the `../routes` safeMount regex (~115 more mounts modelled) and
+ * allowlists the 3 intentionally-public routes it newly surfaces. This guard
+ * locks both so the coverage can't silently regress.
+ *
+ * NOTE: this auditor is a TRIAGE heuristic (file-centric — it clears a route that
+ * is authed at ANY mount, so it does NOT catch a route authed at one mount yet
+ * exposed unauthed at another — the W1191 class). The mount-centric authority for
+ * the safeMount class is `dashboard-rehab-safemount-auth-wave1191`; this guard
+ * only hardens the canonical tool's confirmedCount signal.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const AUDITOR = path.join(__dirname, '..', 'scripts', 'audit-unauthenticated-routes.js');
+const src = fs.readFileSync(AUDITOR, 'utf8');
+
+describe('W1192 auditor models ../routes safeMount + stays clean', () => {
+  test('source models the ../routes safeMount spelling (anti-revert)', () => {
+    // declared + used in a mark(false, …) loop → 2+ occurrences
+    expect((src.match(/safeMountParentRe/g) || []).length).toBeGreaterThanOrEqual(2);
+    // the regex targets the ../routes form (not just ./)
+    expect(src).toContain('../routes/X.routes'); // appears in the explaining comment
+  });
+
+  test('KNOWN_PUBLIC allowlists the 3 intentionally-public routes W1192 surfaced', () => {
+    for (const slug of ['build-info.routes.js', 'integrations-metrics.routes.js', 'otp-auth.routes.js']) {
+      expect(src).toContain(`'${slug}'`);
+    }
+  });
+
+  test('audit --json → confirmedCount 0 with the broadened safeMount model', () => {
+    const out = execFileSync(process.execPath, [AUDITOR, '--json'], { encoding: 'utf8' });
+    const result = JSON.parse(out);
+    expect(result.confirmedCount).toBe(0);
+  });
+});

--- a/backend/scripts/audit-unauthenticated-routes.js
+++ b/backend/scripts/audit-unauthenticated-routes.js
@@ -86,6 +86,15 @@ while ((m = varMountRe.exec(registrySrc))) {
 // (C) safeMount(app, paths, './X.routes' | var) → NO auth (app.use without authenticate)
 const safeMountRe = /safeMount\s*\(\s*app\s*,[^]{0,160}?['"]\.\/([\w/-]+)\.routes['"]/g;
 while ((m = safeMountRe.exec(registrySrc))) mark(false, `${m[1]}.routes.js`);
+// (C2/W1192) safeMount(app, paths, '../routes/X.routes') — the ../routes form.
+// (C) only matched the './X.routes' spelling; the registries in routes/registries/**
+// reference modules as '../routes/X.routes' (relative to _registry.js, where
+// safeMount's require runs). Missing this left ~115 safeMounts classified as
+// "unknown mount" instead of "no-auth" — exactly how the W1190/W1191 anonymous
+// dashboard/rehab aliases reported confirmedCount:0 while live.
+const safeMountParentRe =
+  /safeMount\s*\(\s*app\s*,[^]{0,200}?['"]\.\.\/routes\/([\w/-]+)\.routes['"]/g;
+while ((m = safeMountParentRe.exec(registrySrc))) mark(false, `${m[1]}.routes.js`);
 const safeMountVarRe = /safeMount\s*\(\s*app\s*,\s*[^,]+,\s*(\w+)\s*\)/g;
 while ((m = safeMountVarRe.exec(registrySrc))) {
   if (varToFile[m[1]]) mark(false, varToFile[m[1]]);
@@ -162,6 +171,15 @@ const KNOWN_PUBLIC = new Set([
   'stub-missing.routes.js',
   // Visitor self check-in/login (/api/v1/public/visitor) — pre-auth by design.
   'visitor-auth.routes.js',
+  // W1192 — surfaced by the new ../routes safeMount modelling (C2). All three are
+  // intentionally public by their own file headers; they carry no PII/secrets and
+  // no mutations of protected state:
+  //   build-info (/api/build-info) — version/commit metadata, "carries no secrets".
+  'build-info.routes.js',
+  //   integrations-metrics (/api/health/metrics/integrations) — health-probe gauges.
+  'integrations-metrics.routes.js',
+  //   otp-auth (/api/.../otp) — OTP issue/verify IS a pre-auth login flow (like nafath).
+  'otp-auth.routes.js',
 ]);
 
 const findings = [];

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -821,3 +821,4 @@ __tests__/dashboard-saved-views-auth-behavioral-wave1190.test.js
 __tests__/dashboard-rehab-safemount-auth-wave1191.test.js
 __tests__/dashboard-rehab-safemount-auth-behavioral-wave1191.test.js
 __tests__/check-phantom-schema-writes-script.test.js
+__tests__/auditor-safemount-coverage-wave1192.test.js


### PR DESCRIPTION
## What

Closes the precise blind spot that let W1190/W1191 hide: the canonical unauthenticated-route auditor (`scripts/audit-unauthenticated-routes.js`) modelled `dualMount(Auth)`, `app.use`, and `safeMount(app, …, './X.routes')` — but **not** the dominant `safeMount(app, paths, '../routes/X.routes')` spelling the registries actually use (the path is relative to `_registry.js`, where `safeMount`'s `require` runs).

Result: ~115 `safeMount`s were classified **"unknown mount"** instead of **"no-auth"**, so the auditor reported `confirmedCount: 0` while the W1190/W1191 anonymous dashboard/rehab aliases were live.

## Change

- Add `safeMountParentRe` for the `../routes` form — mount map goes **282 → 397** no-auth mounts modelled.
- Allowlist the 3 intentionally-public routes it newly surfaces (each public by its own file header, no PII/secrets, no protected-state mutations):
  - `build-info` — version/commit metadata
  - `integrations-metrics` — health-probe gauges
  - `otp-auth` — pre-auth OTP login flow (like nafath)
- `confirmedCount` stays **0**; `unauthenticated-routes-wave658` stays green.

## Honest scope

This auditor is a **triage heuristic** — *file-centric*: it clears a route authed at **any** mount, so it does **not** catch a route authed at one mount yet exposed unauthed at another (the W1191 class). The **mount-centric** authority for the `safeMount` class is the `dashboard-rehab-safemount-auth-wave1191` guard (already merged). This PR only hardens the canonical tool's `confirmedCount` signal and closes the `../routes` miss.

## Guard

`auditor-safemount-coverage-wave1192` (3 assertions): locks the `safeMountParentRe` modelling + the 3 `KNOWN_PUBLIC` additions + `confirmedCount: 0`.

## Verified locally

W1192 + wave658 green (8/8) · `check:sprint-paths` in sync · `check:gitignored-sources` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)