### PR TITLE
fix(tests): W1194 - allowlist W1189 self-test fixture requires (unblocks deploy gate)

### DIFF
--- a/backend/__tests__/no-broken-requires.test.js
+++ b/backend/__tests__/no-broken-requires.test.js
@@ -78,6 +78,11 @@ const FALSE_POSITIVE_ALLOWLIST = new Set([
   // fixture strings, not real imports — the scanner is fooled by the quotes.
   path.join('__tests__', 'check-authz-consolidation-script.test.js'),
   path.join('__tests__', 'check-can-scope-contract-script.test.js'),
+  // W1189/W1194 check-phantom-schema-writes self-test writes
+  // `require('../models/Widget')` / `require('./shape')` etc. as fixture
+  // CONTENT (string arrays written to mkdtempSync repos) — same W522 class:
+  // literal fixture strings, not real imports.
+  path.join('__tests__', 'check-phantom-schema-writes-script.test.js'),
 ]);
 
 // Per-(file, target) allow-list for legitimately-optional dynamic loads.


### PR DESCRIPTION
`no-broken-requires` flagged 4 `require()` strings that are **fixture content** inside `check-phantom-schema-writes-script.test.js` (string arrays written to mkdtempSync temp repos) — the documented W522 false-positive class. CI shard 4 failed on the #364/#366 deploy runs → Deploy to VPS skipped. Allowlist entry with reason added; guard green locally (2/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)