### PR TITLE
feat(hr): W1198 — 9-box talent matrix (performance × potential + grid analytics)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1417,6 +1417,10 @@ on:
       - 'backend/__tests__/pay-equity-alert-rule-wave1197.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/smart-insurance-claim-model-wave1210.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/talent-grid-lib-wave1198.test.js'
+      - 'backend/__tests__/talent-grid-routes-wave1198.test.js'
+      - 'backend/__tests__/talent-grid-behavioral-wave1198.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2817,6 +2821,10 @@ on:
       - 'backend/__tests__/pay-equity-alert-rule-wave1197.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/smart-insurance-claim-model-wave1210.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/talent-grid-lib-wave1198.test.js'
+      - 'backend/__tests__/talent-grid-routes-wave1198.test.js'
+      - 'backend/__tests__/talent-grid-behavioral-wave1198.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/talent-grid-behavioral-wave1198.test.js
+++ b/backend/__tests__/talent-grid-behavioral-wave1198.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * talent-grid-behavioral-wave1198.test.js — TalentReview against MongoMemoryServer.
+ * box/segment auto-compute, Wave-18 invariants, unique (employee,cycle) index.
+ * Employee is NOT registered → the hrBranchScope plugin's derive is a graceful
+ * no-op (branchId stays unset), so we test TalentReview's own contract in isolation.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(120000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let TR;
+const oid = () => new mongoose.Types.ObjectId();
+
+function base(over = {}) {
+  return { employeeId: oid(), reviewCycle: '2026-H1', performanceBand: 3, potentialBand: 3, ...over };
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w1198-talent' } });
+  await mongoose.connect(mongod.getUri());
+  TR = require('../models/HR/TalentReview');
+});
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+});
+afterEach(async () => {
+  if (TR) await TR.deleteMany({});
+});
+
+describe('W1198 TalentReview — box/segment auto-compute', () => {
+  test('high/high → box 9 star; default source manual + status draft', async () => {
+    const d = await TR.create(base());
+    expect(d.box).toBe(9);
+    expect(d.segment).toBe('star');
+    expect(d.actionGroup).toBe('develop_retain');
+    expect(d.performanceSource).toBe('manual');
+    expect(d.status).toBe('draft');
+  });
+
+  test('low perf / high potential → box 3 enigma', async () => {
+    const d = await TR.create(base({ performanceBand: 1, potentialBand: 3 }));
+    expect(d.box).toBe(3);
+    expect(d.segment).toBe('enigma');
+  });
+
+  test('box recomputes on update-save when a band changes', async () => {
+    const d = await TR.create(base({ performanceBand: 3, potentialBand: 3 })); // box 9
+    d.potentialBand = 1;
+    await d.save();
+    expect(d.box).toBe(7); // high perf / low potential
+    expect(d.segment).toBe('high_professional');
+  });
+});
+
+describe('W1198 TalentReview — Wave-18 invariants', () => {
+  test('band out of [1,3] is rejected', async () => {
+    await expect(TR.create(base({ performanceBand: 4 }))).rejects.toThrow();
+    await expect(TR.create(base({ potentialBand: 0 }))).rejects.toThrow();
+  });
+
+  test('finalized requires a reviewer', async () => {
+    await expect(TR.create(base({ status: 'finalized' }))).rejects.toThrow(/reviewedBy/);
+  });
+
+  test('finalized with a reviewer + both bands saves', async () => {
+    const d = await TR.create(base({ status: 'finalized', reviewedBy: oid() }));
+    expect(d.status).toBe('finalized');
+    expect(d.box).toBe(9);
+  });
+});
+
+describe('W1198 TalentReview — one review per employee per cycle', () => {
+  test('duplicate (employeeId, reviewCycle) is rejected by the unique index', async () => {
+    const emp = oid();
+    await TR.create(base({ employeeId: emp, reviewCycle: '2026-H1' }));
+    await expect(
+      TR.create(base({ employeeId: emp, reviewCycle: '2026-H1', potentialBand: 1 }))
+    ).rejects.toThrow(/duplicate key|E11000/);
+  });
+
+  test('same employee, different cycle is allowed', async () => {
+    const emp = oid();
+    await TR.create(base({ employeeId: emp, reviewCycle: '2026-H1' }));
+    const d2 = await TR.create(base({ employeeId: emp, reviewCycle: '2026-H2' }));
+    expect(d2._id).toBeDefined();
+  });
+});

