### PR TITLE
feat(hr): W1200 — workforce-intelligence capstone (pay-equity + 9-box + diversity → one summary)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1419,6 +1419,9 @@ on:
       - 'backend/__tests__/diversity-lib-wave1199.test.js'
       - 'backend/__tests__/diversity-routes-wave1199.test.js'
       - 'backend/__tests__/diversity-behavioral-wave1199.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/workforce-intelligence-service-wave1200.test.js'
+      - 'backend/__tests__/workforce-intelligence-routes-wave1200.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2821,6 +2824,9 @@ on:
       - 'backend/__tests__/diversity-lib-wave1199.test.js'
       - 'backend/__tests__/diversity-routes-wave1199.test.js'
       - 'backend/__tests__/diversity-behavioral-wave1199.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/workforce-intelligence-service-wave1200.test.js'
+      - 'backend/__tests__/workforce-intelligence-routes-wave1200.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/workforce-intelligence-routes-wave1200.test.js
+++ b/backend/__tests__/workforce-intelligence-routes-wave1200.test.js
@@ -1,0 +1,34 @@
+/**
+ * W1200 — static drift guard for the workforce-intelligence capstone route + mount.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROUTE = path.join(__dirname, '..', 'routes', 'hr', 'workforce-intelligence.routes.js');
+const REGISTRY = path.join(__dirname, '..', 'routes', 'registries', 'hr.registry.js');
+const src = fs.readFileSync(ROUTE, 'utf8');
+const reg = fs.readFileSync(REGISTRY, 'utf8');
+
+describe('W1200 workforce-intelligence route — auth + isolation + mount', () => {
+  test('self-authenticates + requireBranchAccess', () => {
+    expect(src).toMatch(/router\.use\(\s*authenticateToken\s*\)/);
+    expect(src).toMatch(/router\.use\(\s*requireBranchAccess\s*\)/);
+  });
+  test('W269: effectiveBranchScope, never req.branchId', () => {
+    expect(src).toMatch(/effectiveBranchScope\(req\)/);
+    expect(src).not.toMatch(/req\.branchId/);
+  });
+  test('the /summary read is role-gated to leadership', () => {
+    expect(src).toMatch(/router\.get\(\s*'\/summary'\s*,\s*requireRole\(READ_ROLES\)/);
+    // pay-equity signals present → CFO/finance in the role set
+    expect(src).toMatch(/'cfo'/);
+  });
+  test('mounted in hr.registry at /api(/v1)?/hr/workforce-intelligence', () => {
+    expect(reg).toMatch(/workforce-intelligence\.routes/);
+    expect(reg).toMatch(/app\.use\(\s*'\/api\/hr\/workforce-intelligence'/);
+    expect(reg).toMatch(/app\.use\(\s*'\/api\/v1\/hr\/workforce-intelligence'/);
+  });
+});

--- a/backend/__tests__/workforce-intelligence-service-wave1200.test.js
+++ b/backend/__tests__/workforce-intelligence-service-wave1200.test.js
@@ -1,0 +1,82 @@
+/**
+ * W1200 — workforceIntelligenceService.summary() behaviour.
+ * Mocks the three sub-services to verify section assembly, headline flags, and
+ * Promise.allSettled degradation (a failing sub-analysis → null section + error).
+ */
+
+'use strict';
+
+jest.mock('../services/hr/payEquityService', () => ({ analyze: jest.fn() }));
+jest.mock('../services/hr/talentGridService', () => ({ gridSummary: jest.fn() }));
+jest.mock('../services/hr/diversityService', () => ({ analyze: jest.fn() }));
+
+const payEquity = require('../services/hr/payEquityService');
+const talent = require('../services/hr/talentGridService');
+const diversity = require('../services/hr/diversityService');
+const svc = require('../services/hr/workforceIntelligenceService');
+
+const healthyPay = { headcount: 20, equityScore: 92, genderGap: { reportable: true, medianGapPct: 4 }, nationalityGap: { reportable: false }, cohortOutliers: { count: 0 } };
+const healthyTalent = { total: 20, hiPo: { count: 4, ratePct: 20 }, risk: { count: 2, ratePct: 10 }, counts: {} };
+const healthyDiv = { headcount: 20, saudizationRatePct: 60, diversityIndex: { genderBlau: 0.5, nationalityBlau: 0.48 }, seniorityLens: { gender: { topVsBottomDelta: { female: -5 } } } };
+
+beforeEach(() => {
+  payEquity.analyze.mockReset();
+  talent.gridSummary.mockReset();
+  diversity.analyze.mockReset();
+});
+
+describe('W1200 workforce-intelligence summary — assembly', () => {
+  test('rolls all three sections + zero flags on a healthy branch', async () => {
+    payEquity.analyze.mockResolvedValue(healthyPay);
+    talent.gridSummary.mockResolvedValue(healthyTalent);
+    diversity.analyze.mockResolvedValue(healthyDiv);
+    const s = await svc.summary({ branchId: 'bA' });
+    expect(s.branchId).toBe('bA');
+    expect(s.sections.payEquity.equityScore).toBe(92);
+    expect(s.sections.talent.hiPo.ratePct).toBe(20);
+    expect(s.sections.diversity.saudizationRatePct).toBe(60);
+    expect(s.flags).toEqual([]);
+    expect(s.flagCount).toBe(0);
+  });
+
+  test('passes branchId/department/reviewCycle through to each sub-service', async () => {
+    payEquity.analyze.mockResolvedValue(healthyPay);
+    talent.gridSummary.mockResolvedValue(healthyTalent);
+    diversity.analyze.mockResolvedValue(healthyDiv);
+    await svc.summary({ branchId: 'bX', department: 'PT', reviewCycle: '2026-H1' });
+    expect(payEquity.analyze).toHaveBeenCalledWith({ branchId: 'bX', department: 'PT' });
+    expect(talent.gridSummary).toHaveBeenCalledWith({ branchId: 'bX', reviewCycle: '2026-H1' });
+    expect(diversity.analyze).toHaveBeenCalledWith({ branchId: 'bX', department: 'PT' });
+  });
+});
+
+describe('W1200 workforce-intelligence summary — headline flags', () => {
+  test('low equity score + high gender gap', async () => {
+    payEquity.analyze.mockResolvedValue({ ...healthyPay, equityScore: 55, genderGap: { reportable: true, medianGapPct: 22 } });
+    talent.gridSummary.mockResolvedValue(healthyTalent);
+    diversity.analyze.mockResolvedValue(healthyDiv);
+    const s = await svc.summary({ branchId: 'bA' });
+    expect(s.flags).toEqual(expect.arrayContaining(['pay_equity_score_low', 'gender_pay_gap_high']));
+  });
+
+  test('talent risk concentration (≥25%) + gender glass ceiling (female top delta ≤ -20)', async () => {
+    payEquity.analyze.mockResolvedValue(healthyPay);
+    talent.gridSummary.mockResolvedValue({ ...healthyTalent, risk: { count: 6, ratePct: 30 } });
+    diversity.analyze.mockResolvedValue({ ...healthyDiv, seniorityLens: { gender: { topVsBottomDelta: { female: -40 } } } });
+    const s = await svc.summary({ branchId: 'bA' });
+    expect(s.flags).toEqual(expect.arrayContaining(['talent_risk_concentration', 'glass_ceiling_gender']));
+  });
+});
+
+describe('W1200 workforce-intelligence summary — degradation', () => {
+  test('a failing sub-analysis → null section + recorded error, others survive', async () => {
+    payEquity.analyze.mockRejectedValue(new Error('pay boom'));
+    talent.gridSummary.mockResolvedValue(healthyTalent);
+    diversity.analyze.mockResolvedValue(healthyDiv);
+    const s = await svc.summary({ branchId: 'bA' });
+    expect(s.sections.payEquity).toBeNull();
+    expect(s.errors.payEquity).toMatch(/pay boom/);
+    expect(s.sections.talent).not.toBeNull(); // others unaffected
+    expect(s.sections.diversity).not.toBeNull();
+  });
+});

