### PR TITLE
fix(models): W1213 - AccountingPayment save crash + permanent undeclared-next guard

### DIFF
--- a/backend/__tests__/no-async-next-save-hooks-wave978.test.js
+++ b/backend/__tests__/no-async-next-save-hooks-wave978.test.js
@@ -22,6 +22,10 @@ const path = require('path');
 
 const MODELS_DIR = path.resolve(__dirname, '..', 'models');
 const BROKEN_SAVE_HOOK = /\.(pre|post)\(\s*['"]save['"]\s*,\s*async function \(\s*next\s*\)/;
+// W1213 — 3rd variant of the class: an async NO-PARAM hook whose body still
+// CALLS next(...) → ReferenceError on every save (Communication crashed this
+// way until W1193; AccountingPayment until W1213). Catch it on ANY hook event.
+const ASYNC_NOPARAM_HOOK = /\.(pre|post)\(\s*['"](\w+)['"]\s*,\s*async function \(\s*\)\s*\{([\s\S]*?)\n\}\s*\)/g;
 
 function walk(dir, acc) {
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -39,6 +43,21 @@ describe('W978 — no async save hook declares next (Mongoose-9 throw class)', (
       BROKEN_SAVE_HOOK.test(fs.readFileSync(f, 'utf8'))
     );
     expect(offenders.map(f => path.relative(MODELS_DIR, f))).toEqual([]);
+  });
+
+  it('zero async NO-PARAM hooks call next() in their body (W1213 ReferenceError class)', () => {
+    const offenders = [];
+    for (const f of walk(MODELS_DIR, [])) {
+      const src = fs.readFileSync(f, 'utf8');
+      let m;
+      ASYNC_NOPARAM_HOOK.lastIndex = 0;
+      while ((m = ASYNC_NOPARAM_HOOK.exec(src))) {
+        if (/\bnext\s*\(/.test(m[3])) {
+          offenders.push(`${path.relative(MODELS_DIR, f)} :: ${m[1]}('${m[2]}')`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 });
 

--- a/backend/models/AccountingPayment.js
+++ b/backend/models/AccountingPayment.js
@@ -125,32 +125,30 @@ accountingPaymentSchema.virtual('invoiceDetails', {
 });
 
 // Pre-save middleware
+// W1213 — the old body called `next()` (×4) which an async no-param hook
+// NEVER receives → ReferenceError on every AccountingPayment save (the same
+// crash class fixed on Communication in W1193; repo-wide hunt found this as
+// the last instance). Async hooks signal failure by THROWING (W483 canonical).
 accountingPaymentSchema.pre('save', async function () {
   // Money-Type Migration (audit #5) — dual-write integer-halalas siblings.
   require('../intelligence/money.lib').deriveHalalas(this, ['amount']);
   // إذا كانت الدفعة جديدة ومكتملة، تحديث الفاتورة
   if (this.isNew && this.status === 'completed') {
-    try {
-      const AccountingInvoice = mongoose.model('AccountingInvoice');
-      const invoice = await AccountingInvoice.findById(this.invoice);
+    const AccountingInvoice = mongoose.model('AccountingInvoice');
+    const invoice = await AccountingInvoice.findById(this.invoice);
 
-      if (!invoice) {
-        return next(new Error('الفاتورة غير موجودة'));
-      }
-
-      // التحقق من أن المبلغ لا يتجاوز المبلغ المتبقي
-      if (this.amount > invoice.remainingAmount) {
-        return next(new Error('المبلغ المدفوع يتجاوز المبلغ المتبقي في الفاتورة'));
-      }
-
-      // تحديث الفاتورة
-      await invoice.recordPayment(this.amount, this._id);
-    } catch (error) {
-      return next(error);
+    if (!invoice) {
+      throw new Error('الفاتورة غير موجودة');
     }
-  }
 
-  next();
+    // التحقق من أن المبلغ لا يتجاوز المبلغ المتبقي
+    if (this.amount > invoice.remainingAmount) {
+      throw new Error('المبلغ المدفوع يتجاوز المبلغ المتبقي في الفاتورة');
+    }
+
+    // تحديث الفاتورة
+    await invoice.recordPayment(this.amount, this._id);
+  }
 });
 
 // Post-remove middleware لتحديث الفاتورة عند حذف الدفعة


### PR DESCRIPTION
Repo-wide hunt for the W1193 Communication crash class (async **no-param** hook whose body still calls `next()` → ReferenceError on every save) found **one remaining instance**: `AccountingPayment.pre(''save'')` called `next()` ×4 → every accounting-payment save crashed since the model shipped, and the invoice-update guards (missing invoice / over-payment) never enforced. Converted to the W483 canonical form (throw).

Extended the W978 drift guard with a second assertion scanning all models for this variant on ANY hook event — baseline empty, reintroduction fails CI (closes tooling follow-up #3 from the phantom-writes dossier).

Guards green: W978 (now 2 assertions) + gate-4 self-test = 30/30; routes-load 558 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)