### PR TITLE
fix(auth): W1221 — login 500 on wrong password (Mongoose 9 updatePipeline) + behavioral guard

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1430,6 +1430,8 @@ on:
       - 'backend/__tests__/skills-gap-lib-wave1201.test.js'
       - 'backend/__tests__/skills-gap-routes-wave1201.test.js'
       - 'backend/__tests__/skills-gap-behavioral-wave1201.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/user-login-attempts-behavioral-wave1221.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2843,6 +2845,8 @@ on:
       - 'backend/__tests__/skills-gap-lib-wave1201.test.js'
       - 'backend/__tests__/skills-gap-routes-wave1201.test.js'
       - 'backend/__tests__/skills-gap-behavioral-wave1201.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/user-login-attempts-behavioral-wave1221.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/user-login-attempts-behavioral-wave1221.test.js
+++ b/backend/__tests__/user-login-attempts-behavioral-wave1221.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+/**
+ * user-login-attempts-behavioral-wave1221.test.js — User.incLoginAttempts
+ * against MongoMemoryServer (real Mongoose driver, NO mocks).
+ *
+ * Behavioral counterpart to the W435 static/mocked drift guard. The W435
+ * suite mocks findOneAndUpdate, so it kept passing while Mongoose 9
+ * rejected the aggregation-pipeline array update at runtime
+ * ("Cannot pass an array to query updates unless the `updatePipeline`
+ * option is set") — every wrong-password login on prod returned 500
+ * from 2026-05-29 until the W1221 fix, and the brute-force counter
+ * never incremented. This suite calls the real method end-to-end so any
+ * future driver-level rejection of the pipeline update fails CI.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(120000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let User;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w1221-login-attempts' } });
+  await mongoose.connect(mongod.getUri());
+  User = require('../models/User');
+});
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+});
+afterEach(async () => {
+  if (User) await User.deleteMany({});
+});
+
+const baseUser = (over = {}) => ({
+  fullName: 'مستخدم اختبار',
+  email: `w1221-${new mongoose.Types.ObjectId().toString()}@test.local`,
+  password: 'Str0ng!Passw0rd',
+  ...over,
+});
+
+describe('W1221 User.incLoginAttempts — real-driver behavioral contract', () => {
+  test('resolves (no Mongoose-9 pipeline rejection) and increments 0 → 1', async () => {
+    const u = await User.create(baseUser());
+    const updated = await u.incLoginAttempts();
+    expect(updated).not.toBeNull();
+    expect(updated.failedLoginAttempts).toBe(1);
+    expect(updated.lockUntil ?? null).toBeNull();
+  });
+
+  test('5th consecutive failure sets lockUntil in the future (account locked)', async () => {
+    const u = await User.create(baseUser());
+    for (let i = 0; i < 5; i++) {
+      await u.incLoginAttempts();
+    }
+    const row = await User.findById(u._id).select('+failedLoginAttempts +lockUntil');
+    expect(row.failedLoginAttempts).toBe(5);
+    expect(row.lockUntil).toBeInstanceOf(Date);
+    expect(row.lockUntil.getTime()).toBeGreaterThan(Date.now());
+    expect(row.isLocked).toBe(true);
+  });
+
+  test('expired lock → next failure resets counter to 1 and clears the stale lock', async () => {
+    const u = await User.create(baseUser());
+    await User.updateOne(
+      { _id: u._id },
+      { $set: { failedLoginAttempts: 5, lockUntil: new Date(Date.now() - 60_000) } }
+    );
+    const updated = await u.incLoginAttempts();
+    expect(updated.failedLoginAttempts).toBe(1);
+    expect(updated.lockUntil ?? null).toBeNull();
+  });
+
+  test('resetLoginAttempts clears counter and lock', async () => {
+    const u = await User.create(baseUser());
+    await u.incLoginAttempts();
+    await u.incLoginAttempts();
+    await u.resetLoginAttempts();
+    const row = await User.findById(u._id).select('+failedLoginAttempts +lockUntil');
+    expect(row.failedLoginAttempts).toBe(0);
+    expect(row.lockUntil ?? null).toBeNull();
+    expect(row.isLocked).toBe(false);
+  });
+});

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -359,7 +359,15 @@ userSchema.methods.incLoginAttempts = async function () {
         },
       },
     ],
-    { returnDocument: 'after', projection: { failedLoginAttempts: 1, lockUntil: 1 } }
+    // Mongoose 9 refuses array (aggregation-pipeline) updates unless
+    // `updatePipeline: true` is passed — without it every wrong-password
+    // login threw MongooseError and the route returned 500 (and the
+    // brute-force counter never incremented).
+    {
+      returnDocument: 'after',
+      projection: { failedLoginAttempts: 1, lockUntil: 1 },
+      updatePipeline: true,
+    }
   );
 
   if (!updated) return null;

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -857,3 +857,4 @@ __tests__/rehab-plan-health-behavioral-wave1205.test.js
 __tests__/skills-gap-lib-wave1201.test.js
 __tests__/skills-gap-routes-wave1201.test.js
 __tests__/skills-gap-behavioral-wave1201.test.js
+__tests__/user-login-attempts-behavioral-wave1221.test.js


### PR DESCRIPTION
## The bug (prod, live since ~2026-05-29)

Since the Mongoose 9 upgrade, `User.incLoginAttempts` (the W435 race-free aggregation-pipeline `findOneAndUpdate`) throws:

> Cannot pass an array to query updates unless the `updatePipeline` option is set

so **every wrong-password login for an existing user returns 500** (instead of 401), and the brute-force counter/lockout never increments. Combined with the legacy frontend's silent demo-data fallbacks, the owner has had **no successful login since 2026-05-29** — which is why the recently seeded ready-form templates (W1179) appeared 'invisible' again: the page was rendering the hardcoded fallback list for an unauthenticated session.

Prod evidence: `error.log` 2026-05-29 04:51+ — MongooseError at `models/User.js:319` via `api/routes/auth.routes.js:204`; zero authenticated traffic in retained logs since.

## Fix

Pass `updatePipeline: true` (Mongoose 9 contract) at the single pipeline-update call site in the codebase (verified via `$$NOW` sweep).

## Guard

`user-login-attempts-behavioral-wave1221.test.js` — runs `incLoginAttempts` against a **real MongoMemoryServer** (the W435 suite mocks `findOneAndUpdate`, so it kept passing through the runtime break): increment 0→1, 5-failure lock, expired-lock reset-to-1, `resetLoginAttempts`. 4 tests, verified red without the fix, enumerated in sprint-tests.txt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)