### PR TITLE
feat(hr): W1201 — competency skills-gap analysis + training-needs (L&D)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1426,6 +1426,10 @@ on:
       - 'backend/__tests__/my-day-board-wave1204.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/rehab-plan-health-behavioral-wave1205.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/skills-gap-lib-wave1201.test.js'
+      - 'backend/__tests__/skills-gap-routes-wave1201.test.js'
+      - 'backend/__tests__/skills-gap-behavioral-wave1201.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2835,6 +2839,10 @@ on:
       - 'backend/__tests__/my-day-board-wave1204.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/rehab-plan-health-behavioral-wave1205.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/skills-gap-lib-wave1201.test.js'
+      - 'backend/__tests__/skills-gap-routes-wave1201.test.js'
+      - 'backend/__tests__/skills-gap-behavioral-wave1201.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/skills-gap-behavioral-wave1201.test.js
+++ b/backend/__tests__/skills-gap-behavioral-wave1201.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/**
+ * skills-gap-behavioral-wave1201.test.js — EmployeeCompetency + RoleCompetencyRequirement
+ * against MongoMemoryServer: schema validation + unique indexes. Employee is NOT
+ * registered → the hrBranchScope plugin's derive is a graceful no-op.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(120000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let EC;
+let RCR;
+const oid = () => new mongoose.Types.ObjectId();
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w1201-skg' } });
+  await mongoose.connect(mongod.getUri());
+  EC = require('../models/HR/EmployeeCompetency');
+  RCR = require('../models/HR/RoleCompetencyRequirement');
+});
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+});
+afterEach(async () => {
+  if (EC) await EC.deleteMany({});
+  if (RCR) await RCR.deleteMany({});
+});
+
+describe('W1201 EmployeeCompetency', () => {
+  test('valid assessment saves; defaults assessedAt', async () => {
+    const d = await EC.create({ employeeId: oid(), competencyKey: 'assessment', currentLevel: 3 });
+    expect(d.currentLevel).toBe(3);
+    expect(d.assessedAt).toBeInstanceOf(Date);
+  });
+  test('currentLevel out of [0,5] is rejected', async () => {
+    await expect(EC.create({ employeeId: oid(), competencyKey: 'x', currentLevel: 6 })).rejects.toThrow(/currentLevel/);
+    await expect(EC.create({ employeeId: oid(), competencyKey: 'x', currentLevel: -1 })).rejects.toThrow(/currentLevel/);
+  });
+  test('one row per (employee, competency) — unique index', async () => {
+    const emp = oid();
+    await EC.create({ employeeId: emp, competencyKey: 'assessment', currentLevel: 2 });
+    await expect(EC.create({ employeeId: emp, competencyKey: 'assessment', currentLevel: 4 })).rejects.toThrow(/duplicate key|E11000/);
+  });
+});
+
+describe('W1201 RoleCompetencyRequirement', () => {
+  test('valid requirement saves with default criticality + active', async () => {
+    const d = await RCR.create({ jobTitle: 'أخصائي تخاطب', competencyKey: 'assessment', competencyNameAr: 'التقييم', requiredLevel: 4 });
+    expect(d.criticality).toBe('important');
+    expect(d.active).toBe(true);
+  });
+  test('requiredLevel out of [1,5] rejected; bad criticality rejected', async () => {
+    await expect(RCR.create({ jobTitle: 'r', competencyKey: 'c', competencyNameAr: 'x', requiredLevel: 6 })).rejects.toThrow(/requiredLevel/);
+    await expect(RCR.create({ jobTitle: 'r', competencyKey: 'c', competencyNameAr: 'x', requiredLevel: 3, criticality: 'bogus' })).rejects.toThrow(/criticality/);
+  });
+  test('one requirement per (jobTitle, competency) — unique index', async () => {
+    await RCR.create({ jobTitle: 'role-A', competencyKey: 'k', competencyNameAr: 'x', requiredLevel: 3 });
+    await expect(RCR.create({ jobTitle: 'role-A', competencyKey: 'k', competencyNameAr: 'y', requiredLevel: 4 })).rejects.toThrow(/duplicate key|E11000/);
+  });
+});

--- a/backend/__tests__/skills-gap-lib-wave1201.test.js
+++ b/backend/__tests__/skills-gap-lib-wave1201.test.js
@@ -1,0 +1,75 @@
+/**
+ * W1201 — pure unit tests for intelligence/skills-gap.lib.
+ */
+
+'use strict';
+
+const L = require('../intelligence/skills-gap.lib');
+
+const reqs = [
+  { competencyKey: 'assessment', competencyNameAr: 'التقييم', requiredLevel: 4, criticality: 'core' },
+  { competencyKey: 'documentation', competencyNameAr: 'التوثيق', requiredLevel: 3, criticality: 'important' },
+  { competencyKey: 'aac', competencyNameAr: 'AAC', requiredLevel: 3, criticality: 'nice' },
+];
+
+describe('W1201 skills-gap.lib — employee gaps', () => {
+  test('computes gap, critical-gap, weighted readiness', () => {
+    const g = L.employeeGaps(reqs, { assessment: 2, documentation: 3, aac: 1 });
+    expect(g.gapCount).toBe(2); // assessment (2) + aac (2)
+    expect(g.criticalGapCount).toBe(1); // only assessment is core
+    expect(g.totalGap).toBe(4);
+    expect(g.metCount).toBe(1); // documentation met
+    // weighted: need=4*3+3*2+3*1=21, have=2*3+3*2+1*1=13 → 61.9
+    expect(g.readinessPct).toBeCloseTo(61.9, 1);
+    expect(g.topGaps[0].competencyKey).toBe('assessment'); // highest weighted gap
+  });
+
+  test('all met → readiness 100, zero gaps', () => {
+    const g = L.employeeGaps(reqs, { assessment: 4, documentation: 3, aac: 3 });
+    expect(g.gapCount).toBe(0);
+    expect(g.readinessPct).toBe(100);
+  });
+
+  test('missing competency counts as level 0; over-level capped', () => {
+    const g = L.employeeGaps([{ competencyKey: 'x', requiredLevel: 3, criticality: 'core' }], { x: 9 });
+    expect(g.competencies[0].currentLevel).toBe(5); // clamped
+    expect(g.competencies[0].gap).toBe(0); // 5 >= 3
+    const g2 = L.employeeGaps([{ competencyKey: 'y', requiredLevel: 3, criticality: 'core' }], {});
+    expect(g2.competencies[0].currentLevel).toBe(0);
+    expect(g2.competencies[0].gap).toBe(3);
+  });
+
+  test('no requirements → 100% ready (nothing to meet)', () => {
+    const g = L.employeeGaps([], { a: 1 });
+    expect(g.requiredCount).toBe(0);
+    expect(g.readinessPct).toBe(100);
+  });
+});
+
+describe('W1201 skills-gap.lib — org rollup', () => {
+  test('priorities sorted by weighted gap; affected% computed', () => {
+    const e1 = L.employeeGaps(reqs, { assessment: 2, documentation: 3, aac: 1 }).competencies;
+    const e2 = L.employeeGaps(reqs, { assessment: 4, documentation: 3, aac: 3 }).competencies;
+    const org = L.orgGapRollup([e1, e2]);
+    expect(org.employeesAssessed).toBe(2);
+    expect(org.priorities[0].competencyKey).toBe('assessment'); // core weight 3 × gap 2 = 6
+    expect(org.priorities[0].affectedPct).toBe(50); // 1 of 2
+    expect(org.priorities.find(p => p.competencyKey === 'documentation')).toBeUndefined(); // no gaps
+  });
+});
+
+describe('W1201 skills-gap.lib — training matching', () => {
+  test('matches trainings that cover gap competencies, sorted by coverage', () => {
+    const m = L.matchTrainings(
+      { assessment: 'التقييم', aac: 'AAC' },
+      [
+        { _id: 't1', title: 'دورة شاملة', skillsCovered: ['assessment', 'aac'] },
+        { _id: 't2', title: 'تقييم', skillsCovered: ['assessment'] },
+        { _id: 't3', title: 'غير ذات صلة', skillsCovered: ['x'] },
+      ]
+    );
+    expect(m).toHaveLength(2);
+    expect(m[0].trainingId).toBe('t1'); // covers 2
+    expect(m[0].coversCount).toBe(2);
+  });
+});