--- a/backend/routes/hr/workforce-intelligence.routes.js
+++ b/backend/routes/hr/workforce-intelligence.routes.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * workforce-intelligence.routes.js — branch workforce-health capstone (W1200).
+ *
+ * Mount: /api/hr/workforce-intelligence + /api/v1/... (self-authed → safe under the
+ * plain hr.registry app.use mount, W1190/W1191).
+ *
+ *   GET /summary — one branch summary across pay-equity + talent 9-box + diversity,
+ *                  with headline flags. Branch-isolated (effectiveBranchScope, W269).
+ *
+ * Carries pay-equity signals → gated to HR/finance leadership (the pay-equity
+ * READ_ROLES set), not the broader diversity reader set.
+ */
+
+const express = require('express');
+const router = express.Router();
+
+const { authenticateToken, requireRole } = require('../../middleware/auth');
+const { requireBranchAccess } = require('../../middleware/branchScope.middleware');
+const { effectiveBranchScope } = require('../../middleware/assertBranchMatch');
+const safeError = require('../../utils/safeError');
+const svc = require('../../services/hr/workforceIntelligenceService');
+
+const READ_ROLES = [
+  'admin', 'superadmin', 'super_admin', 'hr_manager', 'hr_director', 'hr',
+  'cfo', 'finance_manager', 'compliance', 'compliance_officer',
+];
+
+router.use(authenticateToken);
+router.use(requireBranchAccess);
+
+/** GET /summary — unified workforce-intelligence summary for the caller's branch. */
+router.get('/summary', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const branchId = effectiveBranchScope(req); // W269 — own branch or null (HQ)
+    const data = await svc.summary({
+      branchId,
+      department: req.query.department ? String(req.query.department) : null,
+      reviewCycle: req.query.reviewCycle ? String(req.query.reviewCycle) : null,
+    });
+    res.json({ success: true, data });
+  } catch (err) {
+    safeError(res, err, 'workforce-intelligence:summary');
+  }
+});
+
+module.exports = router;