--- a/backend/__tests__/talent-grid-lib-wave1198.test.js
+++ b/backend/__tests__/talent-grid-lib-wave1198.test.js
@@ -1,0 +1,79 @@
+/**
+ * W1198 — pure unit tests for intelligence/talent-grid.lib (9-box logic).
+ */
+
+'use strict';
+
+const L = require('../intelligence/talent-grid.lib');
+
+describe('W1198 talent-grid.lib — performance band derivation', () => {
+  test('Arabic rating → band', () => {
+    expect(L.performanceBand({ overallRating: 'ممتاز' })).toBe(3);
+    expect(L.performanceBand({ overallRating: 'جيد جداً' })).toBe(3);
+    expect(L.performanceBand({ overallRating: 'جيد' })).toBe(2);
+    expect(L.performanceBand({ overallRating: 'مقبول' })).toBe(1);
+    expect(L.performanceBand({ overallRating: 'ضعيف' })).toBe(1);
+  });
+  test('falls back to 1-5 score when no rating', () => {
+    expect(L.performanceBand({ overallScore: 4.5 })).toBe(3);
+    expect(L.performanceBand({ overallScore: 3 })).toBe(2);
+    expect(L.performanceBand({ overallScore: 1.5 })).toBe(1);
+  });
+  test('null when nothing derivable', () => {
+    expect(L.performanceBand({})).toBeNull();
+    expect(L.performanceBand({ overallScore: 0 })).toBeNull();
+  });
+});
+
+describe('W1198 talent-grid.lib — box mapping (all 9 corners)', () => {
+  test('box numbering: perf row × potential column', () => {
+    expect(L.boxOf(1, 1)).toBe(1); // low/low
+    expect(L.boxOf(1, 3)).toBe(3); // low perf / high potential = Enigma
+    expect(L.boxOf(3, 1)).toBe(7); // high perf / low potential = High Professional
+    expect(L.boxOf(3, 3)).toBe(9); // star
+    expect(L.boxOf(2, 2)).toBe(5); // core
+  });
+  test('clamps out-of-range bands', () => {
+    expect(L.boxOf(5, 5)).toBe(9);
+    expect(L.boxOf(0, 0)).toBe(1);
+    expect(L.clampBand(2.6)).toBe(3);
+  });
+  test('segment + action group per box', () => {
+    expect(L.segmentOf(9).key).toBe('star');
+    expect(L.segmentOf(1).key).toBe('underperformer');
+    expect(L.segmentOf(3).en).toMatch(/Enigma/);
+    expect(L.actionGroupOf(9)).toBe('develop_retain');
+    expect(L.actionGroupOf(1)).toBe('manage_out');
+  });
+  test('hiPo vs risk box sets are disjoint', () => {
+    expect(L.HIPO_BOXES).toEqual([6, 8, 9]);
+    expect(L.RISK_BOXES).toEqual([1, 2, 4]);
+    expect(L.HIPO_BOXES.some(b => L.RISK_BOXES.includes(b))).toBe(false);
+    expect(L.isHiPo(9)).toBe(true);
+    expect(L.isRisk(1)).toBe(true);
+    expect(L.isHiPo(5)).toBe(false);
+  });
+});
+
+describe('W1198 talent-grid.lib — grid aggregation', () => {
+  test('distribution + hiPo/risk rates, ignores invalid boxes', () => {
+    const g = L.buildGrid([
+      { box: 9 }, { box: 9 }, { box: 8 }, // 3 hiPo
+      { box: 5 }, { box: 7 },
+      { box: 1 }, { box: 2 }, // 2 risk (+ box 4 none)
+      { box: 0 }, { box: 99 }, { box: null }, // invalid → ignored
+    ]);
+    expect(g.total).toBe(7);
+    expect(g.counts[9]).toBe(2);
+    expect(g.hiPo.count).toBe(3);
+    expect(g.hiPo.ratePct).toBeCloseTo((3 / 7) * 100, 1);
+    expect(g.risk.count).toBe(2);
+    expect(g.segments.star).toBe(2);
+  });
+  test('empty input → zeroed grid', () => {
+    const g = L.buildGrid([]);
+    expect(g.total).toBe(0);
+    expect(g.hiPo).toEqual({ count: 0, ratePct: 0 });
+    expect(Object.values(g.counts).every(c => c === 0)).toBe(true);
+  });
+});