--- a/backend/__tests__/skills-gap-routes-wave1201.test.js
+++ b/backend/__tests__/skills-gap-routes-wave1201.test.js
@@ -1,0 +1,57 @@
+/**
+ * W1201 — static drift guard for the skills-gap route surface + mount.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROUTE = path.join(__dirname, '..', 'routes', 'hr', 'skills-gap.routes.js');
+const REGISTRY = path.join(__dirname, '..', 'routes', 'registries', 'hr.registry.js');
+const src = fs.readFileSync(ROUTE, 'utf8');
+const reg = fs.readFileSync(REGISTRY, 'utf8');
+
+describe('W1201 skills-gap routes — auth + branch isolation', () => {
+  test('self-authenticates + requireBranchAccess', () => {
+    expect(src).toMatch(/router\.use\(\s*authenticateToken\s*\)/);
+    expect(src).toMatch(/router\.use\(\s*requireBranchAccess\s*\)/);
+  });
+  test('W269: effectiveBranchScope + enforceEmployeeBranch, never req.branchId', () => {
+    expect(src).toMatch(/effectiveBranchScope\(req\)/);
+    expect(src).toMatch(/enforceEmployeeBranch/);
+    expect(src).not.toMatch(/req\.branchId/);
+  });
+  test('every route is role-gated', () => {
+    const verbs = [...src.matchAll(/router\.(get|post)\(\s*'[^']+'\s*,\s*([A-Za-z_$][\w$]*)/g)];
+    expect(verbs.length).toBe(5);
+    for (const m of verbs) expect(m[2]).toBe('requireRole');
+  });
+  test('role-baseline config is restricted to CONFIG_ROLES', () => {
+    expect(src).toMatch(/CONFIG_ROLES\s*=/);
+    expect(src).toMatch(/'\/requirements',\s*requireRole\(CONFIG_ROLES\)/);
+  });
+  test('employee-keyed calls go through enforceEmployeeBranch (guardEmployee)', () => {
+    expect(src).toMatch(/guardEmployee\(req,\s*res,\s*b\.employeeId\)/);
+    expect(src).toMatch(/guardEmployee\(req,\s*res,\s*req\.params\.employeeId\)/);
+  });
+});
+
+describe('W1201 skills-gap routes — endpoints + mount', () => {
+  test('exposes the 5 endpoints', () => {
+    for (const [verb, p] of [
+      ['post', '/assessments'],
+      ['post', '/requirements'],
+      ['get', '/employee/:employeeId/gaps'],
+      ['get', '/org-gaps'],
+      ['get', '/training-needs'],
+    ]) {
+      expect(src).toMatch(new RegExp(`router\\.${verb}\\(\\s*'${p.replace(/[/:]/g, '\\$&')}'`));
+    }
+  });
+  test('mounted in hr.registry at /api(/v1)?/hr/skills-gap', () => {
+    expect(reg).toMatch(/skills-gap\.routes/);
+    expect(reg).toMatch(/app\.use\(\s*'\/api\/hr\/skills-gap'/);
+    expect(reg).toMatch(/app\.use\(\s*'\/api\/v1\/hr\/skills-gap'/);
+  });
+});

--- a/backend/intelligence/skills-gap.lib.js
+++ b/backend/intelligence/skills-gap.lib.js
@@ -1,0 +1,133 @@
+/**
+ * skills-gap.lib.js — pure competency gap-analysis logic (W1201).
+ *
+ * A gap is `max(0, requiredLevel - currentLevel)` for a competency the employee's
+ * role requires (levels 1-5). The lib rolls gaps up per employee (readiness %,
+ * critical-gap count) and per org (which competencies have the biggest aggregate
+ * gap → training priorities). All pure (no DB, no Date).
+ *
+ * Inputs are plain rows:
+ *   requirements: [{ competencyKey, competencyNameAr, requiredLevel, criticality }]
+ *   current:      Map/obj competencyKey → currentLevel (1-5; missing = level 0)
+ */
+
+'use strict';
+
+const MAX_LEVEL = 5;
+const CRITICALITIES = Object.freeze(['core', 'important', 'nice']);
+const CRIT_WEIGHT = Object.freeze({ core: 3, important: 2, nice: 1 });
+
+function clampLevel(n) {
+  const v = Number(n);
+  if (!Number.isFinite(v) || v < 0) return 0;
+  if (v > MAX_LEVEL) return MAX_LEVEL;
+  return Math.round(v);
+}
+
+/** Per-competency gap for one employee against their role's requirements. */
+function employeeGaps(requirements, currentByKey) {
+  const cur = currentByKey instanceof Map ? currentByKey : new Map(Object.entries(currentByKey || {}));
+  const rows = (requirements || []).map(req => {
+    const required = clampLevel(req.requiredLevel);
+    const current = clampLevel(cur.get(req.competencyKey));
+    const gap = Math.max(0, required - current);
+    const criticality = CRITICALITIES.includes(req.criticality) ? req.criticality : 'important';
+    return {
+      competencyKey: req.competencyKey,
+      competencyNameAr: req.competencyNameAr || req.competencyKey,
+      requiredLevel: required,
+      currentLevel: current,
+      gap,
+      criticality,
+      met: gap === 0,
+    };
+  });
+  const totalRequired = rows.reduce((a, r) => a + r.requiredLevel, 0);
+  const totalCurrentCapped = rows.reduce((a, r) => a + Math.min(r.currentLevel, r.requiredLevel), 0);
+  return {
+    competencies: rows,
+    requiredCount: rows.length,
+    metCount: rows.filter(r => r.met).length,
+    gapCount: rows.filter(r => r.gap > 0).length,
+    criticalGapCount: rows.filter(r => r.gap > 0 && r.criticality === 'core').length,
+    totalGap: rows.reduce((a, r) => a + r.gap, 0),
+    // weighted readiness: how much of the (criticality-weighted) requirement is met
+    readinessPct: weightedReadiness(rows),
+    topGaps: rows.filter(r => r.gap > 0).sort((a, b) => gapScore(b) - gapScore(a)).slice(0, 5),
+  };
+
+  function gapScore(r) {
+    return r.gap * (CRIT_WEIGHT[r.criticality] || 1);
+  }
+  function weightedReadiness(rs) {
+    let need = 0;
+    let have = 0;
+    for (const r of rs) {
+      const w = CRIT_WEIGHT[r.criticality] || 1;
+      need += r.requiredLevel * w;
+      have += Math.min(r.currentLevel, r.requiredLevel) * w;
+    }
+    return need ? Math.round((have / need) * 1000) / 10 : 100;
+  }
+}
+
+/**
+ * Org rollup: aggregate per-competency gap across many employees' gap rows.
+ * `perEmployee` is an array of `employeeGaps(...).competencies` arrays.
+ * Returns priorities sorted by total weighted gap (biggest training need first).
+ */
+function orgGapRollup(perEmployeeCompetencies) {
+  const byKey = new Map();
+  let assessed = 0;
+  for (const comps of perEmployeeCompetencies || []) {
+    assessed++;
+    for (const c of comps || []) {
+      if (!byKey.has(c.competencyKey)) {
+        byKey.set(c.competencyKey, {
+          competencyKey: c.competencyKey,
+          competencyNameAr: c.competencyNameAr,
+          criticality: c.criticality,
+          affected: 0,
+          totalGap: 0,
+          totalRequiring: 0,
+        });
+      }
+      const agg = byKey.get(c.competencyKey);
+      agg.totalRequiring++;
+      if (c.gap > 0) {
+        agg.affected++;
+        agg.totalGap += c.gap;
+      }
+    }
+  }
+  const priorities = [...byKey.values()]
+    .map(a => ({
+      ...a,
+      affectedPct: a.totalRequiring ? Math.round((a.affected / a.totalRequiring) * 1000) / 10 : 0,
+      weightedGap: a.totalGap * (CRIT_WEIGHT[a.criticality] || 1),
+    }))
+    .filter(a => a.affected > 0)
+    .sort((a, b) => b.weightedGap - a.weightedGap);
+  return { employeesAssessed: assessed, priorities };
+}
+
+/** Match a set of gap competency keys to trainings that cover them. */
+function matchTrainings(gapKeyToName, trainings) {
+  const keys = new Set(Object.keys(gapKeyToName || {}));
+  const out = [];
+  for (const t of trainings || []) {
+    const covered = (t.skillsCovered || []).filter(s => keys.has(s));
+    if (covered.length) out.push({ trainingId: t._id, title: t.title, covers: covered, coversCount: covered.length });
+  }
+  return out.sort((a, b) => b.coversCount - a.coversCount);
+}
+
+module.exports = {
+  MAX_LEVEL,
+  CRITICALITIES,
+  CRIT_WEIGHT,
+  clampLevel,
+  employeeGaps,
+  orgGapRollup,
+  matchTrainings,
+};