--- a/backend/routes/registries/hr.registry.js
+++ b/backend/routes/registries/hr.registry.js
@@ -200,5 +200,16 @@ module.exports = function registerHrRoutes(app, { safeRequire, dualMount, safeMo
     logger.warn('[HR] Diversity routes not mounted (module missing)');
   }
 
+  // ── Workforce-intelligence capstone (W1200 — pay-equity + 9-box + diversity) ──
+  // Self-authenticating; fans out across the three surfaces into one branch summary.
+  const wfiRouter = safeRequire('../routes/hr/workforce-intelligence.routes');
+  if (wfiRouter) {
+    app.use('/api/hr/workforce-intelligence', wfiRouter);
+    app.use('/api/v1/hr/workforce-intelligence', wfiRouter);
+    logger.info('[HR] Workforce-intelligence summary mounted (/api/(v1/)?hr/workforce-intelligence)');
+  } else {
+    logger.warn('[HR] Workforce-intelligence routes not mounted (module missing)');
+  }
+
   logger.info('[HR] All ~25 HR/Employee/Workforce modules mounted successfully');
 };

--- a/backend/services/hr/workforceIntelligenceService.js
+++ b/backend/services/hr/workforceIntelligenceService.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * workforceIntelligenceService.js — branch-level capstone that fans out across the
+ * three workforce-intelligence surfaces (W1200):
+ *   - pay equity   (W1193) — equity score + demographic pay gaps
+ *   - talent 9-box (W1198) — hiPo / risk distribution
+ *   - diversity    (W1199) — representation, indices, Saudization, glass-ceiling
+ *
+ * Promise.allSettled so one failing sub-analysis degrades that section to null
+ * rather than breaking the whole summary (the W381 aggregator pattern). Pure
+ * orchestration — no new model, no DB of its own; each sub-service already applies
+ * branch isolation via the branchId the route resolved.
+ */
+
+const payEquity = require('./payEquityService');
+const talent = require('./talentGridService');
+const diversity = require('./diversityService');
+
+function settled(p) {
+  return p.then(
+    value => ({ ok: true, value }),
+    error => ({ ok: false, error: error && error.message })
+  );
+}
+
+/** Roll the three analyses into one branch summary + headline flags. */
+async function summary({ branchId, department = null, reviewCycle = null } = {}) {
+  const [pe, tg, di] = await Promise.all([
+    settled(payEquity.analyze({ branchId, department })),
+    settled(talent.gridSummary({ branchId, reviewCycle })),
+    settled(diversity.analyze({ branchId, department })),
+  ]);
+
+  const flags = [];
+
+  // pay-equity section
+  let payEquitySection = null;
+  if (pe.ok && pe.value) {
+    const v = pe.value;
+    payEquitySection = {
+      headcount: v.headcount,
+      equityScore: v.equityScore,
+      genderMedianGapPct: v.genderGap && v.genderGap.reportable ? v.genderGap.medianGapPct : null,
+      nationalityMedianGapPct: v.nationalityGap && v.nationalityGap.reportable ? v.nationalityGap.medianGapPct : null,
+      flaggedCount: v.cohortOutliers ? v.cohortOutliers.count : 0,
+    };
+    if (typeof v.equityScore === 'number' && v.equityScore < 70) flags.push('pay_equity_score_low');
+    if (v.genderGap && v.genderGap.reportable && v.genderGap.medianGapPct > 15) flags.push('gender_pay_gap_high');
+  }
+
+  // talent section
+  let talentSection = null;
+  if (tg.ok && tg.value) {
+    const v = tg.value;
+    talentSection = {
+      reviewed: v.total,
+      hiPo: v.hiPo,
+      risk: v.risk,
+      distribution: v.counts,
+    };
+    if (v.total > 0 && v.risk && v.risk.ratePct >= 25) flags.push('talent_risk_concentration');
+  }
+
+  // diversity section
+  let diversitySection = null;
+  if (di.ok && di.value) {
+    const v = di.value;
+    const cliff = v.seniorityLens && v.seniorityLens.gender;
+    const femaleTopDelta = cliff && cliff.topVsBottomDelta ? cliff.topVsBottomDelta.female : null;
+    diversitySection = {
+      headcount: v.headcount,
+      saudizationRatePct: v.saudizationRatePct,
+      genderBlau: v.diversityIndex ? v.diversityIndex.genderBlau : null,
+      nationalityBlau: v.diversityIndex ? v.diversityIndex.nationalityBlau : null,
+      femaleTopTierDelta: femaleTopDelta,
+    };
+    if (typeof femaleTopDelta === 'number' && femaleTopDelta <= -20) flags.push('glass_ceiling_gender');
+  }
+
+  return {
+    branchId: branchId || null,
+    scope: { level: department ? 'department' : 'branch', department: department || null },
+    sections: {
+      payEquity: payEquitySection,
+      talent: talentSection,
+      diversity: diversitySection,
+    },
+    errors: {
+      payEquity: pe.ok ? null : pe.error,
+      talent: tg.ok ? null : tg.error,
+      diversity: di.ok ? null : di.error,
+    },
+    flags,
+    flagCount: flags.length,
+  };
+}
+
+module.exports = { summary };

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -850,3 +850,5 @@ __tests__/talent-grid-behavioral-wave1198.test.js
 __tests__/diversity-lib-wave1199.test.js
 __tests__/diversity-routes-wave1199.test.js
 __tests__/diversity-behavioral-wave1199.test.js
