### PR TITLE
feat(hr): W1194 — pay-equity monitoring sweeper (proactive monthly snapshot + breach warn)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1411,6 +1411,8 @@ on:
       - 'backend/__tests__/pay-equity-routes-wave1193.test.js'
       - 'backend/__tests__/pay-equity-behavioral-wave1193.test.js'
 >>>>>>> origin/main
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/pay-equity-sweeper-wave1194.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2805,6 +2807,8 @@ on:
       - 'backend/__tests__/pay-equity-routes-wave1193.test.js'
       - 'backend/__tests__/pay-equity-behavioral-wave1193.test.js'
 >>>>>>> origin/main
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/pay-equity-sweeper-wave1194.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/pay-equity-sweeper-wave1194.test.js
+++ b/backend/__tests__/pay-equity-sweeper-wave1194.test.js
@@ -1,0 +1,91 @@
+/**
+ * W1194 — pay-equity monitoring sweeper guard (static shape + pure behaviour).
+ * Locks the env-gated cron contract (W364 family) and the breach-detection logic.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const BOOT = path.join(__dirname, '..', 'startup', 'payEquitySweeperBootstrap.js');
+const APP = path.join(__dirname, '..', 'app.js');
+const src = fs.readFileSync(BOOT, 'utf8');
+const appSrc = fs.readFileSync(APP, 'utf8');
+
+const boot = require('../startup/payEquitySweeperBootstrap');
+
+describe('W1194 pay-equity sweeper — static contract', () => {
+  test('env-gated (OFF by default) + monthly cron + Asia/Riyadh', () => {
+    expect(src).toMatch(/process\.env\.ENABLE_PAY_EQUITY_SWEEPER === 'true'/);
+    expect(src).toMatch(/cron\.schedule\(\s*'0 6 1 \* \*'/); // 1st of month 06:00
+    expect(src).toMatch(/timezone:\s*'Asia\/Riyadh'/);
+  });
+
+  test('drives the W1193 service snapshot (the one mutating call)', () => {
+    expect(src).toMatch(/payEquityService/);
+    expect(src).toMatch(/svc\.snapshot\(/);
+    // exactly one snapshot call site — adding another mutating call must update this
+    expect((src.match(/\.snapshot\(/g) || []).length).toBe(1);
+  });
+
+  test('wired into app.js after the clinical sweepers', () => {
+    expect(appSrc).toMatch(/payEquitySweeperBootstrap/);
+    expect(appSrc).toMatch(/wirePayEquitySweeper\(app,\s*\{\s*logger\s*\}\)/);
+  });
+});
+
+describe('W1194 pay-equity sweeper — breach detection (pure)', () => {
+  const clean = {
+    equityScore: 92,
+    headcount: 20,
+    genderGap: { reportable: true, medianGapPct: 4, direction: 'female' },
+    nationalityGap: { reportable: false },
+  };
+
+  test('no breach on a healthy snapshot', () => {
+    expect(boot.breachesOf(clean, 70, 15)).toEqual([]);
+  });
+
+  test('flags a low equity score', () => {
+    const b = boot.breachesOf({ ...clean, equityScore: 55 }, 70, 15);
+    expect(b.join(' ')).toMatch(/equityScore=55.*floor 70/);
+  });
+
+  test('flags a reportable gap over the ceiling, names the disadvantaged group', () => {
+    const b = boot.breachesOf(
+      { ...clean, genderGap: { reportable: true, medianGapPct: 22, direction: 'female' } },
+      70,
+      15
+    );
+    expect(b.join(' ')).toMatch(/gender medianGap=22%.*female/);
+  });
+
+  test('ignores a NON-reportable gap (privacy-suppressed small group)', () => {
+    const b = boot.breachesOf(
+      { ...clean, nationalityGap: { reportable: false, medianGapPct: 40, direction: 'saudi' } },
+      70,
+      15
+    );
+    expect(b).toEqual([]); // not reportable → never alerted on
+  });
+});
+
+describe('W1194 pay-equity sweeper — wiring + branch resolution', () => {
+  test('wirePayEquitySweeper is a function that requires a logger', () => {
+    expect(typeof boot.wirePayEquitySweeper).toBe('function');
+    expect(() => boot.wirePayEquitySweeper({}, {})).toThrow(/logger required/);
+  });
+
+  test('resolveBranchIds honours PAY_EQUITY_BRANCH_IDS (no DB hit)', async () => {
+    const prev = process.env.PAY_EQUITY_BRANCH_IDS;
+    process.env.PAY_EQUITY_BRANCH_IDS = ' b1 , b2 ,, b3 ';
+    try {
+      const ids = await boot.resolveBranchIds({ warn() {} });
+      expect(ids).toEqual(['b1', 'b2', 'b3']);
+    } finally {
+      if (prev === undefined) delete process.env.PAY_EQUITY_BRANCH_IDS;
+      else process.env.PAY_EQUITY_BRANCH_IDS = prev;
+    }
+  });
+});

--- a/backend/app.js
+++ b/backend/app.js
@@ -2124,6 +2124,8 @@ require('./startup/riskSweeperBootstrap').wireRiskSweeper(app, { logger });
 require('./startup/clinicalSweepersBootstrap').wireClinicalSweepers(app, { logger });
 // W808 — PPM due-maintenance → preventive work orders (ENABLE_PPM_WO_SWEEPER=true).
 require('./startup/maintenanceHubBootstrap').wireMaintenanceHubSweepers(app, { logger });
+// W1194 — monthly pay-equity snapshot + gap-breach warn (ENABLE_PAY_EQUITY_SWEEPER=true).
+require('./startup/payEquitySweeperBootstrap').wirePayEquitySweeper(app, { logger });
 
 // W676 — DB backup producer cron (env-gated, default OFF). Closes the DR-drill
 // `no_backup_found` gap: feeds backups/mongodb (the dir dr-verify.js scans).

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -841,3 +841,4 @@ __tests__/pay-equity-routes-wave1193.test.js
 __tests__/pay-equity-behavioral-wave1193.test.js
 __tests__/rehab-plan-health-wave1201.test.js
 __tests__/review-worklist-wave1202.test.js
+__tests__/pay-equity-sweeper-wave1194.test.js

--- a/backend/startup/payEquitySweeperBootstrap.js
+++ b/backend/startup/payEquitySweeperBootstrap.js
@@ -1,0 +1,132 @@
+'use strict';
+
+/**
+ * payEquitySweeperBootstrap.js — Wave 1194.
+ *
+ * Turns the on-demand W1193 pay-equity analysis into PROACTIVE monitoring: a
+ * monthly cron persists a branch-scoped PayEquitySnapshot per branch (so /trends
+ * accumulates a real series) and logs a structured WARNING when a branch breaches
+ * the equity-score floor or a reportable demographic gap exceeds the ceiling.
+ *
+ * Mirrors the W364 clinicalSweepersBootstrap contract: single shared node-cron,
+ * Asia/Riyadh timezone, env-gated (OFF by default), per-iteration try/catch.
+ *
+ *   ENABLE_PAY_EQUITY_SWEEPER=true     — schedule it (1st of month, 06:00 Riyadh)
+ *   PAY_EQUITY_BRANCH_IDS=b1,b2        — branches to snapshot (else ALL active Branch docs)
+ *   PAY_EQUITY_SCORE_FLOOR=70          — warn when equityScore < floor
+ *   PAY_EQUITY_GAP_CEILING=15          — warn when a reportable median gap % > ceiling
+ *
+ * It MUTATES (creates snapshot docs) — the only write the sweep performs — but it
+ * never alters Employee/salary data. Full alert-channel wiring (an alerts/rules/*
+ * rule over the snapshot series) is a documented follow-up; the structured warn +
+ * the persisted /trends series are the monitoring surface today.
+ */
+
+function loadOptional(modulePath) {
+  try {
+    return require(modulePath);
+  } catch {
+    return null;
+  }
+}
+
+async function resolveBranchIds(logger) {
+  const fromEnv = (process.env.PAY_EQUITY_BRANCH_IDS || '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  if (fromEnv.length) return fromEnv;
+  // fall back to every active branch
+  const mongoose = require('mongoose');
+  let Branch;
+  try {
+    Branch = mongoose.model('Branch');
+  } catch {
+    logger.warn('[pay-equity] Branch model unavailable + PAY_EQUITY_BRANCH_IDS unset; nothing to sweep');
+    return [];
+  }
+  const filter = { $or: [{ status: 'active' }, { isActive: true }, { status: { $exists: false } }] };
+  const rows = await Branch.find(filter).select('_id').limit(500).lean();
+  return rows.map(r => String(r._id));
+}
+
+function breachesOf(doc, floor, ceiling) {
+  const out = [];
+  if (typeof doc.equityScore === 'number' && doc.equityScore < floor) {
+    out.push(`equityScore=${doc.equityScore} < floor ${floor}`);
+  }
+  for (const [dim, g] of [
+    ['gender', doc.genderGap],
+    ['nationality', doc.nationalityGap],
+  ]) {
+    if (g && g.reportable && typeof g.medianGapPct === 'number' && g.medianGapPct > ceiling) {
+      out.push(`${dim} medianGap=${g.medianGapPct}% > ceiling ${ceiling}% (disadvantaged: ${g.direction})`);
+    }
+  }
+  return out;
+}
+
+function wirePayEquitySweeper(app, deps = {}) {
+  const { logger } = deps;
+  if (!logger) {
+    throw new Error('payEquitySweeperBootstrap.wirePayEquitySweeper: logger required');
+  }
+
+  const cron = loadOptional('node-cron');
+  if (!cron) {
+    logger.warn('[startup] node-cron not available; pay-equity sweeper not scheduled');
+    return;
+  }
+  const TZ = { timezone: 'Asia/Riyadh' };
+  const svc = loadOptional('../services/hr/payEquityService');
+  if (!svc) {
+    logger.warn('[startup] payEquityService unavailable; pay-equity sweeper not scheduled');
+    return;
+  }
+
+  let scheduledCount = 0;
+
+  if (process.env.ENABLE_PAY_EQUITY_SWEEPER === 'true') {
+    const floor = Number(process.env.PAY_EQUITY_SCORE_FLOOR) || 70;
+    const ceiling = Number(process.env.PAY_EQUITY_GAP_CEILING) || 15;
+    // 1st of every month, 06:00 Asia/Riyadh
+    cron.schedule(
+      '0 6 1 * *',
+      async () => {
+        try {
+          const branchIds = await resolveBranchIds(logger);
+          if (!branchIds.length) return;
+          let snapped = 0;
+          let breached = 0;
+          for (const branchId of branchIds) {
+            try {
+              const doc = await svc.snapshot({ branchId });
+              snapped++;
+              const breaches = breachesOf(doc, floor, ceiling);
+              if (breaches.length) {
+                breached++;
+                logger.warn(
+                  `[pay-equity] BREACH branch=${branchId} headcount=${doc.headcount} score=${doc.equityScore} :: ${breaches.join('; ')}`
+                );
+              }
+            } catch (perBranchErr) {
+              logger.error(`[pay-equity] snapshot failed branch=${branchId}`, perBranchErr);
+            }
+          }
+          logger.info(`[pay-equity] monthly sweep: ${snapped} snapshot(s), ${breached} breach(es)`);
+        } catch (err) {
+          logger.error('[pay-equity] sweeper failed', err);
+        }
+      },
+      TZ
+    );
+    scheduledCount++;
+    logger.info('[startup] W1194 pay-equity monitoring sweeper scheduled (monthly, 1st @ 06:00 Asia/Riyadh)');
+  }
+
+  if (scheduledCount === 0) {
+    logger.info('[startup] pay-equity sweeper disabled (ENABLE_PAY_EQUITY_SWEEPER!=true)');
+  }
+}
+
+module.exports = { wirePayEquitySweeper, breachesOf, resolveBranchIds };


### PR DESCRIPTION
## What

Completes the **W1193 pay-equity** feature's proactive dimension (#373). On-demand analysis becomes **monitoring**: a monthly cron persists a branch-scoped `PayEquitySnapshot` per branch (so `GET /trends` accumulates a real series) and logs a structured **WARNING** when a branch breaches the equity-score floor or a reportable demographic gap exceeds the ceiling.

Mirrors the **W364 `clinicalSweepersBootstrap`** contract: single shared `node-cron`, Asia/Riyadh, **env-gated OFF by default**, per-iteration try/catch. Wired in `app.js` right after the clinical sweepers.

| Env | Effect |
| --- | --- |
| `ENABLE_PAY_EQUITY_SWEEPER=true` | schedule (1st of month, 06:00 Riyadh) |
| `PAY_EQUITY_BRANCH_IDS=b1,b2` | branches to sweep (else **all** active `Branch` docs) |
| `PAY_EQUITY_SCORE_FLOOR=70` | warn when `equityScore < floor` |
| `PAY_EQUITY_GAP_CEILING=15` | warn when a **reportable** median gap % > ceiling |

**Privacy-aware:** breach detection only fires on `reportable` gaps — a privacy-suppressed small-group gap (the lib's `MIN_GROUP` rule) is never alerted on. The sweep mutates only by creating snapshot docs (the single `svc.snapshot()` call); it never touches `Employee` data.

## Guard — `pay-equity-sweeper-wave1194` (9 assertions)

Static: env-gate + monthly cron + Asia/Riyadh + single snapshot call site + `app.js` wiring. Pure: `breachesOf` floor/ceiling/**reportable-only** logic + `resolveBranchIds` env-split + logger-required.

## Verified locally

`check:routes-load` (clean) · `check:sprint-paths` in sync · `check:gitignored-sources` · `check:hook-style` · `no-broken-requires` · `enforce-mfa-at-construction-wave276` (app.js scan) · 9/9 green.

> Note: main currently has two **pre-existing** red gates unrelated to this PR — the "🧪 Sprint Tests" workflow (yml `paths:` filter grew past GitHub's limit) and ~35 unbaselined phantom refs from the parallel forms-approval-chains merges. This PR inherits both; verified independently.

## Follow-up (documented)

An `alerts/rules/*` rule over the snapshot series to route breaches to the smart-alerts dashboard (W1006 pattern); today the structured warn + the `/trends` series are the surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)