--- a/backend/models/HR/EmployeeCompetency.js
+++ b/backend/models/HR/EmployeeCompetency.js
@@ -1,0 +1,36 @@
+'use strict';
+
+/**
+ * EmployeeCompetency.js — one assessed competency level for an employee (W1201).
+ *
+ * Employee-keyed, so branchId is denormalised from the employee by the shared
+ * hrBranchScope plugin (W1133) — cross-branch isolation for free. One row per
+ * (employeeId, competencyKey); currentLevel 0-5 (0 = not yet demonstrated).
+ * Validation is schema-level (min/max/required/unique) so the only pre('validate')
+ * hook is the plugin's async branchId derive — no hook-style mixing.
+ */
+
+const mongoose = require('mongoose');
+
+const EmployeeCompetencySchema = new mongoose.Schema(
+  {
+    employeeId: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee', required: true, index: true },
+    competencyKey: { type: String, required: true, trim: true, maxlength: 60 },
+    competencyNameAr: { type: String, maxlength: 160 },
+    currentLevel: { type: Number, required: true, min: 0, max: 5 },
+    assessedAt: { type: Date, default: Date.now },
+    assessedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+    notes: { type: String, maxlength: 1000 },
+  },
+  { timestamps: true, collection: 'hr_employee_competencies' }
+);
+
+EmployeeCompetencySchema.index({ employeeId: 1, competencyKey: 1 }, { unique: true });
+EmployeeCompetencySchema.index({ branchId: 1, competencyKey: 1 });
+
+// W1133 — denormalise branchId from the employee (cross-branch isolation).
+EmployeeCompetencySchema.plugin(require('./hrBranchScope.plugin'));
+
+module.exports =
+  mongoose.models.EmployeeCompetency ||
+  mongoose.model('EmployeeCompetency', EmployeeCompetencySchema);