--- a/backend/__tests__/talent-grid-routes-wave1198.test.js
+++ b/backend/__tests__/talent-grid-routes-wave1198.test.js
@@ -1,0 +1,56 @@
+/**
+ * W1198 — static drift guard for the talent-grid route surface + mount.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROUTE = path.join(__dirname, '..', 'routes', 'hr', 'talent-grid.routes.js');
+const REGISTRY = path.join(__dirname, '..', 'routes', 'registries', 'hr.registry.js');
+const src = fs.readFileSync(ROUTE, 'utf8');
+const reg = fs.readFileSync(REGISTRY, 'utf8');
+
+describe('W1198 talent-grid routes — auth + branch isolation', () => {
+  test('self-authenticates + requireBranchAccess', () => {
+    expect(src).toMatch(/router\.use\(\s*authenticateToken\s*\)/);
+    expect(src).toMatch(/router\.use\(\s*requireBranchAccess\s*\)/);
+  });
+  test('W269: effectiveBranchScope + enforceEmployeeBranch, never req.branchId', () => {
+    expect(src).toMatch(/effectiveBranchScope\(req\)/);
+    expect(src).toMatch(/enforceEmployeeBranch/);
+    expect(src).not.toMatch(/req\.branchId/);
+  });
+  test('every route is role-gated', () => {
+    const verbs = [...src.matchAll(/router\.(get|post)\(\s*'[^']+'\s*,\s*([A-Za-z_$][\w$]*)/g)];
+    expect(verbs.length).toBe(5);
+    for (const m of verbs) expect(m[2]).toBe('requireRole');
+  });
+  test('the identity+negative-label /risks route uses the stricter SENSITIVE_ROLES', () => {
+    expect(src).toMatch(/SENSITIVE_ROLES\s*=/);
+    expect(src).toMatch(/'\/risks',\s*requireRole\(SENSITIVE_ROLES\)/);
+  });
+  test('write goes through enforceEmployeeBranch before upsert', () => {
+    expect(src).toMatch(/guardEmployee\(req,\s*res,\s*body\.employeeId\)/);
+  });
+});
+
+describe('W1198 talent-grid routes — endpoints + mount', () => {
+  test('exposes the 5 endpoints', () => {
+    for (const [verb, p] of [
+      ['post', '/reviews'],
+      ['get', '/grid'],
+      ['get', '/high-potentials'],
+      ['get', '/risks'],
+      ['get', '/employee/:employeeId'],
+    ]) {
+      expect(src).toMatch(new RegExp(`router\\.${verb}\\(\\s*'${p.replace(/[/:]/g, '\\$&')}'`));
+    }
+  });
+  test('mounted in hr.registry at /api(/v1)?/hr/talent-grid', () => {
+    expect(reg).toMatch(/talent-grid\.routes/);
+    expect(reg).toMatch(/app\.use\(\s*'\/api\/hr\/talent-grid'/);
+    expect(reg).toMatch(/app\.use\(\s*'\/api\/v1\/hr\/talent-grid'/);
+  });
+});

--- a/backend/intelligence/talent-grid.lib.js
+++ b/backend/intelligence/talent-grid.lib.js
@@ -1,0 +1,142 @@
+/**
+ * talent-grid.lib.js — pure 9-box talent-matrix logic (W1198).
+ *
+ * The 9-box places each employee on a Performance × Potential grid (each axis
+ * low/medium/high = band 1/2/3). Performance is data-derivable from the latest
+ * PerformanceEvaluation; potential is a manager judgement (there is no objective
+ * "potential" signal — that's why the box is a REVIEW, not an auto-classification).
+ *
+ * All functions are pure (no DB, no Date). Box numbering follows the common
+ * HR convention with box 1 = bottom-left (low perf / low potential) increasing
+ * left→right then bottom→top, so box 9 = top-right (high perf / high potential):
+ *
+ *        potential →   low(1)  med(2)  high(3)
+ *   perf high(3)         7       8       9
+ *   perf med(2)          4       5       6
+ *   perf low(1)          1       2       3
+ */
+
+'use strict';
+
+const BANDS = Object.freeze({ LOW: 1, MEDIUM: 2, HIGH: 3 });
+
+// Arabic 5-point overallRating → performance band.
+const RATING_TO_BAND = Object.freeze({
+  ممتاز: 3,
+  'جيد جداً': 3,
+  جيد: 2,
+  مقبول: 1,
+  ضعيف: 1,
+});
+
+// box → canonical talent segment label (en + ar).
+const SEGMENTS = Object.freeze({
+  9: { key: 'star', en: 'Star', ar: 'نجم' },
+  8: { key: 'high_potential', en: 'High Potential', ar: 'إمكانات عالية' },
+  7: { key: 'high_professional', en: 'High Professional', ar: 'محترف متميز' },
+  6: { key: 'rising_star', en: 'Rising Star', ar: 'نجم صاعد' },
+  5: { key: 'core_player', en: 'Core Player', ar: 'لاعب أساسي' },
+  4: { key: 'solid_professional', en: 'Solid Professional', ar: 'محترف ثابت' },
+  3: { key: 'enigma', en: 'Enigma / Potential Gem', ar: 'إمكانات غير مستغلة' },
+  2: { key: 'inconsistent', en: 'Inconsistent Player', ar: 'لاعب متذبذب' },
+  1: { key: 'underperformer', en: 'Underperformer', ar: 'ضعيف الأداء' },
+});
+
+// high-level action group per box (the "so what")
+const ACTION_GROUP = Object.freeze({
+  9: 'develop_retain', 8: 'develop_retain', 6: 'develop_retain', // top-right cluster
+  7: 'leverage', 5: 'leverage', 3: 'develop', // diagonal / observe
+  4: 'observe', 2: 'improve', 1: 'manage_out', // bottom-left cluster
+});
+
+function clampBand(n) {
+  const v = Math.round(Number(n));
+  if (v <= BANDS.LOW) return BANDS.LOW;
+  if (v >= BANDS.HIGH) return BANDS.HIGH;
+  return v;
+}
+
+/** Derive a performance band (1-3) from an evaluation's rating and/or 1-5 score. */
+function performanceBand({ overallRating, overallScore } = {}) {
+  if (overallRating && RATING_TO_BAND[overallRating]) return RATING_TO_BAND[overallRating];
+  if (Number.isFinite(Number(overallScore))) {
+    const s = Number(overallScore);
+    if (s >= 4) return BANDS.HIGH;
+    if (s >= 3) return BANDS.MEDIUM;
+    if (s > 0) return BANDS.LOW;
+  }
+  return null; // not derivable → caller must supply a manual band
+}
+
+/** box 1-9 from perf + potential bands (1-3 each). */
+function boxOf(perfBand, potentialBand) {
+  const p = clampBand(perfBand);
+  const q = clampBand(potentialBand);
+  return (p - 1) * 3 + q; // perf row offset + potential column
+}
+
+function segmentOf(box) {
+  return SEGMENTS[box] || null;
+}
+
+function actionGroupOf(box) {
+  return ACTION_GROUP[box] || null;
+}
+
+const HIPO_BOXES = Object.freeze([6, 8, 9]); // high potential (top-right cluster)
+const RISK_BOXES = Object.freeze([1, 2, 4]); // low-perf / low-potential cluster
+
+function isHiPo(box) {
+  return HIPO_BOXES.includes(box);
+}
+function isRisk(box) {
+  return RISK_BOXES.includes(box);
+}
+
+/**
+ * Aggregate a set of reviews `[{ box, ... }]` into a grid distribution + segment
+ * counts + hiPo / risk rates. Reviews without a valid box are ignored.
+ */
+function buildGrid(reviews) {
+  const counts = {};
+  for (let b = 1; b <= 9; b++) counts[b] = 0;
+  let total = 0;
+  let hipo = 0;
+  let risk = 0;
+  for (const r of reviews || []) {
+    const b = r && Number(r.box);
+    if (!(b >= 1 && b <= 9)) continue;
+    counts[b]++;
+    total++;
+    if (isHiPo(b)) hipo++;
+    if (isRisk(b)) risk++;
+  }
+  const segments = {};
+  for (let b = 1; b <= 9; b++) {
+    if (counts[b]) segments[SEGMENTS[b].key] = counts[b];
+  }
+  const pct = n => (total ? Math.round((n / total) * 1000) / 10 : 0);
+  return {
+    total,
+    counts, // box → headcount
+    segments, // segment key → headcount
+    hiPo: { count: hipo, ratePct: pct(hipo) },
+    risk: { count: risk, ratePct: pct(risk) },
+  };
+}
+
+module.exports = {
+  BANDS,
+  RATING_TO_BAND,
+  SEGMENTS,
+  HIPO_BOXES,
+  RISK_BOXES,
+  clampBand,
+  performanceBand,
+  boxOf,
+  segmentOf,
+  actionGroupOf,
+  isHiPo,
+  isRisk,
+  buildGrid,
+};

