### PR TITLE
fix(models): W1193 - smart-insurance runtime repair + Communication save crash + phantom-writes triage

### DIFF
--- a/backend/models/Communication.js
+++ b/backend/models/Communication.js
@@ -235,12 +235,14 @@ communicationSchema.methods.updateWorkflowStatus = function () {
 };
 
 // Middleware قبل الحفظ
+// W1193 — the old body called `next()` which was NEVER DECLARED (async hooks
+// take no next; the file's eslint-disable no-undef masked it) → ReferenceError
+// on every save that reached it. Async resolution completes the hook.
 communicationSchema.pre('save', async function () {
   // توليد رقم مرجعي إذا لم يكن موجود
   if (!this.referenceNumber) {
     this.referenceNumber = await this.constructor.generateReferenceNumber();
   }
-  next();
 });
 
 const Communication =

--- a/backend/models/InsuranceEligibilityCheck.js
+++ b/backend/models/InsuranceEligibilityCheck.js
@@ -7,7 +7,10 @@ const mongoose = require('mongoose');
 const insuranceEligibilityCheckSchema = new mongoose.Schema(
   {
     branchId: { type: mongoose.Schema.Types.ObjectId, ref: 'Branch', required: true },
-    uuid: { type: String, unique: true, required: true },
+    // W1193 — required with NO default while no caller ever set it → every
+    // checkEligibility() threw ValidationError at its first step. Schema-side
+    // default fixes all callers.
+    uuid: { type: String, unique: true, required: true, default: () => require('crypto').randomUUID() },
 
     policyId: { type: mongoose.Schema.Types.ObjectId, ref: 'InsurancePolicy', required: true },
     beneficiaryId: { type: mongoose.Schema.Types.ObjectId, ref: 'Beneficiary', required: true },
@@ -19,6 +22,9 @@ const insuranceEligibilityCheckSchema = new mongoose.Schema(
       enum: ['general', 'service_specific', 'preauth'],
       default: 'general',
     },
+    // W1193 — written by smartInsurance.service (options.serviceCode) but
+    // never declared; caught by check:phantom-writes.
+    requestedService: { type: String, default: null },
 
     // النتيجة
     isEligible: { type: Boolean, default: false },

--- a/backend/models/PriorAuthorization.js
+++ b/backend/models/PriorAuthorization.js
@@ -9,10 +9,17 @@ const priorAuthorizationSchema = new mongoose.Schema(
     branchId: { type: mongoose.Schema.Types.ObjectId, ref: 'Branch', required: true },
     authNumber: { type: String, unique: true, required: true },
     authUuid: { type: String, unique: true, required: true },
-    uuid: { type: String, unique: true, required: true },
+    // W1193 — required with NO default while no caller ever set it
+    // (smartInsurance.service sets authUuid only) → every requestPriorAuth()
+    // threw ValidationError. Schema-side default fixes all callers.
+    uuid: { type: String, unique: true, required: true, default: () => require('crypto').randomUUID() },
 
     policyId: { type: mongoose.Schema.Types.ObjectId, ref: 'InsurancePolicy', required: true },
     beneficiaryId: { type: mongoose.Schema.Types.ObjectId, ref: 'Beneficiary', required: true },
+    // W1193 — written by smartInsurance.service since day one but never
+    // declared (strict mode silently dropped them; caught by
+    // check:phantom-writes).
+    insuranceCompanyId: { type: mongoose.Schema.Types.ObjectId, ref: 'InsuranceCompany' },
 
     // NPHIES
     nphiesAuthId: { type: String },
@@ -49,6 +56,9 @@ const priorAuthorizationSchema = new mongoose.Schema(
     respondedAt: { type: Date },
     validFrom: { type: Date },
     validUntil: { type: Date },
+    // W1193 — see insuranceCompanyId note above.
+    estimatedStartDate: { type: Date },
+    estimatedEndDate: { type: Date },
 
     // الرفض
     rejectionReason: { type: String },

--- a/backend/scripts/check-phantom-schema-writes.js
+++ b/backend/scripts/check-phantom-schema-writes.js
@@ -158,7 +158,6 @@ const KNOWN_PHANTOM_WRITES = new Set([
   "services/BeneficiaryService.js::beneficiarytransfer::beneficiary",
   "services/BeneficiaryService.js::beneficiarytransfer::fromBranch",
   "services/BeneficiaryService.js::beneficiarytransfer::toBranch",
-  "services/smartInsurance.service.js::insuranceeligibilitycheck::requestedService",
   "services/smartInsurance.service.js::insuranceclaim::claimUuid",
   "services/smartInsurance.service.js::insuranceclaim::policyId",
   "services/smartInsurance.service.js::insuranceclaim::insuranceCompanyId",
@@ -169,9 +168,6 @@ const KNOWN_PHANTOM_WRITES = new Set([
   "services/smartInsurance.service.js::insuranceclaim::lineItems",
   "services/smartInsurance.service.js::insuranceclaim::priorAuthId",
   "services/smartInsurance.service.js::insuranceclaim::createdBy",
-  "services/smartInsurance.service.js::priorauthorization::insuranceCompanyId",
-  "services/smartInsurance.service.js::priorauthorization::estimatedStartDate",
-  "services/smartInsurance.service.js::priorauthorization::estimatedEndDate",
 ]);
 
 const ALWAYS_ALLOWED = new Set([

--- a/docs/architecture/PHANTOM_WRITES_TRIAGE_2026-06-11.md
+++ b/docs/architecture/PHANTOM_WRITES_TRIAGE_2026-06-11.md
@@ -1,0 +1,108 @@
+# Phantom Schema Writes — Triage Dossier
+
+**Date:** 2026-06-11 · **Tool:** `npm run check:phantom-writes` (W1189) · **Baseline:** 127 findings (was 131; W1189 fixed 2, W1193 fixed 4 + 2 runtime bugs)
+
+## Context
+
+The W1189 audit scans every `Model.create({...})` literal in `routes/` + `services/`
+against the bound model's declared schema paths. A key the schema never declares is
+**silently dropped** by Mongoose strict mode. First triage pass (this doc) shows the
+finding set is NOT mostly "benign missing fields" — several clusters are routes written
+against **imagined schemas** (the W1179 disease) whose `create()` calls **throw
+ValidationError at runtime** because the real model has different *required* fields.
+
+## Classification taxonomy
+
+| Class | Meaning | Fix path |
+|---|---|---|
+| **A — alien model** | Writer's vocabulary matches NO registered model; real model has different required fields → create() always throws | Per-domain design: map to canonical vocabulary, bind to the right model, or build the missing model |
+| **B — semantic mismatch** | Canonical field exists under another name (`beneficiaryId` vs `beneficiary`) — W324 class | Fix the WRITER, never add a parallel field |
+| **C — missing benign field** | Write is intended, field simply never declared | Additive schema declaration (the W1186/`submittedAt` recipe) |
+| **D — tooling gap** | Finding is an artifact of static-analysis limits (re-export shims, multi-registration) | Improve the script, re-baseline |
+
+## Fixed already
+
+| Wave | Fix |
+|---|---|
+| W1186 | FormTemplate `approvalSteps` persistence + FormSubmission `reviewedAt`/`reviewedBy` |
+| W1189 | FormSubmission `submittedAt` (class C) |
+| W1193 | `Communication` pre-save called **undeclared `next()`** → ReferenceError on every save (file had `eslint-disable no-undef` masking it) — a 3rd W978-variant no current guard catches |
+| W1193 | `PriorAuthorization.uuid` + `InsuranceEligibilityCheck.uuid`: **required with no default and no caller ever set them** → `checkEligibility()` and `requestPriorAuth()` threw on every call. Schema-side `crypto.randomUUID()` default fixes all callers |
+| W1193 | Class-C declares: `PriorAuthorization.{insuranceCompanyId, estimatedStartDate, estimatedEndDate}`, `InsuranceEligibilityCheck.requestedService` |
+
+## Open clusters (priority order)
+
+### P1 — live user-facing surfaces, hard-broken (class A)
+
+1. **smartInsurance claims** (`services/smartInsurance.service.js`, 10 keys —
+   `claimUuid, policyId, insuranceCompanyId, serviceSessionId, billedAmount,
+   diagnosisCodes, procedureCodes, lineItems, priorAuthId, createdBy`).
+   `submitClaim()` writes a policy-based vocabulary matching **no** registered model.
+   It binds (via the `models/InsuranceClaim.js` re-export shim) to
+   `insuranceClaim.model.js` whose schema is contract-based with REQUIRED
+   `beneficiary/contract/visitDate/totalGross/totalNet` → **create throws every time**.
+   Even `models/nphies/InsuranceClaim.js` (`NphiesInsuranceClaim`) doesn't match
+   (`insurancePolicyId`, no `claimUuid`). **Decision needed:** map the service onto the
+   canonical contract-based schema, or give smart-insurance its own claim model
+   (then reconcile under ADR-021 patterns — there are already FOUR InsuranceClaim files).
+
+2. **communication message-log writers** (13 keys; `email-v2`, `guardianPortal`,
+   `student-complaints`). Writers want a **message log** (`channel, direction, body,
+   recipient, cc, bcc, sentAt, senderId…`); `models/Communication.js` is a
+   **correspondence-management** model (required `title, subject, sender.name,
+   receiver.name, sentDate, type enum incoming/outgoing/internal, createdBy.userId`)
+   → create throws. Candidate targets that already exist: `Conversation` + `Message`
+   statics (proven live in W276c), `DailyCommunicationLog`,
+   `rehab-center/family-communication.model`. **Fix = rebind each writer**, not extend
+   the correspondence model.
+
+3. **guardianPortal appointment booking** (4 keys). `Appointment` requires
+   `beneficiary` (ref) but the writer sends `beneficiaryId` (+ `serviceType,
+   requestedBy, requestedByUserId`) → required-field throw → **guardian booking is
+   broken**. Class B: fix the writer to canonical names.
+
+4. **BeneficiaryService** (5 keys — `branch, fileNumber, disabilityType,
+   disabilitySeverity, referralSource`). Core entity; W926 already showed the
+   canonical shape is `category`/`disability.type` (nested). Verify the service's
+   liveness (check:dormant-modules) then realign writer or declare flat fields per
+   the W926 normalizer-bridge precedent.
+
+### P2 — staff-facing, likely throwing or lossy
+
+5. **studentactivity** (7 keys; `student-elearning`, `student-events`,
+   `student-rewards-store`). Model is a gamified TASK (`titleAr`, `dueAt` REQUIRED);
+   writers log point-events (`studentId, activityType, points, reason, recordedBy,
+   date`) → throws. Either bind to a new `StudentActivityLog` model or map onto the
+   task vocabulary.
+
+6. **document cluster** (12 keys; `electronic-directives`, `student-certificates`,
+   `documents.smart`). Directives/certificates piggyback on `Document` with fields it
+   lacks (`directiveType, requiredSigners, signatureStatus, verificationCode…`).
+   Needs per-surface decision (dedicated models vs Document.metadata).
+
+7. **guardian** (8 flat contact keys — `name_ar, name_en, phone2, employer, city,
+   preferredContactMethod, preferredLanguage, canPickup`) — probable class C quick
+   win; verify against `models/Guardian.js` vocabulary first.
+
+8. **leaverequest** (6), **user** (`name, status, branch` in admin/user-management),
+   **documentversion** (2), **documentaccesslog** (1).
+
+### P3 — low traffic / analytics-only
+
+9. **riskassessment** (5), **budget** (3 — model uses `amount`), **beneficiarytransfer**
+   (3), **notification/smartnotification `sentBy`** (2), **contract.model `value`** (1),
+   **insuranceeligibilitycheck — remaining**: none.
+
+## Burn-down protocol
+
+Pick ONE cluster per wave: read writer + model → classify (A/B/C/D) → apply the class
+fix → remove the ids from `KNOWN_PHANTOM_WRITES` in the same commit → re-run
+`npm run check:phantom-writes` + the affected domain guards. Never blanket-declare
+class-B keys (creates W324-style duplicate semantics).
+
+## Tooling follow-ups (v2 candidates)
+
+- Follow pure re-export shims (`module.exports = require('./x').Y`) when indexing.
+- Flag **missing required keys** at create sites (catches the `uuid` class statically).
+- Extend W978-family guards to catch `next()` *called but never declared* in async
+  hooks (the W1193 Communication bug shape).


### PR DESCRIPTION
First burn-down wave on the W1189 phantom-writes baseline (131 → 127) + full triage dossier (`docs/architecture/PHANTOM_WRITES_TRIAGE_2026-06-11.md`).

## Runtime repairs (all verified against writers)
- `PriorAuthorization.uuid` + `InsuranceEligibilityCheck.uuid`: required with **no default and no caller ever set them** → `checkEligibility()` and `requestPriorAuth()` threw ValidationError on every call since the models shipped. Schema-side `crypto.randomUUID()` default fixes all callers.
- `Communication` pre-save hook called `next()` **without declaring it** (masked by file-level `eslint-disable no-undef`) → ReferenceError on every save reaching the call. 3rd W978-variant; guard extension listed as tooling follow-up.

## Class-C declares (writes intended, never declared)
`PriorAuthorization.{insuranceCompanyId, estimatedStartDate, estimatedEndDate}`, `InsuranceEligibilityCheck.requestedService`.

## Triage dossier key finding
The biggest baseline clusters are NOT benign missing fields — they are routes written against **imagined schemas** whose `create()` throws at runtime (smartInsurance claims vocabulary matches NO registered model; communication message-log writers vs the correspondence model; guardianPortal appointment booking sends `beneficiaryId` while `Appointment` requires `beneficiary`). Each P1 cluster has a documented fix path.

Baseline ratchet: 4 ids removed. `check:phantom-writes` exits 0; routes-load 558 clean; self-test 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)