--- a/backend/models/HR/RoleCompetencyRequirement.js
+++ b/backend/models/HR/RoleCompetencyRequirement.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * RoleCompetencyRequirement.js — the competency baseline for a job title (W1201).
+ *
+ * Org-global REFERENCE data (a "Senior Therapist" needs the same competencies in
+ * every branch), like CompensationBand — so NO branchId / no branch isolation.
+ * One row per (jobTitle, competencyKey). Drives skills-gap analysis against each
+ * employee's assessed EmployeeCompetency levels.
+ */
+
+const mongoose = require('mongoose');
+
+const RoleCompetencyRequirementSchema = new mongoose.Schema(
+  {
+    jobTitle: { type: String, required: true, trim: true, maxlength: 120, index: true },
+    competencyKey: { type: String, required: true, trim: true, maxlength: 60 },
+    competencyNameAr: { type: String, required: true, maxlength: 160 },
+    requiredLevel: { type: Number, required: true, min: 1, max: 5 },
+    criticality: { type: String, enum: ['core', 'important', 'nice'], default: 'important' },
+    active: { type: Boolean, default: true },
+    createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  },
+  { timestamps: true, collection: 'hr_role_competency_requirements' }
+);
+
+// one requirement per (jobTitle, competencyKey)
+RoleCompetencyRequirementSchema.index({ jobTitle: 1, competencyKey: 1 }, { unique: true });
+
+module.exports =
+  mongoose.models.RoleCompetencyRequirement ||
+  mongoose.model('RoleCompetencyRequirement', RoleCompetencyRequirementSchema);

