### PR TITLE
feat(supervisor-ops): specialist 'my day' board (W1204, read-only)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1422,6 +1422,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/workforce-intelligence-service-wave1200.test.js'
       - 'backend/__tests__/workforce-intelligence-routes-wave1200.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/my-day-board-wave1204.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2827,6 +2829,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/workforce-intelligence-service-wave1200.test.js'
       - 'backend/__tests__/workforce-intelligence-routes-wave1200.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/my-day-board-wave1204.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/my-day-board-wave1204.test.js
+++ b/backend/__tests__/my-day-board-wave1204.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * my-day-board-wave1204.test.js — static guard for the specialist "my day" board
+ * route (domains/goals/routes/supervisor-ops.routes.js → GET /supervisor-ops/my-day).
+ *
+ * The other half of the operational cycle: the therapist's OWN daily In-Process /
+ * Complete board (reuses the W1169 dailyBoardForTherapist). Caller-scoped to
+ * req.user (no therapistId param → no cross-user IDOR), read-only.
+ *
+ * Run: cd backend && npx jest --config=jest.config.js __tests__/my-day-board-wave1204.test.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROUTE_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'domains', 'goals', 'routes', 'supervisor-ops.routes.js'),
+  'utf-8'
+);
+
+describe('my-day board route (W1204) — mount + shape', () => {
+  test('route file loads without throwing', () => {
+    expect(() => require('../domains/goals/routes/supervisor-ops.routes')).not.toThrow();
+  });
+  test('declares GET /supervisor-ops/my-day', () => {
+    expect(ROUTE_SRC).toMatch(/router\.get\(\s*['"]\/supervisor-ops\/my-day['"]/);
+  });
+  test('imports dailyBoardForTherapist + delegates to it', () => {
+    expect(ROUTE_SRC).toMatch(/dailyBoardForTherapist/);
+    expect(ROUTE_SRC).toMatch(/dailyBoardForTherapist\(\s*therapistId/);
+  });
+});
+
+describe('my-day board route (W1204) — caller-scoped (no IDOR) + read-only', () => {
+  test('scopes to the caller via req.user (NOT a therapistId path/query param)', () => {
+    expect(ROUTE_SRC).toMatch(/req\.user\s*&&\s*\(req\.user\._id\s*\|\|\s*req\.user\.id\)/);
+    // the my-day handler must NOT read a therapistId from params/query (would be IDOR)
+    const myDayBlock = ROUTE_SRC.slice(ROUTE_SRC.indexOf("'/supervisor-ops/my-day'"));
+    expect(myDayBlock).not.toMatch(/req\.params\.therapistId|req\.query\.therapistId/);
+  });
+  test('401 when unauthenticated', () => {
+    expect(ROUTE_SRC).toMatch(/status\(\s*401\s*\)/);
+  });
+  test('validates the optional date param', () => {
+    expect(ROUTE_SRC).toMatch(/Number\.isNaN\(\s*date\.getTime\(\)\s*\)/);
+  });
+  test('READ-ONLY — no mutation in the route file', () => {
+    expect(ROUTE_SRC).not.toMatch(
+      /\.(save|create|updateOne|updateMany|deleteOne|deleteMany|insertMany|findOneAndUpdate)\(/
+    );
+  });
+  test('never reads the always-undefined req.branchId', () => {
+    expect(ROUTE_SRC).not.toMatch(/req\.branchId/);
+  });
+});

--- a/backend/domains/goals/routes/supervisor-ops.routes.js
+++ b/backend/domains/goals/routes/supervisor-ops.routes.js
@@ -23,6 +23,7 @@ const {
   documentationBacklog,
   branchProductivity,
   summarizeOverdueReports,
+  dailyBoardForTherapist,
 } = require('../../../services/supervisorOps.service');
 const reassessmentLifecycleService = require('../../../services/reassessmentLifecycle.service');
 const { gatherBranchHealth } = require('../../../services/operationsHealth.service');
@@ -174,6 +175,30 @@ router.get(
 
     const limit = Math.min(parseInt(req.query.limit, 10) || 200, 500);
     const data = await reviewWorklist({ branchId, limit });
+    return res.json({ success: true, data });
+  })
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /supervisor-ops/my-day[?date=]
+//   The SPECIALIST's own daily workflow board — the other half of the operational
+//   cycle (receive task → run session → DOCUMENT → complete). Returns the caller's
+//   clinical sessions for the day folded into "In-Process vs Complete" workflow
+//   states + the awaiting-documentation chase list. Caller-scoped to req.user
+//   (you only ever see YOUR OWN board → no cross-user access). READ-ONLY.
+// ═══════════════════════════════════════════════════════════════════════════
+router.get(
+  '/supervisor-ops/my-day',
+  asyncHandler(async (req, res) => {
+    const therapistId = req.user && (req.user._id || req.user.id);
+    if (!therapistId) {
+      return res.status(401).json({ success: false, error: 'authentication required' });
+    }
+    const date = req.query.date ? new Date(req.query.date) : undefined;
+    if (date && Number.isNaN(date.getTime())) {
+      return res.status(400).json({ success: false, error: 'invalid date' });
+    }
+    const data = await dailyBoardForTherapist(therapistId, date ? { date } : {});
     return res.json({ success: true, data });
   })
 );

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -852,3 +852,4 @@ __tests__/diversity-routes-wave1199.test.js
 __tests__/diversity-behavioral-wave1199.test.js
 __tests__/workforce-intelligence-service-wave1200.test.js
 __tests__/workforce-intelligence-routes-wave1200.test.js
+__tests__/my-day-board-wave1204.test.js


### PR DESCRIPTION
Completes the operational cycle. The **supervisor** side (documentation-backlog / productivity / overdue / operations-health / review-worklist) already exists; this adds the **specialist** side — the therapist's own daily **In-Process vs Complete** board (receive task → run session → DOCUMENT → complete).

- `GET /api(/v1)/goals/supervisor-ops/my-day[?date=]` — reuses the existing W1169 `dailyBoardForTherapist` (built, never routed). Returns the caller's clinical sessions folded into workflow states + the awaiting-documentation chase list + delivered minutes + documented rate.
- **Caller-scoped to req.user** (you only ever see YOUR OWN board → no therapistId param → no cross-user IDOR). 401 unauthenticated, date validated, READ-ONLY.
- 8 static-guard assertions; routes-load (562) + sprint-paths green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)