--- a/backend/models/HR/TalentReview.js
+++ b/backend/models/HR/TalentReview.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * TalentReview.js — a 9-box talent-matrix placement for one employee in one
+ * review cycle (W1198).
+ *
+ * Performance band is data-derivable from the latest PerformanceEvaluation;
+ * potential band is a manager judgement. `box` (1-9) + `segment` are COMPUTED
+ * from the two bands in a pre('validate') hook so they can never drift from the
+ * source bands. Employee-keyed, so branchId is denormalised from the employee by
+ * the shared hrBranchScope plugin (W1133) — cross-branch isolation for free.
+ */
+
+const mongoose = require('mongoose');
+const grid = require('../../intelligence/talent-grid.lib');
+
+const TalentReviewSchema = new mongoose.Schema(
+  {
+    employeeId: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee', required: true, index: true },
+    reviewCycle: { type: String, required: true, maxlength: 20 }, // e.g. '2026-H1'
+
+    performanceBand: { type: Number, required: true, min: 1, max: 3 },
+    potentialBand: { type: Number, required: true, min: 1, max: 3 },
+    performanceSource: { type: String, enum: ['derived', 'manual'], default: 'manual' },
+
+    // computed (pre-validate) — frozen mirrors of (performanceBand × potentialBand)
+    box: { type: Number, min: 1, max: 9 },
+    segment: { type: String, default: null },
+    actionGroup: { type: String, default: null },
+
+    notes: { type: String, maxlength: 2000 },
+    reviewedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+    status: { type: String, enum: ['draft', 'finalized'], default: 'draft', index: true },
+
+    __invariants: { type: mongoose.Schema.Types.Mixed, select: false, default: null },
+  },
+  { timestamps: true, collection: 'hr_talent_reviews' }
+);
+
+// one review per employee per cycle
+TalentReviewSchema.index({ employeeId: 1, reviewCycle: 1 }, { unique: true });
+TalentReviewSchema.index({ branchId: 1, reviewCycle: 1, box: 1 });
+
+// W1133 — denormalise branchId from the employee (cross-branch isolation).
+TalentReviewSchema.plugin(require('./hrBranchScope.plugin'));
+
+// async to MATCH the plugin's async pre('validate') (hook-style gate forbids mixing).
+TalentReviewSchema.pre('validate', async function computeBox() {
+  if (this.performanceBand >= 1 && this.performanceBand <= 3 && this.potentialBand >= 1 && this.potentialBand <= 3) {
+    this.box = grid.boxOf(this.performanceBand, this.potentialBand);
+    const seg = grid.segmentOf(this.box);
+    this.segment = seg ? seg.key : null;
+    this.actionGroup = grid.actionGroupOf(this.box);
+  }
+  this.markModified('__invariants'); // select:false validator skip guard (W1123)
+});
+
+TalentReviewSchema.path('__invariants').validate(function validateInvariants() {
+  // box must equal the canonical mapping of the two bands (no manual override)
+  if (this.performanceBand >= 1 && this.potentialBand >= 1) {
+    const expected = grid.boxOf(this.performanceBand, this.potentialBand);
+    if (this.box !== expected) {
+      this.invalidate('box', `box must equal boxOf(performance,potential)=${expected}`);
+    }
+  }
+  // a finalized review needs a reviewer + both bands
+  if (this.status === 'finalized') {
+    if (!this.reviewedBy) this.invalidate('reviewedBy', 'finalized review requires reviewedBy');
+    if (!this.performanceBand || !this.potentialBand) {
+      this.invalidate('potentialBand', 'finalized review requires both bands');
+    }
+  }
+  return true;
+});
+
+module.exports = mongoose.models.TalentReview || mongoose.model('TalentReview', TalentReviewSchema);

