### PR TITLE
feat(rehab-plan): per-beneficiary plan-health + branch review-worklist (W1201/W1202, read-only)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1402,6 +1402,9 @@ on:
 =======
       - 'backend/__tests__/auditor-safemount-coverage-wave1192.test.js'
 >>>>>>> origin/main
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/rehab-plan-health-wave1201.test.js'
+      - 'backend/__tests__/review-worklist-wave1202.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2787,6 +2790,9 @@ on:
 =======
       - 'backend/__tests__/auditor-safemount-coverage-wave1192.test.js'
 >>>>>>> origin/main
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/rehab-plan-health-wave1201.test.js'
+      - 'backend/__tests__/review-worklist-wave1202.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/rehab-plan-health-wave1201.test.js
+++ b/backend/__tests__/rehab-plan-health-wave1201.test.js
@@ -1,0 +1,217 @@
+'use strict';
+
+/**
+ * rehab-plan-health-wave1201.test.js — unit tests for the READ-ONLY per-beneficiary
+ * Rehabilitation Plan Health service (services/rehabPlanHealth.service.js) + a
+ * static guard for its live route (domains/goals/routes/rehab-plan-health.routes.js).
+ *
+ * Pure logic — no DB. Requiring the service must NOT open a connection.
+ *
+ * Run: cd backend && npx jest --config=jest.config.js __tests__/rehab-plan-health-wave1201.test.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {
+  gradeRehabPlanHealth,
+  buildGoalSignal,
+  PLAN_HEALTH_GRADES,
+  ACTIVE_PLAN_STATUSES,
+} = require('../services/rehabPlanHealth.service');
+
+const review = (over = {}) => ({
+  onTrackRatio: 1,
+  holisticVerdict: 'continue_plan',
+  dischargeReadiness: { ready: false },
+  triggers: [],
+  ...over,
+});
+
+describe('rehab-plan-health — gradeRehabPlanHealth (pure)', () => {
+  test('requires service WITHOUT opening a DB connection + grade list', () => {
+    expect(typeof gradeRehabPlanHealth).toBe('function');
+    expect(PLAN_HEALTH_GRADES).toContain('ON_TRACK');
+    expect(PLAN_HEALTH_GRADES).toContain('AT_RISK');
+    expect(ACTIVE_PLAN_STATUSES).toContain('active');
+  });
+
+  test('no plan → NO_PLAN, composite null, no actions', () => {
+    const g = gradeRehabPlanHealth({ hasPlan: false });
+    expect(g.grade).toBe('NO_PLAN');
+    expect(g.composite).toBeNull();
+    expect(g.actions).toEqual([]);
+  });
+
+  test('plan but zero goals → NO_DATA', () => {
+    expect(gradeRehabPlanHealth({ hasPlan: true, goalCount: 0 }).grade).toBe('NO_DATA');
+  });
+
+  test('strong progress + complete thread + no overdue → ON_TRACK', () => {
+    const g = gradeRehabPlanHealth({
+      hasPlan: true,
+      goalCount: 4,
+      review: review({ onTrackRatio: 0.9 }),
+      threadSummary: { total: 4, completeCount: 4 },
+      reviewOverdueDays: 0,
+    });
+    expect(g.grade).toBe('ON_TRACK');
+    expect(g.composite).toBeGreaterThanOrEqual(90);
+    expect(g.actions).toHaveLength(0);
+  });
+
+  test('holistic new_plan → AT_RISK with P1 goal_progress action', () => {
+    const g = gradeRehabPlanHealth({
+      hasPlan: true,
+      goalCount: 3,
+      review: review({ holisticVerdict: 'new_plan', onTrackRatio: 0.3 }),
+      threadSummary: { total: 3, completeCount: 1 },
+    });
+    expect(g.grade).toBe('AT_RISK');
+    expect(g.actions[0].priority).toBe('P1');
+    expect(g.actions.some(a => a.dimension === 'goal_progress')).toBe(true);
+  });
+
+  test('safety trigger → AT_RISK + P1 safety action first', () => {
+    const g = gradeRehabPlanHealth({
+      hasPlan: true,
+      goalCount: 2,
+      review: review({ triggers: [{ kind: 'safety' }] }),
+      threadSummary: { total: 2, completeCount: 2 },
+    });
+    expect(g.grade).toBe('AT_RISK');
+    expect(g.actions[0].dimension).toBe('safety');
+    expect(g.signals.safety).toBe(true);
+    expect(g.composite).toBeLessThan(100); // safety penalty applied
+  });
+
+  test('review overdue ≥14d → AT_RISK (critical); 1–13d → NEEDS_ATTENTION', () => {
+    const crit = gradeRehabPlanHealth({
+      hasPlan: true,
+      goalCount: 2,
+      review: review(),
+      threadSummary: { total: 2, completeCount: 2 },
+      reviewOverdueDays: 20,
+    });
+    expect(crit.grade).toBe('AT_RISK');
+    expect(crit.actions.find(a => a.dimension === 'review_cadence').priority).toBe('P1');
+
+    const warn = gradeRehabPlanHealth({
+      hasPlan: true,
+      goalCount: 2,
+      review: review(),
+      threadSummary: { total: 2, completeCount: 2 },
+      reviewOverdueDays: 5,
+    });
+    expect(warn.grade).toBe('NEEDS_ATTENTION');
+    expect(warn.actions.find(a => a.dimension === 'review_cadence').priority).toBe('P2');
+  });
+
+  test('holistic revise_plan → NEEDS_ATTENTION', () => {
+    const g = gradeRehabPlanHealth({
+      hasPlan: true,
+      goalCount: 3,
+      review: review({ holisticVerdict: 'revise_plan', onTrackRatio: 0.8 }),
+      threadSummary: { total: 3, completeCount: 3 },
+    });
+    expect(g.grade).toBe('NEEDS_ATTENTION');
+  });
+
+  test('discharge readiness (and not at-risk) → DISCHARGE_READY + P3 action', () => {
+    const g = gradeRehabPlanHealth({
+      hasPlan: true,
+      goalCount: 4,
+      review: review({ onTrackRatio: 0.95, dischargeReadiness: { ready: true } }),
+      threadSummary: { total: 4, completeCount: 4 },
+      reviewOverdueDays: 0,
+    });
+    expect(g.grade).toBe('DISCHARGE_READY');
+    expect(g.actions.some(a => a.dimension === 'discharge' && a.priority === 'P3')).toBe(true);
+  });
+
+  test('incomplete golden thread (<60%) → NEEDS_ATTENTION + golden_thread action', () => {
+    const g = gradeRehabPlanHealth({
+      hasPlan: true,
+      goalCount: 5,
+      review: review({ onTrackRatio: 0.8 }),
+      threadSummary: { total: 5, completeCount: 2 }, // 40%
+    });
+    expect(g.grade).toBe('NEEDS_ATTENTION');
+    expect(g.actions.some(a => a.dimension === 'golden_thread')).toBe(true);
+    expect(g.signals.threadCompletePct).toBe(40);
+  });
+
+  test('actions ordered P1 → P2 → P3', () => {
+    const g = gradeRehabPlanHealth({
+      hasPlan: true,
+      goalCount: 4,
+      review: review({
+        holisticVerdict: 'revise_plan', // P2
+        onTrackRatio: 0.5,
+        triggers: [{ kind: 'safety' }], // P1
+        dischargeReadiness: { ready: true }, // P3 (but at-risk due to safety)
+      }),
+      threadSummary: { total: 4, completeCount: 1 },
+      reviewOverdueDays: 3, // P2
+    });
+    const prios = g.actions.map(a => a.priority);
+    expect(prios[0]).toBe('P1');
+    expect([...prios].sort()).toEqual(prios); // already non-decreasing
+  });
+});
+
+describe('rehab-plan-health — buildGoalSignal (pure)', () => {
+  test('maps progressHistory → measureSeries + target.value → targetValue', () => {
+    const sig = buildGoalSignal({
+      _id: 'g1',
+      target: { value: 80 },
+      progressHistory: [
+        { recordedAt: '2026-01-01', value: 10 },
+        { recordedAt: '2026-02-01', value: 25 },
+        { value: null }, // dropped (no numeric value)
+      ],
+    });
+    expect(sig.goalId).toBe('g1');
+    expect(sig.targetValue).toBe(80);
+    expect(sig.measureSeries).toHaveLength(2);
+    expect(sig.measureSeries[0]).toEqual({ date: '2026-01-01', value: 10 });
+  });
+
+  test('empty/missing fields degrade to empty series + undefined target', () => {
+    const sig = buildGoalSignal({});
+    expect(sig.measureSeries).toEqual([]);
+    expect(sig.targetValue).toBeUndefined();
+    expect(sig.safetyEventLinked).toBe(false);
+  });
+});
+
+describe('rehab-plan-health route (W1201) — static guard', () => {
+  const ROUTE_SRC = fs.readFileSync(
+    path.join(__dirname, '..', 'domains', 'goals', 'routes', 'rehab-plan-health.routes.js'),
+    'utf-8'
+  );
+  const INDEX_SRC = fs.readFileSync(
+    path.join(__dirname, '..', 'domains', 'goals', 'routes', 'index.routes.js'),
+    'utf-8'
+  );
+
+  test('route file loads without throwing', () => {
+    expect(() => require('../domains/goals/routes/rehab-plan-health.routes')).not.toThrow();
+  });
+  test('declares GET /rehab-plan-health/:beneficiaryId + mounted in goals index', () => {
+    expect(ROUTE_SRC).toMatch(/router\.get\(\s*['"]\/rehab-plan-health\/:beneficiaryId['"]/);
+    expect(INDEX_SRC).toMatch(/require\(\s*['"]\.\/rehab-plan-health\.routes['"]\s*\)/);
+  });
+  test('W269 beneficiary-branch isolation (enforceBeneficiaryBranch) + ObjectId validation', () => {
+    expect(ROUTE_SRC).toMatch(/enforceBeneficiaryBranch\(\s*req\s*,\s*beneficiaryId\s*\)/);
+    expect(ROUTE_SRC).toMatch(/isValidObjectId\(\s*beneficiaryId\s*\)/);
+    expect(ROUTE_SRC).not.toMatch(/req\.branchId/);
+  });
+  test('READ-ONLY — no mutation in the route', () => {
+    expect(ROUTE_SRC).not.toMatch(
+      /\.(save|create|updateOne|updateMany|deleteOne|deleteMany|insertMany|findOneAndUpdate)\(/
+    );
+  });
+  test('delegates to assembleBeneficiaryPlanHealth', () => {
+    expect(ROUTE_SRC).toMatch(/assembleBeneficiaryPlanHealth\(/);
+  });
+});

--- a/backend/__tests__/review-worklist-wave1202.test.js
+++ b/backend/__tests__/review-worklist-wave1202.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+/**
+ * review-worklist-wave1202.test.js — unit tests for the READ-ONLY branch
+ * "plans needing review" worklist (#3): the pure W50 severity classifier +
+ * the reviewWorklist degradation + a static guard for the route
+ * (domains/goals/routes/supervisor-ops.routes.js → GET /supervisor-ops/review-worklist).
+ *
+ * Pure logic — no DB. Run: cd backend && npx jest --config=jest.config.js __tests__/review-worklist-wave1202.test.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {
+  classifyReviewSeverity,
+  reviewWorklist,
+  REVIEW_SEVERITIES,
+} = require('../services/rehabPlanHealth.service');
+
+describe('review-worklist — classifyReviewSeverity (pure, W50 SLA bands)', () => {
+  test('not yet due (negative) → null', () => {
+    expect(classifyReviewSeverity(-1)).toBeNull();
+    expect(classifyReviewSeverity(-30)).toBeNull();
+  });
+  test('due today (0) → info', () => {
+    expect(classifyReviewSeverity(0)).toBe('info');
+  });
+  test('1–13 days overdue → warning', () => {
+    expect(classifyReviewSeverity(1)).toBe('warning');
+    expect(classifyReviewSeverity(13)).toBe('warning');
+  });
+  test('14+ days overdue → critical', () => {
+    expect(classifyReviewSeverity(14)).toBe('critical');
+    expect(classifyReviewSeverity(90)).toBe('critical');
+  });
+  test('non-numeric → null', () => {
+    expect(classifyReviewSeverity(undefined)).toBeNull();
+    expect(classifyReviewSeverity(null)).toBeNull();
+  });
+  test('severity order is critical → warning → info', () => {
+    expect(REVIEW_SEVERITIES).toEqual(['critical', 'warning', 'info']);
+  });
+});
+
+describe('review-worklist — reviewWorklist (read-only, graceful)', () => {
+  test('no branchId → empty worklist, zero counts (no scan-all)', async () => {
+    const r = await reviewWorklist({});
+    expect(r.total).toBe(0);
+    expect(r.items).toEqual([]);
+    expect(r.counts).toEqual({ critical: 0, warning: 0, info: 0 });
+    expect(r.branchId).toBeNull();
+  });
+  test('CarePlanVersion model unregistered → degrades to empty (no throw)', async () => {
+    // In this unit context the model is not registered → graceful empty.
+    const r = await reviewWorklist({ branchId: '64b2f0000000000000000001' });
+    expect(r.total).toBe(0);
+    expect(Array.isArray(r.items)).toBe(true);
+  });
+});
+
+describe('review-worklist route (W1202) — static guard', () => {
+  const ROUTE_SRC = fs.readFileSync(
+    path.join(__dirname, '..', 'domains', 'goals', 'routes', 'supervisor-ops.routes.js'),
+    'utf-8'
+  );
+
+  test('declares GET /supervisor-ops/review-worklist', () => {
+    expect(ROUTE_SRC).toMatch(/router\.get\(\s*['"]\/supervisor-ops\/review-worklist['"]/);
+  });
+  test('W269 branch scoping (effectiveBranchScope, no req.branchId, 400 reject, ObjectId)', () => {
+    expect(ROUTE_SRC).toMatch(/effectiveBranchScope\(\s*req\s*\)/);
+    expect(ROUTE_SRC).not.toMatch(/req\.branchId/);
+    expect(ROUTE_SRC).toMatch(/branchId required/);
+    expect(ROUTE_SRC).toMatch(/isValidObjectId\(\s*req\.query\.branchId\s*\)/);
+  });
+  test('delegates to reviewWorklist + caps the limit', () => {
+    expect(ROUTE_SRC).toMatch(/reviewWorklist\(\s*\{\s*branchId/);
+    expect(ROUTE_SRC).toMatch(/Math\.min\(/);
+  });
+  test('READ-ONLY — no mutation', () => {
+    expect(ROUTE_SRC).not.toMatch(
+      /\.(save|create|updateOne|updateMany|deleteOne|deleteMany|insertMany|findOneAndUpdate)\(/
+    );
+  });
+});

--- a/backend/domains/goals/routes/index.routes.js
+++ b/backend/domains/goals/routes/index.routes.js
@@ -17,5 +17,6 @@ router.use('/', require('./goals.routes'));
 router.use('/', require('./measures.routes'));
 router.use('/', require('./golden-thread.routes')); // W1167 — caseload attention triage
 router.use('/', require('./supervisor-ops.routes')); // W1170 — documentation backlog
+router.use('/', require('./rehab-plan-health.routes')); // per-beneficiary plan-on-track
 
 module.exports = router;

--- a/backend/domains/goals/routes/rehab-plan-health.routes.js
+++ b/backend/domains/goals/routes/rehab-plan-health.routes.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * Rehabilitation Plan Health routes — per-beneficiary plan-on-track snapshot.
+ *
+ * Exposes the rehabPlanHealth service as a LIVE, branch-isolated endpoint so a
+ * clinician/case-manager can pull "is this beneficiary's rehab plan on track?"
+ * on-demand (the underlying W44 progress-reviewer + W50 review-cadence
+ * intelligence otherwise only runs on cron). Fuses goal-progress + golden-thread
+ * + review-cadence + safety into one grade + priority actions.
+ *
+ * Mounted by domains/goals/routes/index.routes.js at /api(/v1)/goals.
+ * READ-ONLY. Per-beneficiary access is guarded by enforceBeneficiaryBranch
+ * (W269 — loads the Beneficiary + throws 403 cross-branch / 404 missing).
+ *
+ * @module domains/goals/routes/rehab-plan-health.routes
+ */
+
+const express = require('express');
+const router = express.Router();
+const mongoose = require('mongoose');
+const { enforceBeneficiaryBranch } = require('../../../middleware/assertBranchMatch');
+const { assembleBeneficiaryPlanHealth } = require('../../../services/rehabPlanHealth.service');
+
+function asyncHandler(fn) {
+  return (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /rehab-plan-health/:beneficiaryId
+//   The per-beneficiary rehab-plan-on-track snapshot: overall grade
+//   (ON_TRACK / DISCHARGE_READY / NEEDS_ATTENTION / AT_RISK / NO_PLAN / NO_DATA)
+//   + 0-100 composite + priority-ordered actions, fusing goal-progress (W44),
+//   golden-thread completeness, review cadence, and safety triggers. READ-ONLY.
+//   Branch isolation: enforceBeneficiaryBranch loads the beneficiary and rejects
+//   a foreign-branch caller (403) before any plan data is read.
+// ═══════════════════════════════════════════════════════════════════════════
+router.get(
+  '/rehab-plan-health/:beneficiaryId',
+  asyncHandler(async (req, res) => {
+    const { beneficiaryId } = req.params;
+    if (!mongoose.isValidObjectId(beneficiaryId)) {
+      return res.status(400).json({ success: false, error: 'invalid beneficiaryId' });
+    }
+    await enforceBeneficiaryBranch(req, beneficiaryId);
+    const data = await assembleBeneficiaryPlanHealth(beneficiaryId);
+    return res.json({ success: true, data });
+  })
+);
+
+module.exports = router;

--- a/backend/domains/goals/routes/supervisor-ops.routes.js
+++ b/backend/domains/goals/routes/supervisor-ops.routes.js
@@ -26,6 +26,7 @@ const {
 } = require('../../../services/supervisorOps.service');
 const reassessmentLifecycleService = require('../../../services/reassessmentLifecycle.service');
 const { gatherBranchHealth } = require('../../../services/operationsHealth.service');
+const { reviewWorklist } = require('../../../services/rehabPlanHealth.service');
 
 function asyncHandler(fn) {
   return (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
@@ -145,6 +146,34 @@ router.get(
 
     const sinceDays = Math.min(parseInt(req.query.days, 10) || 7, 90);
     const data = await gatherBranchHealth(mongoose, { branchId, sinceDays });
+    return res.json({ success: true, data });
+  })
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /supervisor-ops/review-worklist[?branchId=&limit=]
+//   The branch "plans needing review" worklist: live care plans whose review is
+//   due/overdue, classified into W50 SLA severity (info/warning/critical),
+//   sorted most-overdue-first. The on-demand read-side of the W50 overdue-review
+//   cron. Same W269 branch scoping. READ-ONLY.
+// ═══════════════════════════════════════════════════════════════════════════
+router.get(
+  '/supervisor-ops/review-worklist',
+  asyncHandler(async (req, res) => {
+    const scoped = effectiveBranchScope(req);
+    let branchId = scoped || null;
+    if (!branchId && req.query.branchId && mongoose.isValidObjectId(req.query.branchId)) {
+      branchId = req.query.branchId;
+    }
+    if (!branchId) {
+      return res.status(400).json({
+        success: false,
+        error: 'branchId required — a cross-branch role must specify ?branchId.',
+      });
+    }
+
+    const limit = Math.min(parseInt(req.query.limit, 10) || 200, 500);
+    const data = await reviewWorklist({ branchId, limit });
     return res.json({ success: true, data });
   })
 );

--- a/backend/services/rehabPlanHealth.service.js
+++ b/backend/services/rehabPlanHealth.service.js
@@ -1,0 +1,426 @@
+'use strict';
+
+/**
+ * rehabPlanHealth.service.js — READ-ONLY per-beneficiary Rehabilitation Plan Health.
+ * ════════════════════════════════════════════════════════════════════════════
+ * The beneficiary-level analog of the branch-level operationsHealth service: it
+ * answers ONE question for a clinician/case-manager — "is THIS beneficiary's
+ * rehabilitation plan on track?" — by FUSING signals that already exist but are
+ * scattered (and, for the W44/W50 intelligence, only run on cron):
+ *
+ *   1. GOAL PROGRESS   — the W44 progress-reviewer (reviewPlan): per-goal trend
+ *                        (improving/plateau/regressing) + holistic verdict
+ *                        (continue/revise/new_plan) + discharge readiness.
+ *   2. GOLDEN THREAD   — goldenThread.traceByBeneficiary: how many goals carry the
+ *                        full assessment→measure→baseline→outcome thread.
+ *   3. REVIEW CADENCE  — is the plan's reviewDate overdue (W50 SLA bands)?
+ *   4. SAFETY/PLATEAU  — triggers surfaced by the W44 reviewer.
+ *
+ * Computes NO new clinical logic — it re-uses the already-tested PURE functions
+ * (reviewPlan / summarizeThread-via-trace) and folds them through one pure grader.
+ * A single read-only pass over the beneficiary's active plan + goals. Safe vs prod.
+ */
+
+const mongoose = require('mongoose');
+const progressReviewer = require('../intelligence/care-plan-progress-reviewer.service');
+const goldenThread = require('./goldenThread.service');
+
+// Overall rehab-plan health grade band.
+const PLAN_HEALTH_GRADES = Object.freeze([
+  'ON_TRACK',
+  'DISCHARGE_READY',
+  'NEEDS_ATTENTION',
+  'AT_RISK',
+  'NO_PLAN',
+  'NO_DATA',
+]);
+
+// The UnifiedCarePlan (DDD) statuses that count as a "live" plan.
+const ACTIVE_PLAN_STATUSES = Object.freeze(['active', 'under_review', 'modified']);
+
+// The CarePlanVersion (W41-51 care-planning workflow) statuses that count as a
+// "live" approved plan — matches the W44 plateau-detector's eligibleStatuses.
+const CARE_PLAN_VERSION_LIVE_STATUSES = Object.freeze([
+  'approved',
+  'saved_to_record',
+  'family_notification_sent',
+]);
+
+const REVIEW_OVERDUE_CRITICAL_DAYS = 14;
+
+/**
+ * PURE — map one TherapeuticGoal (lean doc) to the W44 reviewer's goal signal.
+ * progressHistory[].value → measureSeries[{date,value}]; target.value → targetValue.
+ * @param {object} goal
+ * @returns {{ goalId:any, measureSeries:object[], targetValue:(number|undefined), attendance:(number|undefined), safetyEventLinked:boolean }}
+ */
+function buildGoalSignal(goal = {}) {
+  const history = Array.isArray(goal.progressHistory) ? goal.progressHistory : [];
+  const measureSeries = history
+    .map(h => ({
+      date: h.recordedAt || h.date || h.createdAt || null,
+      value: typeof h.value === 'number' ? h.value : null,
+    }))
+    .filter(p => p.value !== null);
+  const targetValue =
+    goal.target && typeof goal.target.value === 'number' ? goal.target.value : undefined;
+  return {
+    goalId: goal._id,
+    measureSeries,
+    targetValue,
+    attendance: typeof goal.attendance === 'number' ? goal.attendance : undefined,
+    safetyEventLinked: Boolean(goal.safetyEventLinked),
+  };
+}
+
+/**
+ * PURE — fuse the goal-progress review + golden-thread summary + review-cadence
+ * into ONE plan-health grade + 0-100 composite + priority-ordered action list.
+ * No DB / no I/O — unit-testable in isolation.
+ *
+ * @param {{
+ *   hasPlan?: boolean,
+ *   goalCount?: number,
+ *   review?: { onTrackRatio?: number, holisticVerdict?: string, dischargeReadiness?: { ready?: boolean }, triggers?: object[] },
+ *   threadSummary?: { total?: number, completeCount?: number },
+ *   reviewOverdueDays?: (number|null)
+ * }} parts
+ * @returns {{ grade:string, composite:(number|null), signals:object, actions:object[] }}
+ */
+function gradeRehabPlanHealth(parts = {}) {
+  const hasPlan = parts.hasPlan !== false;
+  const goalCount = typeof parts.goalCount === 'number' ? parts.goalCount : 0;
+  const review = parts.review || {};
+  const threadSummary = parts.threadSummary || null;
+  const overdueDays =
+    typeof parts.reviewOverdueDays === 'number' && parts.reviewOverdueDays > 0
+      ? parts.reviewOverdueDays
+      : 0;
+
+  const onTrackRatio = typeof review.onTrackRatio === 'number' ? review.onTrackRatio : null;
+  const holistic = review.holisticVerdict || null;
+  const dischargeReady = Boolean(review.dischargeReadiness && review.dischargeReadiness.ready);
+  const triggers = Array.isArray(review.triggers) ? review.triggers : [];
+  const safety = triggers.some(t => t && (t.kind === 'safety' || t.kind === 'safety_event'));
+  const plateau = triggers.some(t => t && (t.kind === 'plateau' || t.kind === 'regression'));
+
+  const threadPct =
+    threadSummary && typeof threadSummary.total === 'number' && threadSummary.total > 0
+      ? Math.round((100 * (threadSummary.completeCount || 0)) / threadSummary.total)
+      : null;
+
+  // ── grade band ──
+  let grade;
+  if (!hasPlan) {
+    grade = 'NO_PLAN';
+  } else if (goalCount === 0) {
+    grade = 'NO_DATA';
+  } else {
+    const atRisk =
+      holistic === 'new_plan' ||
+      safety ||
+      overdueDays >= REVIEW_OVERDUE_CRITICAL_DAYS ||
+      (onTrackRatio !== null && onTrackRatio < 0.4);
+    const needsAttention =
+      holistic === 'revise_plan' ||
+      overdueDays > 0 ||
+      plateau ||
+      (onTrackRatio !== null && onTrackRatio < 0.7) ||
+      (threadPct !== null && threadPct < 60);
+    if (atRisk) grade = 'AT_RISK';
+    else if (dischargeReady) grade = 'DISCHARGE_READY';
+    else if (needsAttention) grade = 'NEEDS_ATTENTION';
+    else grade = 'ON_TRACK';
+  }
+
+  // ── composite 0-100 (only when there is goal data) ──
+  let composite = null;
+  if (hasPlan && goalCount > 0) {
+    const onTrackComponent = onTrackRatio !== null ? onTrackRatio * 100 : 60;
+    const threadComponent = threadPct !== null ? threadPct : onTrackComponent;
+    let score = Math.round(onTrackComponent * 0.6 + threadComponent * 0.4);
+    if (overdueDays >= REVIEW_OVERDUE_CRITICAL_DAYS) score -= 20;
+    else if (overdueDays > 0) score -= 10;
+    if (safety) score -= 25;
+    composite = Math.max(0, Math.min(100, score));
+  }
+
+  // ── priority-ordered actions (highest-leverage first) ──
+  const actions = [];
+  if (safety) {
+    actions.push({
+      priority: 'P1',
+      dimension: 'safety',
+      action: 'هدف مرتبط بحدث سلامة — راجِع الخطة وخفّف الخطر فوراً.',
+    });
+  }
+  if (holistic === 'new_plan') {
+    actions.push({
+      priority: 'P1',
+      dimension: 'goal_progress',
+      action: 'المراجعة الكلّية توصي بخطة جديدة — أهداف متعدّدة متعثّرة؛ أعِد بناء الخطة.',
+    });
+  } else if (holistic === 'revise_plan') {
+    actions.push({
+      priority: 'P2',
+      dimension: 'goal_progress',
+      action: 'المراجعة الكلّية توصي بمراجعة الخطة — عدّل الأهداف المتعثّرة.',
+    });
+  }
+  if (overdueDays >= REVIEW_OVERDUE_CRITICAL_DAYS) {
+    actions.push({
+      priority: 'P1',
+      dimension: 'review_cadence',
+      action: `مراجعة الخطة متأخّرة ${overdueDays} يوماً (حرِجة) — جدوِل المراجعة الآن.`,
+    });
+  } else if (overdueDays > 0) {
+    actions.push({
+      priority: 'P2',
+      dimension: 'review_cadence',
+      action: `مراجعة الخطة متأخّرة ${overdueDays} يوماً — جدوِل المراجعة.`,
+    });
+  }
+  if (plateau) {
+    actions.push({
+      priority: 'P2',
+      dimension: 'goal_progress',
+      action: 'أهداف على هضبة/تراجع — راجِع التدخّلات أو خط الأساس.',
+    });
+  }
+  if (threadPct !== null && threadPct < 60) {
+    actions.push({
+      priority: 'P2',
+      dimension: 'golden_thread',
+      action: `اكتمال الخيط الذهبي ${threadPct}% — اربط مقاييس/خطوط أساس لإغلاق حلقة النتائج.`,
+    });
+  }
+  if (dischargeReady) {
+    actions.push({
+      priority: 'P3',
+      dimension: 'discharge',
+      action: 'جاهزية الخروج: ≥80% من الأهداف على المسار — قيّم خطة الخروج/الانتقال.',
+    });
+  }
+  const rank = { P1: 0, P2: 1, P3: 2 };
+  actions.sort((a, b) => (rank[a.priority] ?? 9) - (rank[b.priority] ?? 9));
+
+  return {
+    grade,
+    composite,
+    signals: {
+      goalCount,
+      onTrackRatio,
+      holisticVerdict: holistic,
+      dischargeReady,
+      reviewOverdueDays: overdueDays,
+      threadCompletePct: threadPct,
+      safety,
+      plateau,
+    },
+    actions,
+  };
+}
+
+function resolveModel(name) {
+  try {
+    return mongoose.model(name);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * READ-ONLY — resolve the beneficiary's current active plan + review cadence,
+ * normalised to one shape, preferring the live CarePlanVersion over UnifiedCarePlan.
+ * @param {string|ObjectId} beneficiaryId
+ * @returns {Promise<({ planId:any, source:string, type:any, status:string, reviewDate:(Date|null) }|null)>}
+ */
+async function resolveActivePlan(beneficiaryId) {
+  const CarePlanVersion = resolveModel('CarePlanVersion');
+  if (CarePlanVersion) {
+    const cpv = await CarePlanVersion.findOne({
+      beneficiaryId,
+      status: { $in: CARE_PLAN_VERSION_LIVE_STATUSES },
+    })
+      .sort({ approvedAt: -1, createdAt: -1 })
+      .lean();
+    if (cpv) {
+      return {
+        planId: cpv._id,
+        source: 'CarePlanVersion',
+        type: cpv.planType,
+        status: cpv.status,
+        reviewDate: cpv.reviewSchedule ? cpv.reviewSchedule.nextReviewAt || null : null,
+      };
+    }
+  }
+  const UnifiedCarePlan = resolveModel('UnifiedCarePlan');
+  if (UnifiedCarePlan) {
+    const ucp = await UnifiedCarePlan.findOne({
+      beneficiaryId,
+      status: { $in: ACTIVE_PLAN_STATUSES },
+      isDeleted: { $ne: true },
+    })
+      .sort({ updatedAt: -1 })
+      .lean();
+    if (ucp) {
+      return {
+        planId: ucp._id,
+        source: 'UnifiedCarePlan',
+        type: ucp.type,
+        status: ucp.status,
+        reviewDate: ucp.reviewDate || ucp.nextReviewAt || null,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * READ-ONLY — assemble the rehab-plan health snapshot for one beneficiary:
+ * load the active UnifiedCarePlan + the beneficiary's TherapeuticGoals, build W44
+ * signals, run reviewPlan, trace the golden thread, and grade. Degrades
+ * gracefully (NO_PLAN / NO_DATA) when models/data are missing.
+ * @param {string|ObjectId} beneficiaryId
+ * @param {{ now?: Date }} [opts]
+ */
+async function assembleBeneficiaryPlanHealth(beneficiaryId, opts = {}) {
+  const now = opts.now instanceof Date ? opts.now : new Date();
+  const TherapeuticGoal = resolveModel('TherapeuticGoal');
+
+  // 1. The active plan + its review cadence. Plan-model fragmentation is real:
+  //    PREFER the live CarePlanVersion (the care-planning W41-51 workflow + the
+  //    W44/W50 intelligence run on it — review cadence = reviewSchedule.nextReviewAt),
+  //    fall back to the DDD UnifiedCarePlan (reviewDate). Normalised to one shape.
+  let plan = await resolveActivePlan(beneficiaryId);
+
+  // 2. The beneficiary's goals (canonical TherapeuticGoal, golden-thread-linked,
+  //    with progressHistory for the W44 signals).
+  let goals = [];
+  if (TherapeuticGoal) {
+    goals = await TherapeuticGoal.find({ beneficiaryId, isDeleted: { $ne: true } })
+      .select('target progressHistory status attendance safetyEventLinked')
+      .lean();
+  }
+
+  // 3. W44 review (pure) over the goal signals.
+  const goalSignals = goals.map(buildGoalSignal);
+  const planReviewDueAt = plan ? plan.reviewDate : null;
+  const review = progressReviewer.reviewPlan({ goalSignals, now, planReviewDueAt });
+
+  // 4. Golden-thread completeness for this beneficiary.
+  let threadSummary = null;
+  try {
+    const trace = await goldenThread.traceByBeneficiary(beneficiaryId);
+    threadSummary = trace && trace.summary ? trace.summary : null;
+  } catch {
+    /* golden-thread unavailable — leave null */
+  }
+
+  // 5. Review-overdue days.
+  let reviewOverdueDays = null;
+  if (planReviewDueAt) {
+    const due = new Date(planReviewDueAt).getTime();
+    reviewOverdueDays = Math.floor((now.getTime() - due) / (1000 * 60 * 60 * 24));
+  }
+
+  const grade = gradeRehabPlanHealth({
+    hasPlan: Boolean(plan),
+    goalCount: goals.length,
+    review,
+    threadSummary,
+    reviewOverdueDays,
+  });
+
+  return {
+    beneficiaryId: String(beneficiaryId),
+    generatedAt: now,
+    plan, // normalised { planId, source, type, status, reviewDate } | null
+    review: {
+      holisticVerdict: review.holisticVerdict,
+      onTrackRatio: review.onTrackRatio,
+      counts: review.counts,
+      dischargeReadiness: review.dischargeReadiness,
+      triggers: review.triggers,
+    },
+    threadSummary,
+    grade,
+  };
+}
+
+// ── #3 — branch "plans needing review" worklist (W50 read-side, on-demand) ──
+
+const REVIEW_SEVERITIES = Object.freeze(['critical', 'warning', 'info']);
+
+/**
+ * PURE — classify a plan's review-overdue days into the W50 SLA severity band
+ * (matches care-plan-overdue-review.scanner: <1d info · 1–13d warning · 14+ critical).
+ * Returns null when the review is not yet due (negative overdue).
+ * @param {number} overdueDays
+ * @returns {('critical'|'warning'|'info'|null)}
+ */
+function classifyReviewSeverity(overdueDays) {
+  if (typeof overdueDays !== 'number' || overdueDays < 0) return null;
+  if (overdueDays >= REVIEW_OVERDUE_CRITICAL_DAYS) return 'critical';
+  if (overdueDays >= 1) return 'warning';
+  return 'info';
+}
+
+/**
+ * READ-ONLY — the branch worklist of live plans whose review is due/overdue:
+ * the on-demand read-side of the W50 overdue-review cron, branch-scoped, sorted
+ * most-overdue-first. The supervisor's "which plans need review now" list.
+ * @param {{ branchId?: any, now?: Date, limit?: number }} [opts]
+ */
+async function reviewWorklist(opts = {}) {
+  const at = opts.now instanceof Date ? opts.now : new Date();
+  const cap = Number.isFinite(opts.limit) && opts.limit > 0 ? opts.limit : 200;
+  const counts = { critical: 0, warning: 0, info: 0 };
+  const CarePlanVersion = resolveModel('CarePlanVersion');
+  if (!CarePlanVersion || !opts.branchId) {
+    return { branchId: opts.branchId ? String(opts.branchId) : null, total: 0, counts, items: [] };
+  }
+
+  const rows = await CarePlanVersion.find({
+    branchId: opts.branchId,
+    status: { $in: CARE_PLAN_VERSION_LIVE_STATUSES },
+    'reviewSchedule.nextReviewAt': { $ne: null, $lte: at },
+  })
+    .select('beneficiaryId planType status reviewSchedule')
+    .sort({ 'reviewSchedule.nextReviewAt': 1 })
+    .limit(cap)
+    .lean();
+
+  const items = [];
+  for (const r of rows) {
+    const due = r.reviewSchedule && r.reviewSchedule.nextReviewAt;
+    if (!due) continue;
+    const overdueDays = Math.floor((at.getTime() - new Date(due).getTime()) / 86400000);
+    const severity = classifyReviewSeverity(overdueDays);
+    if (!severity) continue;
+    counts[severity] += 1;
+    items.push({
+      planId: r._id,
+      beneficiaryId: r.beneficiaryId,
+      planType: r.planType,
+      status: r.status,
+      dueAt: due,
+      overdueDays,
+      severity,
+    });
+  }
+  return { branchId: String(opts.branchId), total: items.length, counts, items };
+}
+
+module.exports = {
+  PLAN_HEALTH_GRADES,
+  ACTIVE_PLAN_STATUSES,
+  CARE_PLAN_VERSION_LIVE_STATUSES,
+  REVIEW_SEVERITIES,
+  buildGoalSignal,
+  gradeRehabPlanHealth,
+  classifyReviewSeverity,
+  resolveActivePlan,
+  assembleBeneficiaryPlanHealth,
+  reviewWorklist,
+};

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -836,3 +836,5 @@ __tests__/operations-health-wave1195.test.js
 __tests__/supervisor-ops-route-wave1170.test.js
 __tests__/supervisor-ops-service-behavioral-wave1169.test.js
 __tests__/supervisor-ops-service-wave1169.test.js
+__tests__/rehab-plan-health-wave1201.test.js
+__tests__/review-worklist-wave1202.test.js


### PR DESCRIPTION
## What
Two grounded gaps from the rehabilitation-plan domain audit — both **READ-ONLY**, reusing the existing (cron-only) **W44/W50** intelligence on-demand. **Zero new clinical logic, zero edits to any core/conflicted model.**

### W1201 — per-beneficiary Rehabilitation Plan Health
The beneficiary-level analog of operations-health. `services/rehabPlanHealth.service.js` fuses goal-progress (W44 `reviewPlan`) + golden-thread completeness + review cadence + safety into ONE grade (`ON_TRACK` / `DISCHARGE_READY` / `NEEDS_ATTENTION` / `AT_RISK` / `NO_PLAN` / `NO_DATA`) + 0-100 composite + priority actions.
- **Model-robust:** prefers the LIVE `CarePlanVersion` (the W41-51 workflow + what W44/W50 run on) for review cadence; falls back to `UnifiedCarePlan`; goal signals from the canonical golden-thread-linked `TherapeuticGoal`.
- Route `GET /api(/v1)/goals/rehab-plan-health/:beneficiaryId` — W269 beneficiary-branch isolation (`enforceBeneficiaryBranch`).

### W1202 — branch review-worklist
The on-demand read-side of the W50 overdue-review cron: live `CarePlanVersion`s whose `reviewSchedule.nextReviewAt` is due/overdue, classified into W50 SLA severity (info <1d / warning 1-13d / critical 14+d), sorted most-overdue-first.
- Route `GET /api(/v1)/goals/supervisor-ops/review-worklist` — W269 branch-scoped.

## Verification
- ✅ **30 assertions** (pure graders + signal builder + W50 classifier + degradation + route static guards)
- ✅ `check:routes-load` (558), `check:hook-style`, `sprint-paths` in sync

## Note on the 3rd audited gap (MDT)
MDT team coordination is **already backend-complete** (`models/MDTCoordination.js` + `routes/mdt-coordination.routes.js`, 13 endpoints) — its only gap is a web-admin UI, addressed separately. No model build needed (audit-first avoided a redundant + risky core-model change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)