### PR TITLE
feat(hr): W1197 — pay-equity-gap-exceeded smart-alert rule (closes the W1193/W1194 loop)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1413,6 +1413,8 @@ on:
 >>>>>>> origin/main
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/pay-equity-sweeper-wave1194.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/pay-equity-alert-rule-wave1197.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2809,6 +2811,8 @@ on:
 >>>>>>> origin/main
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/pay-equity-sweeper-wave1194.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/pay-equity-alert-rule-wave1197.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/alerts-bootstrap.test.js
+++ b/backend/__tests__/alerts-bootstrap.test.js
@@ -2,7 +2,7 @@
  * alerts-bootstrap.test.js — Wave 7.
  *
  * Verifies the one-call wiring helper composes a working stack:
- *   - engine has all 19 bundled rules registered
+ *   - engine has all 34 bundled rules registered
  *   - ctxFactory surfaces models + kpiHistoryStore + a fresh `now`
  *   - dispatcher persists raised findings through the AlertModel
  *   - scheduler integrates with the dispatcher.tick contract
@@ -23,10 +23,10 @@ const { buildAlertsStack } = require('../alerts/bootstrap');
 // own dedicated test suite (`alerts.dispatcher.test.js`).
 
 describe('buildAlertsStack — composition', () => {
-  test('registers every bundled rule (19)', () => {
+  test('registers every bundled rule (34)', () => {
     const stack = buildAlertsStack({ logger: { warn() {}, info() {}, error() {} } });
-    expect(stack.rules.length).toBe(19);
-    expect(stack.engine.rules.size).toBe(19);
+    expect(stack.rules.length).toBe(34);
+    expect(stack.engine.rules.size).toBe(34);
   });
 
   test('returns a fresh ctx from ctxFactory each call', () => {

--- a/backend/__tests__/alerts.engine.test.js
+++ b/backend/__tests__/alerts.engine.test.js
@@ -111,10 +111,10 @@ describe('buildEngine() with bundled rules', () => {
   // baseline of 5. Wave 5 (2026-05-16) added the EWMA anomaly
   // bridge. Pin the exact total so accidental rule removal shows
   // up as a test regression rather than a silent gap.
-  test('registers all 33 bundled rules (W1151 added staff-certification expiry pair)', () => {
-    expect(rules.length).toBe(33);
+  test('registers all 34 bundled rules (W1197 added pay-equity-gap-exceeded)', () => {
+    expect(rules.length).toBe(34);
     const eng = buildEngine();
-    expect(eng.rules.size).toBe(33);
+    expect(eng.rules.size).toBe(34);
   });
 
   test('credential-expiry-30d fires on near-expiry records', async () => {

--- a/backend/__tests__/pay-equity-alert-rule-wave1197.test.js
+++ b/backend/__tests__/pay-equity-alert-rule-wave1197.test.js
@@ -1,0 +1,84 @@
+/**
+ * W1197 — pay-equity-gap-exceeded alert rule guard.
+ * Static: registered + correct contract shape. Behavioural: the evaluate()
+ * predicate (breach detection, reportable-only, latest-per-branch dedup, idempotent
+ * key) against a mock model — no DB.
+ */
+
+'use strict';
+
+const path = require('path');
+const rules = require('../alerts/rules');
+const rule = require('../alerts/rules/pay-equity-gap-exceeded');
+
+// mock PayEquitySnapshot model: find(filter).lean() → rows
+function model(rows) {
+  return { find: () => ({ lean: () => Promise.resolve(rows) }) };
+}
+const ctx = (rows, now) => ({ models: { PayEquitySnapshot: model(rows) }, now: now || new Date('2026-06-15') });
+
+const snap = (over = {}) => ({
+  _id: over._id || 's1',
+  branchId: over.branchId || 'bA',
+  scope: over.scope || { level: 'branch', department: null },
+  computedAt: over.computedAt || new Date('2026-06-01'),
+  equityScore: over.equityScore != null ? over.equityScore : 90,
+  genderGap: over.genderGap || { reportable: true, medianGapPct: 4, direction: 'female' },
+  nationalityGap: over.nationalityGap || { reportable: false },
+  ...over,
+});
+
+describe('W1197 pay-equity alert rule — contract + registration', () => {
+  test('registered in the rules index', () => {
+    expect(rules).toContain(rule);
+  });
+  test('exports the canonical rule shape', () => {
+    expect(rule.id).toBe('pay-equity-gap-exceeded');
+    expect(rule.category).toBe('hr');
+    expect(['warning', 'critical', 'info']).toContain(rule.severity);
+    expect(typeof rule.evaluate).toBe('function');
+  });
+});
+
+describe('W1197 pay-equity alert rule — evaluate predicate', () => {
+  test('no alert for a healthy snapshot', async () => {
+    const out = await rule.evaluate(ctx([snap()]));
+    expect(out).toEqual([]);
+  });
+
+  test('alerts on a low equity score, idempotent key + branchId carried', async () => {
+    const out = await rule.evaluate(ctx([snap({ _id: 'sLow', equityScore: 55, branchId: 'bX' })]));
+    expect(out).toHaveLength(1);
+    expect(out[0].key).toBe('pay-equity-gap:sLow');
+    expect(out[0].branchId).toBe('bX');
+    expect(out[0].message).toMatch(/equity score 55 < floor 70/);
+  });
+
+  test('alerts on a reportable gap over the ceiling, NOT on a suppressed one', async () => {
+    const reportable = snap({ _id: 'sGap', equityScore: 95, genderGap: { reportable: true, medianGapPct: 25, direction: 'female' } });
+    const suppressed = snap({ _id: 'sSup', branchId: 'bB', equityScore: 95, nationalityGap: { reportable: false, medianGapPct: 40, direction: 'saudi' } });
+    const out = await rule.evaluate(ctx([reportable, suppressed]));
+    expect(out.map(a => a.key)).toEqual(['pay-equity-gap:sGap']); // only the reportable breach
+    expect(out[0].message).toMatch(/gender median gap 25%/);
+  });
+
+  test('keeps only the LATEST snapshot per branch', async () => {
+    const older = snap({ _id: 'old', branchId: 'bA', equityScore: 50, computedAt: new Date('2026-05-01') });
+    const newer = snap({ _id: 'new', branchId: 'bA', equityScore: 92, computedAt: new Date('2026-06-01') });
+    const out = await rule.evaluate(ctx([older, newer]));
+    expect(out).toEqual([]); // newest (92) is healthy → the older breach is ignored
+  });
+
+  test('department-scoped snapshots are deduped independently of the branch-scoped one', async () => {
+    const branchScope = snap({ _id: 'b', branchId: 'bA', equityScore: 92, scope: { level: 'branch', department: null } });
+    const deptScope = snap({ _id: 'd', branchId: 'bA', equityScore: 40, scope: { level: 'department', department: 'PT' } });
+    const out = await rule.evaluate(ctx([branchScope, deptScope]));
+    expect(out.map(a => a.key)).toEqual(['pay-equity-gap:d']); // dept breach kept separately
+  });
+
+  test('no model → empty (defensive)', async () => {
+    const out = await rule.evaluate({ models: {}, now: new Date('2026-06-15') });
+    // lazy mongoose lookup returns null outside a connection → []
+    expect(Array.isArray(out)).toBe(true);
+  });
+});

--- a/backend/alerts/rules/index.js
+++ b/backend/alerts/rules/index.js
@@ -115,4 +115,10 @@ module.exports = [
   // ── W1141 — financial / budget (1) ──────────────────────────
   // Active budget consumed ≥90% of allocation (≥100% = critical). Self-loading.
   require('./budget-overrun'),
+
+  // ── W1197 — HR / pay equity (1) ─────────────────────────────
+  // Latest pay-equity snapshot breaches the equity-score floor or a REPORTABLE
+  // demographic gap ceiling (closes the W1193/W1194 loop into the Alert sink).
+  // Self-loading (lazy PayEquitySnapshot lookup, no app.js model-loader edit).
+  require('./pay-equity-gap-exceeded'),
 ];

--- a/backend/alerts/rules/pay-equity-gap-exceeded.js
+++ b/backend/alerts/rules/pay-equity-gap-exceeded.js
@@ -1,0 +1,90 @@
+/**
+ * Rule: latest pay-equity snapshot breaches the equity-score floor or a
+ * REPORTABLE demographic gap ceiling (W1197).
+ *
+ * Closes the W1194 monitoring loop: the monthly sweeper persists a
+ * PayEquitySnapshot per branch; this rule surfaces a breach on the latest
+ * snapshot to the smart-alerts dashboard (the W1006 operational-alert path)
+ * instead of only logging a warning. One alert per snapshot (keyed by _id), so
+ * a monthly cadence yields ~1 alert per branch per month.
+ *
+ * PRIVACY: only `reportable` gaps trigger — a privacy-suppressed small-group gap
+ * (the lib's MIN_GROUP rule) is never alerted on. Thresholds match the sweeper's
+ * env so the two layers stay consistent.
+ */
+
+'use strict';
+
+const SCORE_FLOOR = Number(process.env.PAY_EQUITY_SCORE_FLOOR) || 70;
+const GAP_CEILING = Number(process.env.PAY_EQUITY_GAP_CEILING) || 15;
+const WINDOW_DAYS = 45; // a monthly snapshot is always inside this window
+
+function lazySnapModel() {
+  const mongoose = require('mongoose');
+  try {
+    return mongoose.model('PayEquitySnapshot');
+  } catch {
+    try {
+      require('../../models/HR/PayEquitySnapshot');
+      return mongoose.model('PayEquitySnapshot');
+    } catch {
+      return null;
+    }
+  }
+}
+
+function breachesOf(snap) {
+  const out = [];
+  if (typeof snap.equityScore === 'number' && snap.equityScore < SCORE_FLOOR) {
+    out.push(`equity score ${snap.equityScore} < floor ${SCORE_FLOOR}`);
+  }
+  for (const [dim, g] of [
+    ['gender', snap.genderGap],
+    ['nationality', snap.nationalityGap],
+  ]) {
+    if (g && g.reportable && typeof g.medianGapPct === 'number' && g.medianGapPct > GAP_CEILING) {
+      out.push(`${dim} median gap ${g.medianGapPct}% > ceiling ${GAP_CEILING}% (${g.direction} disadvantaged)`);
+    }
+  }
+  return out;
+}
+
+module.exports = {
+  id: 'pay-equity-gap-exceeded',
+  severity: 'warning',
+  category: 'hr',
+  description: 'Latest pay-equity snapshot breaches the equity-score floor or a reportable gap ceiling',
+
+  // exposed for the drift guard
+  _breachesOf: breachesOf,
+
+  async evaluate(ctx) {
+    const Model = (ctx.models && ctx.models.PayEquitySnapshot) || lazySnapModel();
+    if (!Model) return [];
+    const now = ctx.now || new Date();
+    const since = new Date(now.getTime() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+    const rows = await Model.find({ computedAt: { $gte: since } }).lean();
+    if (!Array.isArray(rows) || !rows.length) return [];
+
+    // newest-first, then keep only the latest snapshot per (branch, dept-scope)
+    rows.sort((a, b) => new Date(b.computedAt).getTime() - new Date(a.computedAt).getTime());
+    const seen = new Set();
+    const alerts = [];
+    for (const s of rows) {
+      const dept = (s.scope && s.scope.department) || '';
+      const k = `${s.branchId}|${dept}`;
+      if (seen.has(k)) continue;
+      seen.add(k);
+      const breaches = breachesOf(s);
+      if (!breaches.length) continue;
+      alerts.push({
+        key: `pay-equity-gap:${s._id}`, // idempotent — one alert per snapshot
+        subject: { type: 'PayEquitySnapshot', id: s._id },
+        branchId: s.branchId,
+        message: `Pay-equity breach (branch ${s.branchId}${dept ? '/' + dept : ''}): ${breaches.join('; ')}`,
+      });
+    }
+    return alerts;
+  },
+};

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -842,3 +842,4 @@ __tests__/pay-equity-behavioral-wave1193.test.js
 __tests__/rehab-plan-health-wave1201.test.js
 __tests__/review-worklist-wave1202.test.js
 __tests__/pay-equity-sweeper-wave1194.test.js
+__tests__/pay-equity-alert-rule-wave1197.test.js


### PR DESCRIPTION
## What

Closes the pay-equity monitoring loop. The **W1194** sweeper persists a monthly `PayEquitySnapshot` per branch but only **logged** a warning on a breach. This routes that breach into the **smart-alerts dashboard** — the W1006 operational path: `rules/*` → engine tick → `Alert` → `/dashboards/alerts`.

## Rule — `alerts/rules/pay-equity-gap-exceeded.js` (category `hr`, severity `warning`)

- Reads the **latest** `PayEquitySnapshot` per `(branch, dept-scope)` within a 45-day window; emits an alert when `equityScore < PAY_EQUITY_SCORE_FLOOR` (70) **or** a **reportable** median gap % > `PAY_EQUITY_GAP_CEILING` (15). Thresholds match the sweeper's env so the two layers stay consistent.
- **Privacy:** only `reportable` gaps fire — a privacy-suppressed small-group gap (the lib's `MIN_GROUP` rule) is never alerted on.
- **Idempotent** key `pay-equity-gap:<snapshotId>` → one alert per snapshot (~1 per branch per month). **Self-loading** (lazy `mongoose` lookup, the W1121 pattern — no `app.js` model-loader edit).

## Guard — `pay-equity-alert-rule-wave1197` (9 assertions)

Registration + contract shape (static) + `evaluate()` predicate — breach detection, reportable-only, latest-per-branch dedup, dept-scope independence, idempotent key — against a mock model, no DB.

## Rule-count baselines updated

- `alerts.engine` 33 → **34** (my +1).
- `alerts-bootstrap` 19 → **34** — the latter was **stale pre-existing**: the parallel agent added ~15 rules (W1124-W1141) without bumping it, so it was already failing on main. Fixed as a side-effect.

## Verified locally

`alerts.engine` + `alerts-bootstrap` + `alerts.rules.wave3` + W1197 guard = 27/27 · `check:routes-load` · `check:sprint-paths` in sync · `check:gitignored-sources` · `no-broken-requires`.

> Note: main has two unrelated **pre-existing** reds (Sprint Tests yml paths-limit + ~35 phantom refs from the forms-approval-chains merges) — this PR inherits them; verified independently.

## Pay-equity feature — now complete end-to-end

on-demand analysis (W1193, 5 routes) → proactive monthly snapshots (W1194 sweeper) → **dashboard alerts on breach (W1197)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)