--- a/backend/routes/hr/talent-grid.routes.js
+++ b/backend/routes/hr/talent-grid.routes.js
@@ -1,0 +1,129 @@
+'use strict';
+
+/**
+ * talent-grid.routes.js — HR 9-box talent-matrix surface (W1198).
+ *
+ * Mount: /api/hr/talent-grid + /api/v1/hr/talent-grid (self-authed → safe under
+ * the plain hr.registry app.use mount, W1190/W1191 doctrine).
+ *
+ *   POST /reviews              — upsert a talent review (manager/HR)
+ *   GET  /grid                 — 9-box distribution + hiPo/risk rates (aggregate)
+ *   GET  /high-potentials      — employees in hiPo boxes (identity-bearing)
+ *   GET  /risks                — employees in risk boxes (identity-bearing, stricter)
+ *   GET  /employee/:employeeId — one employee's placement
+ *
+ * SECURITY: branch isolation (W269) — writes go through enforceEmployeeBranch on
+ * the target employee; reads scope to effectiveBranchScope(req). Risk/hiPo lists
+ * carry identities → role-gated.
+ */
+
+const express = require('express');
+const router = express.Router();
+
+const { authenticateToken, requireRole } = require('../../middleware/auth');
+const { requireBranchAccess } = require('../../middleware/branchScope.middleware');
+const { effectiveBranchScope, enforceEmployeeBranch } = require('../../middleware/assertBranchMatch');
+const safeError = require('../../utils/safeError');
+const svc = require('../../services/hr/talentGridService');
+
+const READ_ROLES = ['admin', 'superadmin', 'super_admin', 'hr_manager', 'hr_director', 'hr', 'manager'];
+const WRITE_ROLES = ['admin', 'superadmin', 'super_admin', 'hr_manager', 'hr_director', 'manager'];
+// negative-label identity lists → narrower
+const SENSITIVE_ROLES = ['admin', 'superadmin', 'super_admin', 'hr_director', 'hr_manager'];
+
+router.use(authenticateToken);
+router.use(requireBranchAccess);
+
+function mapErr(res, err, ctx) {
+  if (err && err.code === 'MODEL_UNAVAILABLE') return res.status(503).json({ success: false, error: err.message });
+  if (err && (err.code === 'VALIDATION' || err.code === 'NO_PERFORMANCE')) {
+    return res.status(400).json({ success: false, error: err.message });
+  }
+  if (err && err.name === 'ValidationError') return res.status(400).json({ success: false, error: err.message });
+  if (err && err.status) return res.status(err.status).json({ success: false, error: err.message });
+  return safeError(res, err, ctx);
+}
+
+async function guardEmployee(req, res, employeeId) {
+  try {
+    await enforceEmployeeBranch(req, employeeId); // W269 — throws 403/404 on cross-branch
+    return false;
+  } catch (err) {
+    res.status(err.status || 403).json({ success: false, error: err.message });
+    return true;
+  }
+}
+
+/** POST /reviews — upsert a talent review for an employee. */
+router.post('/reviews', requireRole(WRITE_ROLES), async (req, res) => {
+  try {
+    const body = req.body || {};
+    if (!body.employeeId) return res.status(400).json({ success: false, error: 'employeeId required' });
+    if (await guardEmployee(req, res, body.employeeId)) return; // W269
+    const actor = req.user || {};
+    const doc = await svc.upsertReview({
+      employeeId: body.employeeId,
+      reviewCycle: body.reviewCycle,
+      potentialBand: body.potentialBand,
+      performanceBand: body.performanceBand, // optional → derived from PerformanceEvaluation
+      notes: body.notes,
+      reviewedBy: actor.id || actor._id || actor.userId || null,
+      status: body.status,
+    });
+    res.status(201).json({ success: true, data: doc });
+  } catch (err) {
+    mapErr(res, err, 'talent-grid:upsert');
+  }
+});
+
+/** GET /grid — 9-box distribution (aggregate, no identities). */
+router.get('/grid', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const branchId = effectiveBranchScope(req); // W269 — own branch or null (HQ)
+    const data = await svc.gridSummary({ branchId, reviewCycle: req.query.reviewCycle || null });
+    res.json({ success: true, data });
+  } catch (err) {
+    mapErr(res, err, 'talent-grid:grid');
+  }
+});
+
+/** GET /high-potentials — hiPo employees (identities). */
+router.get('/high-potentials', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const branchId = effectiveBranchScope(req);
+    const items = await svc.highPotentials({ branchId, reviewCycle: req.query.reviewCycle || null });
+    res.json({ success: true, data: { count: items.length, items } });
+  } catch (err) {
+    mapErr(res, err, 'talent-grid:hipo');
+  }
+});
+
+/** GET /risks — at-risk employees (identities + negative labels) — stricter role. */
+router.get('/risks', requireRole(SENSITIVE_ROLES), async (req, res) => {
+  try {
+    const branchId = effectiveBranchScope(req);
+    const items = await svc.risks({ branchId, reviewCycle: req.query.reviewCycle || null });
+    res.json({ success: true, data: { count: items.length, items } });
+  } catch (err) {
+    mapErr(res, err, 'talent-grid:risks');
+  }
+});
+
+/** GET /employee/:employeeId — one employee's placement. */
+router.get('/employee/:employeeId', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    if (await guardEmployee(req, res, req.params.employeeId)) return; // W269
+    const branchId = effectiveBranchScope(req);
+    const doc = await svc.getByEmployee({
+      branchId,
+      employeeId: req.params.employeeId,
+      reviewCycle: req.query.reviewCycle || null,
+    });
+    if (!doc) return res.status(404).json({ success: false, error: 'no talent review found' });
+    res.json({ success: true, data: doc });
+  } catch (err) {
+    mapErr(res, err, 'talent-grid:employee');
+  }
+});
+
+module.exports = router;

