### PR TITLE
ci(deploy): W1202 - harden the SSH retry window (3 transient failures in one day)

### DIFF
--- a/.github/workflows/deploy-hostinger.yml
+++ b/.github/workflows/deploy-hostinger.yml
@@ -317,18 +317,23 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "${{ secrets.VPS_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null || true
 
-          # Retry SSH connection up to 5 times (transient VPS issues are
-          # the #1 cause of otherwise-green deploys failing).
-          SSH_CMD='ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=15 '"${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}"
-          for attempt in 1 2 3 4 5; do
+          # Retry SSH connection up to 8 times (~10 min total backoff).
+          # Transient GitHub→VPS failures are the #1 cause of otherwise-green
+          # deploys failing: W1202 observed 3 in one day where all 5 of the
+          # old attempts (~3.5 min) failed while the VPS was verifiably
+          # healthy (sshd active, fail2ban clean, SSH fine from elsewhere) —
+          # the window simply outlasted the backoff. ConnectTimeout raised
+          # 15→25 for slow-handshake windows.
+          SSH_CMD='ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=25 '"${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}"
+          for attempt in 1 2 3 4 5 6 7 8; do
             if $SSH_CMD "echo '✅ SSH test attempt $attempt ok'"; then
               echo "✅ SSH configured (attempt $attempt)"
               exit 0
             fi
-            echo "⚠️  SSH attempt $attempt failed — retrying in $((attempt * 10))s"
-            sleep $((attempt * 10))
+            echo "⚠️  SSH attempt $attempt failed — retrying in $((attempt * 12))s"
+            sleep $((attempt * 12))
           done
-          echo "❌ SSH connection failed after 5 attempts. Check VPS_HOST/VPS_USER/VPS_SSH_KEY and that the VPS is reachable."
+          echo "❌ SSH connection failed after 8 attempts (~10 min). Check VPS_HOST/VPS_USER/VPS_SSH_KEY and that the VPS is reachable."
           exit 1
 
       - name: Deploy backend


### PR DESCRIPTION
Three otherwise-green deploys failed at **Setup SSH** in one day (#364, #368, #372) while the VPS was verifiably healthy each time (sshd active, fail2ban clean, SSH fine from elsewhere) — the transient GitHub→VPS window simply outlasted the 5-attempt/~3.5 min backoff, and each needed a manual `gh run rerun --failed`. Raised to 8 attempts / 12s-step backoff (~10 min) + ConnectTimeout 15→25.

`.github/**` is paths-ignored by the deploy workflow, so this merge does not itself spawn a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)