+__tests__/workforce-intelligence-service-wave1200.test.js
+__tests__/workforce-intelligence-routes-wave1200.test.js


### PR DESCRIPTION
## What

The capstone that ties the three workforce-intelligence surfaces into a **single branch-health view** for leadership. Fans out (`Promise.allSettled` — the W381 aggregator pattern) across:

| Surface | Contributes |
| --- | --- |
| **Pay equity** (W1193) | `equityScore` + gender/nationality median gaps + flagged count |
| **Talent 9-box** (W1198) | hiPo / risk rates + box distribution |
| **Diversity** (W1199) | Saudization + Blau indices + female top-tier delta |

**Headline flags:** `pay_equity_score_low` (<70) · `gender_pay_gap_high` (>15%) · `talent_risk_concentration` (≥25% in risk boxes) · `glass_ceiling_gender` (female top-tier delta ≤ -20).

A failing sub-analysis **degrades that section to `null` + records the error** rather than breaking the whole summary.

## Stack

- **`services/hr/workforceIntelligenceService.js`** — pure orchestration (no new model, no DB of its own); each sub-service already applies the route-resolved `branchId`.
- **`routes/hr/workforce-intelligence.routes.js`** — `GET /summary`, self-authed, **branch-isolated** (`effectiveBranchScope`, W269), gated to **HR/finance leadership** (carries pay-equity signals → CFO/finance in `READ_ROLES`). Mounted in `hr.registry`.

**Endpoint:** `GET /api/(v1/)?hr/workforce-intelligence/summary`

## Tests — 9 assertions / 2 sprint-enumerated files

Service behaviour (section assembly, arg pass-through, **every** flag, `Promise.allSettled` degradation — sub-services mocked) + route static (auth / W269 / role gating / mount).

## Verified locally

`check:routes-load` · `check:sprint-paths` in sync · `check:gitignored-sources` · `no-broken-requires` · 9/9 green.

> Note: main has two unrelated **pre-existing** reds (Sprint Tests yml paths-limit + ~35 phantom refs from the parallel forms-approval-chains merges) — inherited; verified independently.

## The workforce-intelligence suite is now complete

pay-equity (fairness) + 9-box (talent) + diversity (representation) + **this capstone (one summary + flags)** — all on the same Employee data, branch-isolated, privacy-aware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)