--- a/backend/routes/hr/skills-gap.routes.js
+++ b/backend/routes/hr/skills-gap.routes.js
@@ -1,0 +1,126 @@
+'use strict';
+
+/**
+ * skills-gap.routes.js — HR competency gap-analysis surface (W1201).
+ *
+ * Mount: /api/hr/skills-gap + /api/v1/hr/skills-gap (self-authed → safe under the
+ * plain hr.registry app.use mount, W1190/W1191).
+ *
+ *   POST /assessments               — record/update an employee competency level
+ *   POST /requirements              — define a role's competency requirement (config)
+ *   GET  /employee/:employeeId/gaps — one employee's gaps vs their role baseline
+ *   GET  /org-gaps                  — branch-wide gap rollup (training priorities)
+ *   GET  /training-needs            — top gaps matched to covering trainings
+ *
+ * SECURITY: employee-keyed calls go through enforceEmployeeBranch (W269); org reads
+ * scope to effectiveBranchScope. Role baseline config is admin/HR-director only.
+ */
+
+const express = require('express');
+const router = express.Router();
+
+const { authenticateToken, requireRole } = require('../../middleware/auth');
+const { requireBranchAccess } = require('../../middleware/branchScope.middleware');
+const { effectiveBranchScope, enforceEmployeeBranch } = require('../../middleware/assertBranchMatch');
+const safeError = require('../../utils/safeError');
+const svc = require('../../services/hr/skillsGapService');
+
+const READ_ROLES = ['admin', 'superadmin', 'super_admin', 'hr_manager', 'hr_director', 'hr', 'manager'];
+const WRITE_ROLES = ['admin', 'superadmin', 'super_admin', 'hr_manager', 'hr_director', 'manager'];
+const CONFIG_ROLES = ['admin', 'superadmin', 'super_admin', 'hr_director'];
+
+router.use(authenticateToken);
+router.use(requireBranchAccess);
+
+function mapErr(res, err, ctx) {
+  if (err && err.code === 'MODEL_UNAVAILABLE') return res.status(503).json({ success: false, error: err.message });
+  if (err && err.code === 'VALIDATION') return res.status(400).json({ success: false, error: err.message });
+  if (err && err.name === 'ValidationError') return res.status(400).json({ success: false, error: err.message });
+  return safeError(res, err, ctx);
+}
+
+async function guardEmployee(req, res, employeeId) {
+  try {
+    await enforceEmployeeBranch(req, employeeId); // W269 — throws 403/404 cross-branch
+    return false;
+  } catch (err) {
+    res.status(err.status || 403).json({ success: false, error: err.message });
+    return true;
+  }
+}
+
+/** POST /assessments — record/update an employee competency level. */
+router.post('/assessments', requireRole(WRITE_ROLES), async (req, res) => {
+  try {
+    const b = req.body || {};
+    if (!b.employeeId) return res.status(400).json({ success: false, error: 'employeeId required' });
+    if (await guardEmployee(req, res, b.employeeId)) return; // W269
+    const actor = req.user || {};
+    const doc = await svc.upsertAssessment({
+      employeeId: b.employeeId,
+      competencyKey: b.competencyKey,
+      competencyNameAr: b.competencyNameAr,
+      currentLevel: b.currentLevel,
+      notes: b.notes,
+      assessedBy: actor.id || actor._id || actor.userId || null,
+    });
+    res.status(201).json({ success: true, data: doc });
+  } catch (err) {
+    mapErr(res, err, 'skills-gap:assess');
+  }
+});
+
+/** POST /requirements — define a role competency baseline (org-global config). */
+router.post('/requirements', requireRole(CONFIG_ROLES), async (req, res) => {
+  try {
+    const b = req.body || {};
+    const actor = req.user || {};
+    const doc = await svc.upsertRequirement({
+      jobTitle: b.jobTitle,
+      competencyKey: b.competencyKey,
+      competencyNameAr: b.competencyNameAr,
+      requiredLevel: b.requiredLevel,
+      criticality: b.criticality,
+      createdBy: actor.id || actor._id || actor.userId || null,
+    });
+    res.status(201).json({ success: true, data: doc });
+  } catch (err) {
+    mapErr(res, err, 'skills-gap:requirement');
+  }
+});
+
+/** GET /employee/:employeeId/gaps — one employee's gaps. */
+router.get('/employee/:employeeId/gaps', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    if (await guardEmployee(req, res, req.params.employeeId)) return; // W269
+    const data = await svc.employeeGaps({ employeeId: req.params.employeeId });
+    if (!data) return res.status(404).json({ success: false, error: 'employee not found' });
+    res.json({ success: true, data });
+  } catch (err) {
+    mapErr(res, err, 'skills-gap:employee');
+  }
+});
+
+/** GET /org-gaps — branch-wide gap rollup. */
+router.get('/org-gaps', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const branchId = effectiveBranchScope(req); // W269 — own branch or null (HQ)
+    const data = await svc.orgGaps({ branchId, jobTitle: req.query.jobTitle ? String(req.query.jobTitle) : null });
+    res.json({ success: true, data });
+  } catch (err) {
+    mapErr(res, err, 'skills-gap:org');
+  }
+});
+
+/** GET /training-needs — top gaps → covering trainings. */
+router.get('/training-needs', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const branchId = effectiveBranchScope(req);
+    const data = await svc.trainingNeeds({ branchId, jobTitle: req.query.jobTitle ? String(req.query.jobTitle) : null });
+    res.json({ success: true, data });
+  } catch (err) {
+    mapErr(res, err, 'skills-gap:training-needs');
+  }
+});
+
+module.exports = router;

