### PR TITLE
fix(test): W1222 — deflake wave1205 behavioral suite (autoIndex race → E11000; deploy gate red since PR #392)

### DIFF
--- a/backend/__tests__/rehab-plan-health-behavioral-wave1205.test.js
+++ b/backend/__tests__/rehab-plan-health-behavioral-wave1205.test.js
@@ -46,6 +46,13 @@ beforeAll(async () => {
   CarePlanVersion = cpvMod.CarePlanVersion || cpvMod;
   TherapeuticGoal = require('../domains/goals/models/TherapeuticGoal').TherapeuticGoal;
   svc = require('../services/rehabPlanHealth.service');
+  // Build indexes NOW instead of racing autoIndex: on CI the unique
+  // {planId, versionNumber} index finished building before seedPlan's raw
+  // inserts and two index-key-less docs collided on {null, null} (E11000);
+  // locally the inserts won the race and the suite stayed green. Forcing
+  // init() makes every environment behave like CI.
+  await CarePlanVersion.init();
+  await TherapeuticGoal.init();
 }, 60000);
 
 afterAll(async () => {
@@ -60,6 +67,10 @@ beforeEach(async () => {
 
 async function seedPlan({ beneficiaryId, branchId, status = 'approved', nextReviewAt, planType = 'individual_therapy' }) {
   await CarePlanVersion.collection.insertOne({
+    // unique per doc — the collection has a unique {planId, versionNumber}
+    // index, and omitting both makes every seeded doc key {null, null}
+    planId: new mongoose.Types.ObjectId(),
+    versionNumber: 1,
     beneficiaryId,
     branchId,
     status,


### PR DESCRIPTION
## Why every main deploy has failed since PR #392

The W1205 behavioral suite seeds `CarePlanVersion` docs via raw `collection.insertOne` **without** `planId`/`versionNumber`. The collection carries a unique `{planId: 1, versionNumber: -1}` index that autoIndex builds asynchronously after connect:

- **CI**: index build finishes before the seeds → second key-less doc collides on `{null, null}` → `E11000` → 2 tests fail → test gate red → **Deploy-to-VPS skipped on every merge since #392** (prod frozen at `23033f072`).
- **Local**: seeds win the race → suite green → invisible to authors.

## Fix

1. Seed a unique `planId` + `versionNumber` per doc.
2. Force `Model.init()` in `beforeAll` so every environment behaves like CI (kills the race both ways).

## Verification

- With `init()` forced and the old seeds: the **exact CI E11000 reproduces locally** (same 2 tests).
- With the fix: 6/6 green.

Unblocks the W1221 login-500 fix (PR #394) and everything since #390 from reaching prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)