--- a/backend/routes/registries/hr.registry.js
+++ b/backend/routes/registries/hr.registry.js
@@ -178,5 +178,16 @@ module.exports = function registerHrRoutes(app, { safeRequire, dualMount, safeMo
     logger.warn('[HR] Pay-equity routes not mounted (module missing)');
   }
 
+  // ── 9-box talent matrix (W1198 — performance × potential placement) ───────
+  // Self-authenticating; salary-free but identity-bearing reads are role-gated.
+  const talentGridRouter = safeRequire('../routes/hr/talent-grid.routes');
+  if (talentGridRouter) {
+    app.use('/api/hr/talent-grid', talentGridRouter);
+    app.use('/api/v1/hr/talent-grid', talentGridRouter);
+    logger.info('[HR] Talent grid (9-box) mounted (/api/(v1/)?hr/talent-grid)');
+  } else {
+    logger.warn('[HR] Talent grid routes not mounted (module missing)');
+  }
+
   logger.info('[HR] All ~25 HR/Employee/Workforce modules mounted successfully');
 };

--- a/backend/services/hr/talentGridService.js
+++ b/backend/services/hr/talentGridService.js
@@ -1,0 +1,156 @@
+'use strict';
+
+/**
+ * talentGridService.js — 9-box talent-matrix service (W1198).
+ *
+ * Derives an employee's performance band from the latest APPROVED
+ * PerformanceEvaluation, upserts a TalentReview (one per employee per cycle), and
+ * aggregates the branch-scoped grid + hiPo / risk segments. The route resolves
+ * branchId from the caller's effective scope; lists/grid filter on the
+ * TalentReview.branchId the hrBranchScope plugin denormalised.
+ *
+ * Models looked up lazily so tests can inject fakes + load order can't break.
+ */
+
+const grid = require('../../intelligence/talent-grid.lib');
+
+function getModel(name, file) {
+  const mongoose = require('mongoose');
+  try {
+    return mongoose.model(name);
+  } catch {
+    try {
+      require(file);
+      return mongoose.model(name);
+    } catch {
+      return null;
+    }
+  }
+}
+
+/** Latest approved PerformanceEvaluation → performance band (1-3) or null. */
+async function derivePerformanceBand(employeeId) {
+  const PE = getModel('PerformanceEvaluation', '../../models/HR/PerformanceEvaluation');
+  if (!PE) return null;
+  const latest = await PE.findOne({ employeeId, status: 'approved' })
+    .sort({ 'evaluationPeriod.startDate': -1, createdAt: -1 })
+    .select('summary')
+    .lean();
+  if (!latest || !latest.summary) return null;
+  return grid.performanceBand({
+    overallRating: latest.summary.overallRating,
+    overallScore: latest.summary.overallScore,
+  });
+}
+
+/**
+ * Upsert a talent review. `performanceBand` is optional — when omitted we derive
+ * it from PerformanceEvaluation (performanceSource='derived'). Returns the doc.
+ */
+async function upsertReview({
+  employeeId,
+  reviewCycle,
+  potentialBand,
+  performanceBand,
+  notes,
+  reviewedBy = null,
+  status,
+} = {}) {
+  const TalentReview = getModel('TalentReview', '../../models/HR/TalentReview');
+  if (!TalentReview) {
+    const err = new Error('TalentReview model unavailable');
+    err.code = 'MODEL_UNAVAILABLE';
+    throw err;
+  }
+  if (!employeeId || !reviewCycle) {
+    const err = new Error('employeeId and reviewCycle are required');
+    err.code = 'VALIDATION';
+    throw err;
+  }
+
+  let source = 'manual';
+  let perf = performanceBand;
+  if (perf == null) {
+    perf = await derivePerformanceBand(employeeId);
+    source = 'derived';
+    if (perf == null) {
+      const err = new Error('performanceBand not supplied and not derivable (no approved evaluation)');
+      err.code = 'NO_PERFORMANCE';
+      throw err;
+    }
+  }
+
+  const existing = await TalentReview.findOne({ employeeId, reviewCycle });
+  const doc = existing || new TalentReview({ employeeId, reviewCycle });
+  doc.performanceBand = perf;
+  doc.potentialBand = potentialBand;
+  doc.performanceSource = source;
+  if (notes !== undefined) doc.notes = notes;
+  if (reviewedBy) doc.reviewedBy = reviewedBy;
+  if (status) doc.status = status;
+  await doc.save(); // pre('validate') computes box/segment + invariants run
+  return doc;
+}
+
+function scopeFilter({ branchId, reviewCycle, status }) {
+  const f = {};
+  if (branchId) f.branchId = branchId; // W269 — caller-resolved branch only
+  if (reviewCycle) f.reviewCycle = reviewCycle;
+  if (status) f.status = status;
+  return f;
+}
+
+/** Grid distribution + hiPo/risk rates for a branch + cycle. */
+async function gridSummary({ branchId, reviewCycle } = {}) {
+  const TalentReview = getModel('TalentReview', '../../models/HR/TalentReview');
+  if (!TalentReview) return grid.buildGrid([]);
+  const reviews = await TalentReview.find(scopeFilter({ branchId, reviewCycle }))
+    .select('box')
+    .limit(5000)
+    .lean();
+  const g = grid.buildGrid(reviews);
+  // attach a human label per box for UI rendering
+  g.boxes = {};
+  for (let b = 1; b <= 9; b++) {
+    const seg = grid.segmentOf(b);
+    g.boxes[b] = { count: g.counts[b], segment: seg.key, en: seg.en, ar: seg.ar };
+  }
+  return g;
+}
+
+/** Reviews in a given set of boxes, identity-bearing (employee populated). */
+async function reviewsInBoxes({ branchId, reviewCycle, boxes } = {}) {
+  const TalentReview = getModel('TalentReview', '../../models/HR/TalentReview');
+  if (!TalentReview) return [];
+  const f = scopeFilter({ branchId, reviewCycle });
+  f.box = { $in: boxes };
+  return TalentReview.find(f)
+    .sort({ box: -1 })
+    .limit(2000)
+    .populate('employeeId', 'full_name name job_title_en job_title_ar department')
+    .lean();
+}
+
+function highPotentials(opts) {
+  return reviewsInBoxes({ ...opts, boxes: grid.HIPO_BOXES });
+}
+function risks(opts) {
+  return reviewsInBoxes({ ...opts, boxes: grid.RISK_BOXES });
+}
+
+async function getByEmployee({ branchId, employeeId, reviewCycle } = {}) {
+  const TalentReview = getModel('TalentReview', '../../models/HR/TalentReview');
+  if (!TalentReview) return null;
+  const f = { employeeId, ...scopeFilter({ branchId, reviewCycle }) };
+  return TalentReview.findOne(f).populate('employeeId', 'full_name name department').lean();
+}
+
+module.exports = {
+  derivePerformanceBand,
+  upsertReview,
+  gridSummary,
+  reviewsInBoxes,
+  highPotentials,
+  risks,
+  getByEmployee,
+};

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -844,3 +844,6 @@ __tests__/review-worklist-wave1202.test.js
 __tests__/pay-equity-sweeper-wave1194.test.js
 __tests__/pay-equity-alert-rule-wave1197.test.js
 __tests__/smart-insurance-claim-model-wave1210.test.js