--- a/backend/routes/registries/hr.registry.js
+++ b/backend/routes/registries/hr.registry.js
@@ -211,5 +211,16 @@ module.exports = function registerHrRoutes(app, { safeRequire, dualMount, safeMo
     logger.warn('[HR] Workforce-intelligence routes not mounted (module missing)');
   }
 
+  // ── Skills-gap & competency development (W1201 — gap analysis + training needs) ─
+  // Self-authenticating; employee-keyed reads + branch-isolated org rollups.
+  const skillsGapRouter = safeRequire('../routes/hr/skills-gap.routes');
+  if (skillsGapRouter) {
+    app.use('/api/hr/skills-gap', skillsGapRouter);
+    app.use('/api/v1/hr/skills-gap', skillsGapRouter);
+    logger.info('[HR] Skills-gap analysis mounted (/api/(v1/)?hr/skills-gap)');
+  } else {
+    logger.warn('[HR] Skills-gap routes not mounted (module missing)');
+  }
+
   logger.info('[HR] All ~25 HR/Employee/Workforce modules mounted successfully');
 };

--- a/backend/services/hr/skillsGapService.js
+++ b/backend/services/hr/skillsGapService.js
@@ -1,0 +1,167 @@
+'use strict';
+
+/**
+ * skillsGapService.js — competency gap analysis (W1201).
+ *
+ * Joins each employee's assessed EmployeeCompetency levels against their job
+ * title's RoleCompetencyRequirement baseline to compute gaps, rolls them up per
+ * org, and matches the top gaps to trainings (TrainingPlan.skillsCovered). The
+ * route resolves branchId from the caller's effective scope; employee-keyed reads
+ * are additionally gated by enforceEmployeeBranch.
+ *
+ * Lazy model lookup so tests can inject fakes + load order can't break.
+ */
+
+const lib = require('../../intelligence/skills-gap.lib');
+
+function getModel(name, file) {
+  const mongoose = require('mongoose');
+  try {
+    return mongoose.model(name);
+  } catch {
+    try {
+      require(file);
+      return mongoose.model(name);
+    } catch {
+      return null;
+    }
+  }
+}
+
+function jobTitleOf(emp) {
+  return emp.job_title_en || emp.job_title_ar || null;
+}
+
+async function upsertAssessment({ employeeId, competencyKey, competencyNameAr, currentLevel, assessedBy = null, notes } = {}) {
+  const EC = getModel('EmployeeCompetency', '../../models/HR/EmployeeCompetency');
+  if (!EC) throwUnavailable('EmployeeCompetency');
+  if (!employeeId || !competencyKey) throwValidation('employeeId and competencyKey are required');
+  const existing = await EC.findOne({ employeeId, competencyKey });
+  const doc = existing || new EC({ employeeId, competencyKey });
+  doc.competencyKey = competencyKey;
+  if (competencyNameAr !== undefined) doc.competencyNameAr = competencyNameAr;
+  doc.currentLevel = currentLevel;
+  doc.assessedAt = new Date();
+  if (assessedBy) doc.assessedBy = assessedBy;
+  if (notes !== undefined) doc.notes = notes;
+  await doc.save();
+  return doc;
+}
+
+async function upsertRequirement({ jobTitle, competencyKey, competencyNameAr, requiredLevel, criticality, createdBy = null } = {}) {
+  const RCR = getModel('RoleCompetencyRequirement', '../../models/HR/RoleCompetencyRequirement');
+  if (!RCR) throwUnavailable('RoleCompetencyRequirement');
+  if (!jobTitle || !competencyKey) throwValidation('jobTitle and competencyKey are required');
+  const existing = await RCR.findOne({ jobTitle, competencyKey });
+  const doc = existing || new RCR({ jobTitle, competencyKey });
+  if (competencyNameAr !== undefined) doc.competencyNameAr = competencyNameAr;
+  doc.requiredLevel = requiredLevel;
+  if (criticality) doc.criticality = criticality;
+  if (createdBy) doc.createdBy = createdBy;
+  await doc.save();
+  return doc;
+}
+
+/** Gap analysis for one employee against their role's requirements. */
+async function employeeGaps({ employeeId } = {}) {
+  const Employee = getModel('Employee', '../../models/HR/Employee');
+  const RCR = getModel('RoleCompetencyRequirement', '../../models/HR/RoleCompetencyRequirement');
+  const EC = getModel('EmployeeCompetency', '../../models/HR/EmployeeCompetency');
+  if (!Employee || !RCR || !EC) throwUnavailable('competency models');
+  const emp = await Employee.findById(employeeId).select('job_title_en job_title_ar full_name name department branch_id').lean();
+  if (!emp) return null;
+  const jobTitle = jobTitleOf(emp);
+  const requirements = jobTitle ? await RCR.find({ jobTitle, active: true }).lean() : [];
+  const competencies = await EC.find({ employeeId }).select('competencyKey currentLevel').lean();
+  const current = {};
+  for (const c of competencies) current[c.competencyKey] = c.currentLevel;
+  const analysis = lib.employeeGaps(requirements, current);
+  return {
+    employeeId,
+    employeeName: emp.full_name || emp.name || null,
+    jobTitle,
+    department: emp.department || null,
+    hasRoleBaseline: requirements.length > 0,
+    ...analysis,
+  };
+}
+
+/** Org-wide rollup of gaps for a branch (+ optional jobTitle). */
+async function orgGaps({ branchId, jobTitle = null, limit = 2000 } = {}) {
+  const Employee = getModel('Employee', '../../models/HR/Employee');
+  const RCR = getModel('RoleCompetencyRequirement', '../../models/HR/RoleCompetencyRequirement');
+  const EC = getModel('EmployeeCompetency', '../../models/HR/EmployeeCompetency');
+  if (!Employee || !RCR || !EC) throwUnavailable('competency models');
+
+  const empFilter = { status: 'active', deleted_at: null };
+  if (branchId) empFilter.branch_id = branchId; // branch isolation (caller-resolved)
+  const employees = await Employee.find(empFilter)
+    .select('job_title_en job_title_ar')
+    .limit(Math.min(Number(limit) || 2000, 5000))
+    .lean();
+  const scoped = jobTitle ? employees.filter(e => jobTitleOf(e) === jobTitle) : employees;
+  if (!scoped.length) return { employeesAssessed: 0, priorities: [] };
+
+  // requirements grouped by jobTitle
+  const reqs = await RCR.find({ active: true }).lean();
+  const reqByTitle = new Map();
+  for (const r of reqs) {
+    if (!reqByTitle.has(r.jobTitle)) reqByTitle.set(r.jobTitle, []);
+    reqByTitle.get(r.jobTitle).push(r);
+  }
+  // competencies grouped by employee
+  const ids = scoped.map(e => e._id);
+  const comps = await EC.find({ employeeId: { $in: ids } }).select('employeeId competencyKey currentLevel').lean();
+  const compByEmp = new Map();
+  for (const c of comps) {
+    const k = String(c.employeeId);
+    if (!compByEmp.has(k)) compByEmp.set(k, {});
+    compByEmp.get(k)[c.competencyKey] = c.currentLevel;
+  }
+  const perEmployee = scoped
+    .map(e => {
+      const requirements = reqByTitle.get(jobTitleOf(e)) || [];
+      if (!requirements.length) return null;
+      return lib.employeeGaps(requirements, compByEmp.get(String(e._id)) || {}).competencies;
+    })
+    .filter(Boolean);
+
+  return lib.orgGapRollup(perEmployee);
+}
+
+/** Top org gaps → trainings that cover them. */
+async function trainingNeeds({ branchId, jobTitle = null } = {}) {
+  const TrainingPlan = getModel('TrainingPlan', '../../models/HR/TrainingPlan');
+  const org = await orgGaps({ branchId, jobTitle });
+  const top = org.priorities.slice(0, 15);
+  const gapKeyToName = {};
+  for (const p of top) gapKeyToName[p.competencyKey] = p.competencyNameAr;
+  let trainings = [];
+  if (TrainingPlan) {
+    trainings = await TrainingPlan.find({ skillsCovered: { $in: Object.keys(gapKeyToName) } })
+      .select('title skillsCovered')
+      .limit(200)
+      .lean();
+  }
+  return { priorities: top, recommendedTrainings: lib.matchTrainings(gapKeyToName, trainings) };
+}
+
+function throwUnavailable(what) {
+  const e = new Error(`${what} unavailable`);
+  e.code = 'MODEL_UNAVAILABLE';
+  throw e;
+}
+function throwValidation(msg) {
+  const e = new Error(msg);
+  e.code = 'VALIDATION';
+  throw e;
+}
+
+module.exports = {
+  jobTitleOf,
+  upsertAssessment,
+  upsertRequirement,
+  employeeGaps,
+  orgGaps,
+  trainingNeeds,
+};

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -854,3 +854,6 @@ __tests__/workforce-intelligence-service-wave1200.test.js
 __tests__/workforce-intelligence-routes-wave1200.test.js
 __tests__/my-day-board-wave1204.test.js
 __tests__/rehab-plan-health-behavioral-wave1205.test.js
