### PR TITLE
feat(audit): W1216 - missing-required detector (v2) + the waitlist name fix it caught

### DIFF
--- a/backend/__tests__/check-phantom-schema-writes-script.test.js
+++ b/backend/__tests__/check-phantom-schema-writes-script.test.js
@@ -179,6 +179,61 @@ describe('scanRepo (fixture repos)', () => {
   });
 });
 
+// ─── W1214 missing-required detector ─────────────────────────────────────────
+
+describe('scanRepo — missingRequired detector (W1214)', () => {
+  function makeRequiredFixture(modelExtra, createBody) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'phantom-req-'));
+    fs.mkdirSync(path.join(root, 'models'));
+    fs.mkdirSync(path.join(root, 'routes'));
+    fs.mkdirSync(path.join(root, 'services'));
+    fs.writeFileSync(
+      path.join(root, 'models', 'Gadget.js'),
+      [
+        "const mongoose = require('mongoose');",
+        'const GadgetSchema = new mongoose.Schema({',
+        "  name: { type: String, required: true },",
+        modelExtra,
+        '});',
+        modelExtra.includes('hooked')
+          ? "GadgetSchema.pre('validate', async function () { this.hooked = 'x'; });"
+          : '',
+        "module.exports = mongoose.model('Gadget', GadgetSchema);",
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(root, 'routes', 'gadget.routes.js'),
+      [
+        "const Gadget = require('../models/Gadget');",
+        `async function create(req) { return Gadget.create({ ${createBody} }); }`,
+        'module.exports = { create };',
+      ].join('\n')
+    );
+    return root;
+  }
+
+  it('flags a required-no-default key omitted from the create literal', () => {
+    const root = makeRequiredFixture("  code: { type: String, required: true },", 'name: 1');
+    const r = scanRepo({ root });
+    const missing = r.newFindings.filter(f => f.type === 'missingRequired');
+    expect(missing).toHaveLength(1);
+    expect(missing[0].key).toBe('code');
+    expect(missing[0].id).toContain('::MISSING::code');
+  });
+
+  it('does NOT flag when the key is provided, defaulted, hook-assigned, or array-typed', () => {
+    for (const [extra, body] of [
+      ["  code: { type: String, required: true },", 'name: 1, code: 2'], // provided
+      ["  code: { type: String, required: true, default: 'X' },", 'name: 1'], // default
+      ["  hooked: { type: String, required: true },", 'name: 1'], // hook-assigned
+      ["  subs: [{ q: { type: String, required: true } }],", 'name: 1'], // array-typed
+    ]) {
+      const r = scanRepo({ root: makeRequiredFixture(extra, body) });
+      expect(r.newFindings.filter(f => f.type === 'missingRequired')).toEqual([]);
+    }
+  });
+});
+
 // ─── CLI exit-code contract ──────────────────────────────────────────────────
 
 describe('check-phantom-schema-writes — CLI exit-code contract', () => {

--- a/backend/routes/waitlist.routes.js
+++ b/backend/routes/waitlist.routes.js
@@ -519,10 +519,19 @@ router.post('/:id/enroll', validateId, async (req, res) => {
       };
       const disType = WAITLIST_TO_MODEL_TYPE[entry.disabilityType] || 'other';
 
+      // W1216 — firstName/lastName are the REQUIRED canonical name fields
+      // (the *_ar pair is optional); caught by the audit's new
+      // missing-required detector on its first run.
+      const nameParts = entry.applicantName.trim().split(/\s+/);
+      const firstName = nameParts[0] || entry.applicantName;
+      const lastName = nameParts.length > 1 ? nameParts[nameParts.length - 1] : firstName;
+
       const newBeneficiary = await Beneficiary.create({
         branchId: targetBranch,
-        firstName_ar: entry.applicantName.split(' ')[0] || entry.applicantName,
-        lastName_ar: entry.applicantName.split(' ').slice(-1)[0] || entry.applicantName,
+        firstName,
+        lastName,
+        firstName_ar: firstName,
+        lastName_ar: lastName,
         phone: entry.applicantPhone,
         email: entry.applicantEmail,
         nationalId: entry.applicantNationalId,

--- a/backend/scripts/check-phantom-schema-writes.js
+++ b/backend/scripts/check-phantom-schema-writes.js
@@ -41,6 +41,36 @@ const JSON_MODE = process.argv.includes('--json');
 // file::model-file-base::key — pre-existing findings to burn down (W325c
 // ratchet pattern): new entries must FAIL CI; fixed entries must be removed.
 const KNOWN_PHANTOM_WRITES = new Set([
+  "routes/electronic-directives.routes.js::document::MISSING::fileName",
+  "routes/electronic-directives.routes.js::document::MISSING::originalFileName",
+  "routes/electronic-directives.routes.js::document::MISSING::fileSize",
+  "routes/electronic-directives.routes.js::document::MISSING::filePath",
+  "routes/electronic-directives.routes.js::document::MISSING::uploadedBy",
+  "routes/email-v2.routes.js::communication::MISSING::title",
+  "routes/email-v2.routes.js::communication::MISSING::type",
+  "routes/email-v2.routes.js::communication::MISSING::receiver",
+  "routes/email-v2.routes.js::communication::MISSING::sentDate",
+  "routes/email-v2.routes.js::communication::MISSING::createdBy",
+  "routes/guardians.routes.js::guardian::MISSING::userId",
+  "routes/student-certificates.routes.js::document::MISSING::fileName",
+  "routes/student-certificates.routes.js::document::MISSING::originalFileName",
+  "routes/student-certificates.routes.js::document::MISSING::fileSize",
+  "routes/student-certificates.routes.js::document::MISSING::filePath",
+  "routes/student-certificates.routes.js::document::MISSING::uploadedBy",
+  "routes/student-complaints.routes.js::communication::MISSING::title",
+  "routes/student-complaints.routes.js::communication::MISSING::type",
+  "routes/student-complaints.routes.js::communication::MISSING::receiver",
+  "routes/student-complaints.routes.js::communication::MISSING::sentDate",
+  "routes/student-complaints.routes.js::communication::MISSING::createdBy",
+  "routes/student-elearning.routes.js::studentactivity::MISSING::beneficiaryId",
+  "routes/student-elearning.routes.js::studentactivity::MISSING::titleAr",
+  "routes/student-elearning.routes.js::studentactivity::MISSING::dueAt",
+  "routes/student-events.routes.js::studentactivity::MISSING::beneficiaryId",
+  "routes/student-events.routes.js::studentactivity::MISSING::titleAr",
+  "routes/student-events.routes.js::studentactivity::MISSING::dueAt",
+  "routes/student-rewards-store.routes.js::studentactivity::MISSING::beneficiaryId",
+  "routes/student-rewards-store.routes.js::studentactivity::MISSING::titleAr",
+  "routes/student-rewards-store.routes.js::studentactivity::MISSING::dueAt",
   "routes/electronic-directives.routes.js::document::directiveType",
   "routes/electronic-directives.routes.js::document::beneficiaryId",
   "routes/electronic-directives.routes.js::document::content",
@@ -141,6 +171,10 @@ const ALWAYS_ALLOWED = new Set([
 function scanObjectLiteral(src, openIdx) {
   if (src[openIdx] !== '{') return null;
   const keys = [];
+  // W1216 — per-key VALUE spans [{key, start, end}] so callers can inspect
+  // field definitions (required/default detection). Shorthand keys have no span.
+  const entries = [];
+  let current = null;
   let hasSpread = false;
   let depth = 0;
   let i = openIdx;
@@ -216,6 +250,7 @@ function scanObjectLiteral(src, openIdx) {
       if (c === '.' && next === '.' && src[i + 2] === '.') {
         hasSpread = true;
         expectKey = false;
+        current = null;
         i += 3;
         continue;
       }
@@ -232,6 +267,7 @@ function scanObjectLiteral(src, openIdx) {
         while (k < src.length && /\s/.test(src[k])) k += 1;
         if (src[k] === ':') {
           keys.push(key);
+          current = { key, start: k + 1 };
           expectKey = false;
           i = k + 1;
           continue;
@@ -247,6 +283,7 @@ function scanObjectLiteral(src, openIdx) {
         while (k < src.length && /\s/.test(src[k])) k += 1;
         if (src[k] === ':') {
           keys.push(word);
+          current = { key: word, start: k + 1 };
           expectKey = false;
           i = k + 1;
           continue;
@@ -254,11 +291,13 @@ function scanObjectLiteral(src, openIdx) {
         // shorthand `{ data, }` — the property name IS the key
         if (src[k] === ',' || src[k] === '}') {
           keys.push(word);
+          current = null;
           expectKey = false;
           i = j;
           continue;
         }
         expectKey = false;
+        current = null;
         i = j;
         continue;
       }
@@ -295,12 +334,19 @@ function scanObjectLiteral(src, openIdx) {
         continue;
       }
       depth -= 1;
-      if (depth === 0) return { keys, end: i, hasSpread };
+      if (depth === 0) {
+        if (current) entries.push({ ...current, end: i });
+        return { keys, entries, end: i, hasSpread };
+      }
       i += 1;
       continue;
     }
 
     if (depth === 1 && c === ',') {
+      if (current) {
+        entries.push({ ...current, end: i });
+        current = null;
+      }
       expectKey = true;
       i += 1;
       continue;
@@ -364,6 +410,60 @@ function extractSchemaKeySets(src) {
   return sets;
 }
 
+/**
+ * W1216 — top-level keys of the file's MAIN schema (largest literal — a
+ * multi-schema file carries sub-schemas whose required fields don't apply at
+ * the create() top level) that are REQUIRED with NO default. A create-site
+ * literal missing one of these throws ValidationError at runtime — the
+ * dominant killer found in the 2026-06-11 burn-down (uuid / branchId /
+ * startTime / fullName / recipientId / period / lines / organizationId…).
+ */
+function extractRequiredNoDefault(src) {
+  const objs = [];
+  const re = /new\s+(?:mongoose\.)?Schema\s*\(\s*/g;
+  let m;
+  while ((m = re.exec(src))) {
+    const i = m.index + m[0].length;
+    let obj = null;
+    if (src[i] === '{') {
+      obj = scanObjectLiteral(src, i);
+    } else {
+      const idM = /^([A-Za-z_$][\w$]*)/.exec(src.slice(i, i + 80));
+      if (idM) {
+        const defRe = new RegExp(
+          `(?:const|let|var)\\s+${idM[1].replace(/\$/g, '\\$')}\\s*=\\s*`,
+          'g'
+        );
+        const dm = defRe.exec(src);
+        if (dm) {
+          let j = dm.index + dm[0].length;
+          while (j < src.length && /\s/.test(src[j])) j += 1;
+          if (src[j] === '{') obj = scanObjectLiteral(src, j);
+        }
+      }
+    }
+    if (obj && obj.keys.length > 0) objs.push(obj);
+  }
+  if (!objs.length) return new Set();
+  const main = objs.reduce((a, b) => (b.keys.length > a.keys.length ? b : a));
+  const out = new Set();
+  for (const e of main.entries || []) {
+    const span = src.slice(e.start, e.end);
+    // Array-typed fields auto-default to [] — a `required:` inside the span
+    // belongs to a SUBDOC key (e.g. subScores: [{question: {required}}]),
+    // not to the field itself.
+    if (/^\s*\[/.test(span)) continue;
+    if (/\brequired\s*:\s*(true|\[)/.test(span) && !/\bdefault\s*:/.test(span)) {
+      // Hook-generated values (`this.<key> = …` anywhere in the model file —
+      // pre('validate')/pre('save') number generators etc.) satisfy the
+      // requirement at save time → not a caller obligation.
+      const hookAssigned = new RegExp(`this\\.${e.key}\\s*=`).test(src);
+      if (!hookAssigned) out.add(e.key);
+    }
+  }
+  return out;
+}
+
 // ─── repo walking ────────────────────────────────────────────────────────────
 
 function listJsFiles(dir) {
@@ -389,6 +489,7 @@ function buildModelIndex(modelsDir) {
   // whose schemas were unresolvable POISONS the base (deleted from index)
   // so partial key sets can't flood false positives.
   const index = new Map();
+  const requiredIndex = new Map(); // base → Set(required-no-default keys) | null=ambiguous
   const poisoned = new Set();
   for (const file of listJsFiles(modelsDir)) {
     let src;
@@ -418,9 +519,18 @@ function buildModelIndex(modelsDir) {
     const union = index.get(base) || new Set();
     for (const keys of sets) for (const k of keys) union.add(k);
     index.set(base, union);
+    // W1216 — required-with-no-default keys of the file's main schema. A base
+    // seen in MULTIPLE files is ambiguous for required-checks (we can't tell
+    // which file a binding resolves to) → drop it from the required index.
+    if (requiredIndex.has(base)) requiredIndex.set(base, null);
+    else requiredIndex.set(base, extractRequiredNoDefault(src));
   }
-  for (const base of poisoned) index.delete(base);
-  return index;
+  for (const base of poisoned) {
+    index.delete(base);
+    requiredIndex.delete(base);
+  }
+  for (const [base, v] of requiredIndex) if (!v || v.size === 0) requiredIndex.delete(base);
+  return { index, requiredIndex };
 }
 
 /** Resolve `X` → model file base, from require/model-lookup bindings. */
@@ -449,7 +559,7 @@ function scanRepo({ root = ROOT, baseline } = {}) {
     (path.resolve(root) === path.resolve(path.join(__dirname, '..'))
       ? KNOWN_PHANTOM_WRITES
       : new Set());
-  const modelIndex = buildModelIndex(path.join(root, 'models'));
+  const { index: modelIndex, requiredIndex } = buildModelIndex(path.join(root, 'models'));
   const findings = [];
   let scannedSites = 0;
   let skippedSites = 0;
@@ -484,15 +594,35 @@ function scanRepo({ root = ROOT, baseline } = {}) {
         continue;
       }
       scannedSites += 1;
+      const rel = path.relative(root, file).replace(/\\/g, '/');
+      const line = lineOf(src, m.index);
       const unknown = obj.keys.filter(k => !declared.has(k) && !ALWAYS_ALLOWED.has(k));
       for (const key of unknown) {
         findings.push({
-          file: path.relative(root, file).replace(/\\/g, '/'),
-          line: lineOf(src, m.index),
+          file: rel,
+          line,
           model: base,
           key,
-          id: `${path.relative(root, file).replace(/\\/g, '/')}::${base}::${key}`,
+          type: 'phantomKey',
+          id: `${rel}::${base}::${key}`,
         });
+      }
+      // W1216 — required-with-no-default keys ABSENT from the literal →
+      // guaranteed ValidationError at runtime.
+      const reqSet = requiredIndex.get(base);
+      if (reqSet) {
+        for (const rk of reqSet) {
+          if (!obj.keys.includes(rk) && !ALWAYS_ALLOWED.has(rk)) {
+            findings.push({
+              file: rel,
+              line,
+              model: base,
+              key: rk,
+              type: 'missingRequired',
+              id: `${rel}::${base}::MISSING::${rk}`,
+            });
+          }
+        }
       }
     }
   }
@@ -536,7 +666,11 @@ function main() {
       `check-phantom-schema-writes — models indexed: ${r.modelsIndexed}, create-sites verified: ${r.scannedSites} (skipped ${r.skippedSites})\n`
     );
     for (const f of r.newFindings) {
-      process.stdout.write(`  ✗ ${f.file}:${f.line} — ${f.model}.create() writes undeclared key '${f.key}'\n`);
+      const msg =
+        f.type === 'missingRequired'
+          ? `omits REQUIRED-no-default key '${f.key}' (throws at runtime)`
+          : `writes undeclared key '${f.key}'`;
+      process.stdout.write(`  ✗ ${f.file}:${f.line} — ${f.model}.create() ${msg}\n`);
     }
     for (const id of r.staleBaseline) {
       process.stdout.write(`  ⚠ stale baseline entry (fixed — remove from KNOWN_PHANTOM_WRITES): ${id}\n`);


### PR DESCRIPTION
`check:phantom-writes` v2 (dossier tooling follow-up #1): every verified create-site is now also checked for schema keys that are **REQUIRED with no default and absent from the literal** → guaranteed runtime ValidationError (the dominant killer class of this burn-down campaign).

False-positive hardened on first run: main-schema-only (sub-schema required ≠ caller obligation), hook-assigned keys skipped (`this.key =` generators), array-typed fields skipped (auto-`[]`; caught the NpsResponse `subScores` FP), ambiguous same-basename models skipped.

**First-run catches**: my own W1209 waitlist conversion missed the canonical REQUIRED `firstName`/`lastName` (only set the optional `*_ar` pair) — fixed; plus 30 missing-required ids on the dormant files baselined with a `MISSING::` marker (quantifying why they must not be wired before repair).

Self-test 16/16; routes-load 558 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)