+__tests__/talent-grid-lib-wave1198.test.js
+__tests__/talent-grid-routes-wave1198.test.js
+__tests__/talent-grid-behavioral-wave1198.test.js


### PR DESCRIPTION
## What

Audit-first confirmed gap: the platform has retention / anomaly / succession / copilot / pay-equity intelligence but **no 9-box talent matrix** (`talent-grid`/`nine-box`/`potential` = 0 files). This is the classic talent-management grid: each employee placed on **Performance × Potential** (low/med/high) → one of **9 boxes** → a talent **segment** + recommended action.

```
        potential →   low   med   high
   perf high          7     8     9 (Star)
   perf med           4     5     6
   perf low           1     2     3 (Enigma)
```

## Stack — mirrors the W1193 pay-equity architecture

- **`intelligence/talent-grid.lib.js`** — pure: `performanceBand` (from the Arabic 5-point `overallRating` **or** a 1-5 score), `boxOf`, 9 segment labels (en+ar — Star / High Potential / Enigma / Underperformer / …), action groups, hiPo/risk box sets, `buildGrid` distribution + rates.
- **`models/HR/TalentReview.js`** — employee-keyed, **one per employee per cycle** (unique index). `box`/`segment`/`actionGroup` **computed** in an async `pre('validate')` (matched to the hrBranchScope plugin's async hook for gate-4 hook-style). Wave-18 invariants: bands 1-3, `box == boxOf(bands)`, finalized needs a reviewer. **branchId denormalised from the employee by the W1133 plugin → cross-branch isolation for free.**
- **`services/hr/talentGridService.js`** — derives performance from the latest **approved** `PerformanceEvaluation` (`performanceSource='derived'`) else manual; upsert; grid summary; hiPo / risk lists; per-employee lookup.
- **`routes/hr/talent-grid.routes.js`** — 5 endpoints, self-authed, branch-isolated (`effectiveBranchScope` + `enforceEmployeeBranch` on every employee call, no `req.branchId`), role-gated; the identity + negative-label `/risks` list uses a **stricter** role set. Mounted in `hr.registry` (self-authed → plain `app.use` is safe, W1190/W1191).

**Why potential is manager-rated, not auto-derived:** there is no objective "potential" signal in the data — that's the point of a talent *review*. Performance is the data-driven axis; potential is the judgement. The box can never drift (auto-computed from the two bands).

**Endpoints:** `POST /reviews` · `GET /grid` · `GET /high-potentials` · `GET /risks` · `GET /employee/:employeeId` — under `/api/(v1/)?hr/talent-grid`.

## Tests — 24 assertions / 3 sprint-enumerated files

lib unit (9-box mapping, band derivation, grid) + routes static (auth / W269 / per-route role gating / mount) + behavioral MMS (box auto-compute **and** recompute-on-update, invariants, unique employee+cycle index).

## Verified locally

`check:routes-load` · `check:hook-style` (async hook matches the plugin) · `check:sprint-paths` in sync · `check:gitignored-sources` · `no-broken-requires` + `no-duplicate-model-registration` + `canonical-beneficiary-ref` (my model is clean — no new phantom ref) · 24/24 green.

> Note: main has two unrelated **pre-existing** reds (Sprint Tests yml paths-limit + ~35 phantom refs from the parallel forms-approval-chains merges) — inherited; verified independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)