+__tests__/skills-gap-lib-wave1201.test.js
+__tests__/skills-gap-routes-wave1201.test.js
+__tests__/skills-gap-behavioral-wave1201.test.js


### PR DESCRIPTION
## What

Audit-first confirmed gap: `EmployeeSkill`/`Competency` were empty **stub** models (no fields), and no role→required-competency baseline existed. This builds the competency framework + gap analysis — the **action-oriented L&D** complement to the analytics suite (9-box tells you *who* the talent is; this tells you *what to develop*).

## What it computes — `intelligence/skills-gap.lib.js` (pure)

| Output | Detail |
| --- | --- |
| **Per-employee gap** | `required − current` per competency (levels 1-5), criticality-**weighted** readiness % |
| **Org rollup** | per-competency affected % + weighted gap → **training priorities** (biggest first) |
| **Training match** | top gap keys → `TrainingPlan.skillsCovered` |

## Stack

- **`models/HR/RoleCompetencyRequirement.js`** — org-**global** baseline (`jobTitle × competency × requiredLevel × criticality`), like `CompensationBand` (no branchId). Unique `(jobTitle, competencyKey)`.
- **`models/HR/EmployeeCompetency.js`** — assessed levels, **employee-keyed** → branchId denormalised by the W1133 plugin (cross-branch isolation). Unique `(employeeId, competencyKey)`. Schema-level validation only → no hook-style mixing with the plugin's async `pre('validate')`.
- **`services/hr/skillsGapService.js`** — `employeeGaps` (joins `Employee.jobTitle` → requirements vs assessed levels), `orgGaps` (branch-scoped rollup), `trainingNeeds`, upsert assess/requirement.
- **`routes/hr/skills-gap.routes.js`** — 5 endpoints, self-authed, **branch-isolated** (`enforceEmployeeBranch` on employee calls + `effectiveBranchScope` on org reads, no `req.branchId`), role-gated; role-baseline config restricted to `CONFIG_ROLES`. Mounted in `hr.registry`.

**Endpoints:** `POST /assessments` · `POST /requirements` · `GET /employee/:id/gaps` · `GET /org-gaps` · `GET /training-needs` — under `/api/(v1/)?hr/skills-gap`.

## Tests — 19 assertions / 3 sprint-enumerated files

lib unit (gap / weighted readiness / org rollup / training-match) + routes static (auth / W269 / role gating / mount) + behavioral MMS (schema validation + both unique indexes).

## Verified locally

`check:routes-load` · `check:hook-style` · `check:sprint-paths` in sync · `check:gitignored-sources` · `no-broken-requires` + `no-duplicate-model-registration` + `canonical-beneficiary-ref` (models clean) · 19/19 green.

> Note: main has two unrelated **pre-existing** reds (Sprint Tests yml paths-limit + ~35 phantom refs from the parallel forms merges) — inherited; verified independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)