### PR TITLE
fix(admin): W1203 - repair admin user create/update + alias-aware audit (burn-down wave 6)

### DIFF
--- a/backend/routes/admin.routes.js
+++ b/backend/routes/admin.routes.js
@@ -273,14 +273,20 @@ router.post('/users', async (req, res) => {
     if (existing) {
       return res.status(400).json({ success: false, message: 'البريد الإلكتروني مسجل مسبقاً' });
     }
+    if (!name || !String(name).trim()) {
+      return res.status(400).json({ success: false, message: 'الاسم الكامل مطلوب' });
+    }
     const crypto = require('crypto');
     const tempPass = crypto.randomBytes(16).toString('hex');
+    // W1203 — User's declared fields are fullName (REQUIRED) + isActive; the
+    // old phantom name/status payload made this endpoint throw
+    // ValidationError on every admin user-create since it shipped.
     const user = await User.create({
-      name,
+      fullName: String(name).trim(),
       email,
       phone,
       role,
-      status: status || 'active',
+      isActive: (status || 'active') === 'active',
       password: tempPass,
     });
     const safeUser = await User.findById(user._id).select('-password').lean();
@@ -297,11 +303,19 @@ router.put('/users/:id', async (req, res) => {
     if (role && !ALLOWED_ROLES.includes(role)) {
       return res.status(400).json({ success: false, message: 'الدور غير مسموح به' });
     }
-    const user = await User.findByIdAndUpdate(
-      req.params.id,
-      { name, email, phone, role, status },
-      { returnDocument: 'after', runValidators: true }
-    )
+    // W1203 — same phantom vocabulary on the update path: name/status were
+    // silently dropped, so admin edits to a user's name or activation state
+    // never persisted.
+    const updates = {};
+    if (name !== undefined) updates.fullName = name;
+    if (email !== undefined) updates.email = email;
+    if (phone !== undefined) updates.phone = phone;
+    if (role !== undefined) updates.role = role;
+    if (status !== undefined) updates.isActive = status === 'active';
+    const user = await User.findByIdAndUpdate(req.params.id, updates, {
+      returnDocument: 'after',
+      runValidators: true,
+    })
       .select('-password')
       .lean();
     if (!user) return res.status(404).json({ success: false, message: 'المستخدم غير موجود' });

--- a/backend/scripts/check-phantom-schema-writes.js
+++ b/backend/scripts/check-phantom-schema-writes.js
@@ -41,8 +41,6 @@ const JSON_MODE = process.argv.includes('--json');
 // file::model-file-base::key — pre-existing findings to burn down (W325c
 // ratchet pattern): new entries must FAIL CI; fixed entries must be removed.
 const KNOWN_PHANTOM_WRITES = new Set([
-  "routes/admin.routes.js::user::name",
-  "routes/admin.routes.js::user::status",
   "routes/budgetManagement.routes.js::budget::totalAmount",
   "routes/budgetManagement.routes.js::budget::spentAmount",
   "routes/budgetManagement.routes.js::budget::lineItems",
@@ -129,7 +127,6 @@ const KNOWN_PHANTOM_WRITES = new Set([
   "routes/student-rewards-store.routes.js::studentactivity::reason",
   "routes/student-rewards-store.routes.js::studentactivity::recordedBy",
   "routes/student-rewards-store.routes.js::studentactivity::date",
-  "routes/user-management.routes.js::user::branch",
   "routes/waitlist.routes.js::beneficiary::branch",
   "routes/waitlist.routes.js::beneficiary::fileNumber",
   "routes/waitlist.routes.js::beneficiary::disabilityType",
@@ -431,6 +428,16 @@ function buildModelIndex(modelsDir) {
     }
     const base = path.basename(file, '.js').toLowerCase();
     const sets = extractSchemaKeySets(src);
+    // W1203 — mongoose field aliases (`alias: 'branch'` on branchId) accept
+    // writes under the alias name; count them as declared keys. Verified
+    // false-positive class: user-management's `branch` write is the official
+    // User.branchId alias. Only when the schema itself parsed — aliases must
+    // never un-poison an unparseable file.
+    if (sets.length > 0) {
+      const aliasRe = /\balias\s*:\s*['"](\w+)['"]/g;
+      let am;
+      while ((am = aliasRe.exec(src))) sets.push([am[1]]);
+    }
     if (sets.length === 0) {
       // No parseable schema. If the file LOOKS like it defines one (mentions
       // Schema), poison the base; pure re-export shims don't poison.

--- a/docs/architecture/PHANTOM_WRITES_TRIAGE_2026-06-11.md
+++ b/docs/architecture/PHANTOM_WRITES_TRIAGE_2026-06-11.md
@@ -129,8 +129,12 @@ lines and show the matched text.**
    hoursCount, leaveType validated against the enum. Sibling phantom READS fixed too:
    balance aggregation summed phantom `$totalDays` (always-zero balances) and list/
    balance matched phantom `employee` key.
-9. **user** (`name, status, branch` in admin/user-management), **documentversion** (2),
-   **documentaccesslog** (1) — LIVE, next quick wins.
+9. ~~**user**~~ — **FIXED W1203**: admin create wrote phantom `name`/`status` while
+   `fullName` is REQUIRED → user-create threw since shipping; the UPDATE path silently
+   dropped name/activation edits. Realigned to `fullName`/`isActive`. The
+   user-management `branch` write was a VERIFIED FALSE POSITIVE — it is the official
+   `User.branchId` alias; the audit script now parses `alias:` declarations (class D
+   tooling fix). documentversion/documentaccesslog cleared in W1201.
 
 ### P3 — low traffic / analytics-only
 


### PR DESCRIPTION
Baseline 107 → 104.

- **POST /users**: phantom `name`/`status` while `User.fullName` is REQUIRED → admin user-creation **threw on every call since shipping**. **PUT /users/:id**: name/activation edits silently dropped. Realigned to `fullName`/`isActive` with explicit partial-update object.
- **Audit tooling (class D)**: `check-phantom-schema-writes` now parses mongoose `alias:` declarations — user-management writing `branch` is the official `User.branchId` alias (verified false positive); guarded so aliases never un-poison unparseable schema files.

`check:phantom-writes` exits 0; routes-load 558 clean; self-test 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)