### PR TITLE
feat(hr): W1203 — data-driven headcount planning & forecasting (workforce supply)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1434,6 +1434,10 @@ on:
       - 'backend/__tests__/user-login-attempts-behavioral-wave1221.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/seed-hr-intelligence-wave1202.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/headcount-forecast-lib-wave1203.test.js'
+      - 'backend/__tests__/headcount-planning-routes-wave1203.test.js'
+      - 'backend/__tests__/headcount-plan-behavioral-wave1203.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -2851,6 +2855,10 @@ on:
       - 'backend/__tests__/user-login-attempts-behavioral-wave1221.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/seed-hr-intelligence-wave1202.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/headcount-forecast-lib-wave1203.test.js'
+      - 'backend/__tests__/headcount-planning-routes-wave1203.test.js'
+      - 'backend/__tests__/headcount-plan-behavioral-wave1203.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/headcount-forecast-lib-wave1203.test.js
+++ b/backend/__tests__/headcount-forecast-lib-wave1203.test.js
@@ -1,0 +1,54 @@
+/**
+ * W1203 — pure unit tests for intelligence/headcount-forecast.lib.
+ */
+
+'use strict';
+
+const L = require('../intelligence/headcount-forecast.lib');
+
+describe('W1203 headcount-forecast.lib — forecast', () => {
+  test('compound survivors + hiring need to reach a growth target', () => {
+    const f = L.forecastHeadcount({ current: 100, target: 120, attritionRatePct: 10, periods: 3 });
+    expect(f.survivors).toBe(73); // 100 × 0.9^3 = 72.9
+    expect(f.attritionLosses).toBe(27);
+    expect(f.growthHires).toBe(20); // 120 − 100
+    expect(f.replacementHires).toBe(27);
+    expect(f.totalHiringNeed).toBe(47);
+    expect(f.gapToTargetNoAction).toBe(47); // 120 − 73
+    expect(f.trajectory.map(t => t.headcount)).toEqual([100, 90, 81, 73]);
+    expect(f.annualHiringPace).toBe(16); // 47/3
+  });
+
+  test('no attrition + no growth → zero hiring need', () => {
+    const f = L.forecastHeadcount({ current: 50, attritionRatePct: 0, periods: 2 });
+    expect(f.survivors).toBe(50);
+    expect(f.target).toBe(50); // defaults to current
+    expect(f.totalHiringNeed).toBe(0);
+  });
+
+  test('shrinking target → growthHires 0 (never negative)', () => {
+    const f = L.forecastHeadcount({ current: 100, target: 80, attritionRatePct: 20, periods: 1 });
+    expect(f.growthHires).toBe(0); // target < current
+    expect(f.survivors).toBe(80); // 100 × 0.8
+  });
+
+  test('clamps out-of-range inputs', () => {
+    const f = L.forecastHeadcount({ current: -5, target: 10, attritionRatePct: 150, periods: 99 });
+    expect(f.current).toBe(0);
+    expect(f.attritionRatePct).toBe(100);
+    expect(f.periods).toBe(10);
+    expect(L.clampPct(-3)).toBe(0);
+    expect(L.clampInt(0, 1, 10)).toBe(1);
+  });
+});
+
+describe('W1203 headcount-forecast.lib — rollup', () => {
+  test('sums hiring need across units', () => {
+    const a = L.forecastHeadcount({ current: 100, target: 120, attritionRatePct: 10, periods: 3 });
+    const b = L.forecastHeadcount({ current: 40, target: 50, attritionRatePct: 5, periods: 3 });
+    const r = L.rollupPlans([a, b]);
+    expect(r.units).toBe(2);
+    expect(r.current).toBe(140);
+    expect(r.totalHiringNeed).toBe(a.totalHiringNeed + b.totalHiringNeed);
+  });
+});

--- a/backend/__tests__/headcount-plan-behavioral-wave1203.test.js
+++ b/backend/__tests__/headcount-plan-behavioral-wave1203.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+/**
+ * headcount-plan-behavioral-wave1203.test.js — HeadcountPlan against MongoMemoryServer:
+ * valid save + Wave-18 invariants (on save AND update-save).
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(120000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let Plan;
+const oid = () => new mongoose.Types.ObjectId();
+
+function base(over = {}) {
+  return {
+    branchId: oid(),
+    department: 'PT',
+    planLabel: '2026',
+    currentHeadcount: 100,
+    targetHeadcount: 120,
+    attritionRatePct: 10,
+    periods: 3,
+    forecast: { totalHiringNeed: 47 },
+    ...over,
+  };
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w1203-hcp' } });
+  await mongoose.connect(mongod.getUri());
+  Plan = require('../models/HR/HeadcountPlan');
+});
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+});
+
+describe('W1203 HeadcountPlan — happy path', () => {
+  test('a valid plan saves with defaults', async () => {
+    const d = await Plan.create(base());
+    expect(d._id).toBeDefined();
+    expect(d.status).toBe('draft');
+    expect(d.forecast.totalHiringNeed).toBe(47);
+  });
+});
+
+describe('W1203 HeadcountPlan — Wave-18 invariants', () => {
+  test('attritionRatePct out of [0,100] rejected', async () => {
+    await expect(Plan.create(base({ attritionRatePct: 150 }))).rejects.toThrow(/attritionRatePct/);
+  });
+  test('periods out of [1,10] rejected', async () => {
+    await expect(Plan.create(base({ periods: 0 }))).rejects.toThrow(/periods/);
+    await expect(Plan.create(base({ periods: 11 }))).rejects.toThrow(/periods/);
+  });
+  test('negative headcounts rejected', async () => {
+    await expect(Plan.create(base({ targetHeadcount: -5 }))).rejects.toThrow(/targetHeadcount/);
+    await expect(Plan.create(base({ currentHeadcount: -1 }))).rejects.toThrow(/currentHeadcount/);
+  });
+  test('invariants fire on UPDATE-save too (markModified)', async () => {
+    const d = await Plan.create(base());
+    d.attritionRatePct = 999;
+    await expect(d.save()).rejects.toThrow(/attritionRatePct/);
+  });
+});

--- a/backend/__tests__/headcount-planning-routes-wave1203.test.js
+++ b/backend/__tests__/headcount-planning-routes-wave1203.test.js
@@ -1,0 +1,48 @@
+/**
+ * W1203 — static drift guard for the headcount-planning route surface + mount.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROUTE = path.join(__dirname, '..', 'routes', 'hr', 'headcount-planning.routes.js');
+const REGISTRY = path.join(__dirname, '..', 'routes', 'registries', 'hr.registry.js');
+const src = fs.readFileSync(ROUTE, 'utf8');
+const reg = fs.readFileSync(REGISTRY, 'utf8');
+
+describe('W1203 headcount-planning routes — auth + isolation', () => {
+  test('self-authenticates + requireBranchAccess', () => {
+    expect(src).toMatch(/router\.use\(\s*authenticateToken\s*\)/);
+    expect(src).toMatch(/router\.use\(\s*requireBranchAccess\s*\)/);
+  });
+  test('W269: effectiveBranchScope, never req.branchId', () => {
+    expect(src).toMatch(/effectiveBranchScope\(req\)/);
+    expect(src).not.toMatch(/req\.branchId/);
+  });
+  test('every route is role-gated; plan creation uses WRITE_ROLES', () => {
+    const verbs = [...src.matchAll(/router\.(get|post)\(\s*'[^']+'\s*,\s*([A-Za-z_$][\w$]*)/g)];
+    expect(verbs.length).toBe(4);
+    for (const m of verbs) expect(m[2]).toBe('requireRole');
+    expect(src).toMatch(/'\/plans',\s*requireRole\(WRITE_ROLES\)/);
+  });
+});
+
+describe('W1203 headcount-planning routes — endpoints + mount', () => {
+  test('exposes the 4 endpoints', () => {
+    for (const [verb, p] of [
+      ['get', '/current'],
+      ['post', '/preview'],
+      ['post', '/plans'],
+      ['get', '/plans'],
+    ]) {
+      expect(src).toMatch(new RegExp(`router\\.${verb}\\(\\s*'${p}'`));
+    }
+  });
+  test('mounted in hr.registry at /api(/v1)?/hr/headcount-planning', () => {
+    expect(reg).toMatch(/headcount-planning\.routes/);
+    expect(reg).toMatch(/app\.use\(\s*'\/api\/hr\/headcount-planning'/);
+    expect(reg).toMatch(/app\.use\(\s*'\/api\/v1\/hr\/headcount-planning'/);
+  });
+});

--- a/backend/intelligence/headcount-forecast.lib.js
+++ b/backend/intelligence/headcount-forecast.lib.js
@@ -1,0 +1,99 @@
+/**
+ * headcount-forecast.lib.js — pure workforce supply-planning math (W1203).
+ *
+ * Given a current headcount, an attrition rate, a target, and a horizon, projects
+ * survivors and the hiring need to reach the target. All pure (no DB, no Date).
+ *
+ * Model (deliberately simple + explainable — it drives recruitment budget, so each
+ * number must be defensible):
+ *   - survivors after N periods = current × (1 − attrition)^N   (compound retention)
+ *   - attritionLosses           = current − survivors
+ *   - growthHires               = max(0, target − current)
+ *   - replacementHires          = attritionLosses  (offset what you lose; first-order —
+ *                                 second-order attrition of NEW hires is ignored and
+ *                                 flagged in `assumptions`, so plans stay conservative)
+ *   - totalHiringNeed           = growthHires + replacementHires
+ *   - gapToTargetNoAction       = target − survivors  (shortfall if you hire nothing)
+ */
+
+'use strict';
+
+function clampPct(p) {
+  const v = Number(p);
+  if (!Number.isFinite(v) || v < 0) return 0;
+  if (v > 100) return 100;
+  return v;
+}
+function clampInt(n, min, max) {
+  const v = Math.round(Number(n));
+  if (!Number.isFinite(v)) return min;
+  if (v < min) return min;
+  if (v > max) return max;
+  return v;
+}
+function round(n) {
+  return Math.round(Number(n) || 0);
+}
+
+/**
+ * @param {object} p
+ * @param {number} p.current        current headcount (≥0)
+ * @param {number} p.target         target headcount at end of horizon (≥0)
+ * @param {number} p.attritionRatePct  per-period attrition % (0-100)
+ * @param {number} p.periods        horizon length (1-10)
+ */
+function forecastHeadcount({ current, target, attritionRatePct, periods } = {}) {
+  const cur = Math.max(0, round(current));
+  const tgt = Math.max(0, round(target == null ? current : target));
+  const a = clampPct(attritionRatePct) / 100;
+  const n = clampInt(periods == null ? 1 : periods, 1, 10);
+
+  // per-period survivor trajectory (period 0 = now)
+  const trajectory = [{ period: 0, headcount: cur }];
+  let hc = cur;
+  for (let t = 1; t <= n; t++) {
+    hc = hc * (1 - a);
+    trajectory.push({ period: t, headcount: round(hc) });
+  }
+  const survivors = round(cur * Math.pow(1 - a, n));
+  const attritionLosses = Math.max(0, cur - survivors);
+  const growthHires = Math.max(0, tgt - cur);
+  const replacementHires = attritionLosses;
+  const totalHiringNeed = growthHires + replacementHires;
+  const gapToTargetNoAction = tgt - survivors;
+
+  return {
+    current: cur,
+    target: tgt,
+    periods: n,
+    attritionRatePct: clampPct(attritionRatePct),
+    survivors,
+    attritionLosses,
+    growthHires,
+    replacementHires,
+    totalHiringNeed,
+    gapToTargetNoAction,
+    annualHiringPace: round(totalHiringNeed / n),
+    trajectory,
+    assumptions: [
+      'compound retention: survivors = current × (1−attrition)^periods',
+      'replacement = first-order attrition only (new hires not re-attrited — conservative)',
+    ],
+  };
+}
+
+/** Roll several department/branch forecasts into an org total. */
+function rollupPlans(forecasts) {
+  const sum = (key) => (forecasts || []).reduce((a, f) => a + (Number(f && f[key]) || 0), 0);
+  return {
+    units: (forecasts || []).length,
+    current: sum('current'),
+    target: sum('target'),
+    survivors: sum('survivors'),
+    growthHires: sum('growthHires'),
+    replacementHires: sum('replacementHires'),
+    totalHiringNeed: sum('totalHiringNeed'),
+  };
+}
+
+module.exports = { clampPct, clampInt, round, forecastHeadcount, rollupPlans };

--- a/backend/models/HR/HeadcountPlan.js
+++ b/backend/models/HR/HeadcountPlan.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/**
+ * HeadcountPlan.js — a workforce supply-plan for a branch (+ optional department) (W1203).
+ *
+ * Captures the inputs (target, attrition, horizon) + a snapshot of the current
+ * headcount at plan time + the computed forecast (survivors / hiring need). branchId
+ * is the plan SCOPE (set directly by the service from the caller's effective branch),
+ * so no hrBranchScope plugin. Multiple plans per scope allowed (scenarios).
+ */
+
+const mongoose = require('mongoose');
+
+const HeadcountPlanSchema = new mongoose.Schema(
+  {
+    branchId: { type: mongoose.Schema.Types.ObjectId, ref: 'Branch', required: true, index: true },
+    department: { type: String, default: null, trim: true, maxlength: 120 },
+    planLabel: { type: String, required: true, trim: true, maxlength: 60 }, // e.g. '2026' or '2026-Q3 growth'
+
+    currentHeadcount: { type: Number, required: true, min: 0 }, // snapshot at plan time
+    targetHeadcount: { type: Number, required: true, min: 0 },
+    attritionRatePct: { type: Number, required: true, min: 0, max: 100 },
+    periods: { type: Number, required: true, min: 1, max: 10 },
+
+    // computed forecast (from headcount-forecast.lib)
+    forecast: { type: mongoose.Schema.Types.Mixed, default: () => ({}) },
+
+    status: { type: String, enum: ['draft', 'approved'], default: 'draft', index: true },
+    createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+
+    __invariants: { type: mongoose.Schema.Types.Mixed, select: false, default: null },
+  },
+  { timestamps: true, collection: 'hr_headcount_plans' }
+);
+
+HeadcountPlanSchema.index({ branchId: 1, planLabel: 1, department: 1 });
+
+// W1123 — markModified so the select:false validator runs on update-saves too.
+HeadcountPlanSchema.pre('validate', function markInvariants() {
+  this.markModified('__invariants');
+});
+
+HeadcountPlanSchema.path('__invariants').validate(function validateInvariants() {
+  if (this.attritionRatePct != null && (this.attritionRatePct < 0 || this.attritionRatePct > 100)) {
+    this.invalidate('attritionRatePct', 'attritionRatePct must be within [0,100]');
+  }
+  if (this.periods != null && (this.periods < 1 || this.periods > 10)) {
+    this.invalidate('periods', 'periods must be within [1,10]');
+  }
+  if (this.targetHeadcount != null && this.targetHeadcount < 0) {
+    this.invalidate('targetHeadcount', 'targetHeadcount cannot be negative');
+  }
+  if (this.currentHeadcount != null && this.currentHeadcount < 0) {
+    this.invalidate('currentHeadcount', 'currentHeadcount cannot be negative');
+  }
+  return true;
+});
+
+module.exports = mongoose.models.HeadcountPlan || mongoose.model('HeadcountPlan', HeadcountPlanSchema);

--- a/backend/routes/hr/headcount-planning.routes.js
+++ b/backend/routes/hr/headcount-planning.routes.js
@@ -1,0 +1,104 @@
+'use strict';
+
+/**
+ * headcount-planning.routes.js — HR workforce supply-planning surface (W1203).
+ *
+ * Mount: /api/hr/headcount-planning + /api/v1/... (self-authed → safe under the
+ * plain hr.registry app.use mount, W1190/W1191).
+ *
+ *   GET  /current   — live active headcount + per-department breakdown
+ *   POST /preview   — what-if hiring-need forecast (no persist)
+ *   POST /plans     — build + persist a supply plan (current headcount pulled live)
+ *   GET  /plans     — list saved plans
+ *
+ * Branch isolation via effectiveBranchScope (W269 — the caller's own branch only).
+ * Headcount is org-operational (not PII): reads gated to HR/finance leadership.
+ */
+
+const express = require('express');
+const router = express.Router();
+
+const { authenticateToken, requireRole } = require('../../middleware/auth');
+const { requireBranchAccess } = require('../../middleware/branchScope.middleware');
+const { effectiveBranchScope } = require('../../middleware/assertBranchMatch');
+const safeError = require('../../utils/safeError');
+const svc = require('../../services/hr/headcountPlanningService');
+
+const READ_ROLES = ['admin', 'superadmin', 'super_admin', 'hr_manager', 'hr_director', 'hr', 'manager', 'cfo', 'finance_manager'];
+const WRITE_ROLES = ['admin', 'superadmin', 'super_admin', 'hr_manager', 'hr_director', 'cfo'];
+
+router.use(authenticateToken);
+router.use(requireBranchAccess);
+
+function mapErr(res, err, ctx) {
+  if (err && err.code === 'MODEL_UNAVAILABLE') return res.status(503).json({ success: false, error: err.message });
+  if (err && err.code === 'VALIDATION') return res.status(400).json({ success: false, error: err.message });
+  if (err && err.name === 'ValidationError') return res.status(400).json({ success: false, error: err.message });
+  return safeError(res, err, ctx);
+}
+
+/** GET /current — live active headcount + per-department breakdown. */
+router.get('/current', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const branchId = effectiveBranchScope(req); // W269 — own branch or null (HQ)
+    const data = await svc.currentHeadcount({ branchId, department: req.query.department ? String(req.query.department) : null });
+    res.json({ success: true, data });
+  } catch (err) {
+    mapErr(res, err, 'headcount:current');
+  }
+});
+
+/** POST /preview — what-if forecast (no persist). */
+router.post('/preview', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const b = req.body || {};
+    const branchId = effectiveBranchScope(req);
+    const data = await svc.previewForecast({
+      branchId,
+      department: b.department ? String(b.department) : null,
+      targetHeadcount: b.targetHeadcount,
+      attritionRatePct: b.attritionRatePct,
+      periods: b.periods,
+    });
+    res.json({ success: true, data });
+  } catch (err) {
+    mapErr(res, err, 'headcount:preview');
+  }
+});
+
+/** POST /plans — build + persist a supply plan. */
+router.post('/plans', requireRole(WRITE_ROLES), async (req, res) => {
+  try {
+    const b = req.body || {};
+    const branchId = effectiveBranchScope(req);
+    if (!branchId && !b.branchId) {
+      return res.status(400).json({ success: false, error: 'branchId required (HQ must specify a branch)' });
+    }
+    const actor = req.user || {};
+    const doc = await svc.buildPlan({
+      branchId: branchId || b.branchId,
+      department: b.department ? String(b.department) : null,
+      planLabel: b.planLabel,
+      targetHeadcount: b.targetHeadcount,
+      attritionRatePct: b.attritionRatePct,
+      periods: b.periods,
+      createdBy: actor.id || actor._id || actor.userId || null,
+    });
+    res.status(201).json({ success: true, data: doc });
+  } catch (err) {
+    mapErr(res, err, 'headcount:plan');
+  }
+});
+
+/** GET /plans — list saved plans (branch-scoped). */
+router.get('/plans', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const branchId = effectiveBranchScope(req);
+    const items = await svc.listPlans({ branchId, department: req.query.department ? String(req.query.department) : null, limit: req.query.limit });
+    res.json({ success: true, data: { count: items.length, items } });
+  } catch (err) {
+    mapErr(res, err, 'headcount:plans');
+  }
+});
+
+module.exports = router;

--- a/backend/routes/registries/hr.registry.js
+++ b/backend/routes/registries/hr.registry.js
@@ -222,5 +222,16 @@ module.exports = function registerHrRoutes(app, { safeRequire, dualMount, safeMo
     logger.warn('[HR] Skills-gap routes not mounted (module missing)');
   }
 
+  // ── Headcount planning & forecasting (W1203 — supply planning + hiring need) ──
+  // Self-authenticating; live current headcount from Employee + branch-isolated.
+  const headcountRouter = safeRequire('../routes/hr/headcount-planning.routes');
+  if (headcountRouter) {
+    app.use('/api/hr/headcount-planning', headcountRouter);
+    app.use('/api/v1/hr/headcount-planning', headcountRouter);
+    logger.info('[HR] Headcount planning mounted (/api/(v1/)?hr/headcount-planning)');
+  } else {
+    logger.warn('[HR] Headcount planning routes not mounted (module missing)');
+  }
+
   logger.info('[HR] All ~25 HR/Employee/Workforce modules mounted successfully');
 };

--- a/backend/services/hr/headcountPlanningService.js
+++ b/backend/services/hr/headcountPlanningService.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * headcountPlanningService.js — data-driven workforce supply planning (W1203).
+ *
+ * Reads the LIVE current headcount from Employee (branch-scoped), runs the forecast
+ * lib to size the hiring need to reach a target, and persists a HeadcountPlan. The
+ * route resolves branchId from the caller's effective scope.
+ */
+
+const lib = require('../../intelligence/headcount-forecast.lib');
+
+function getModel(name, file) {
+  const mongoose = require('mongoose');
+  try {
+    return mongoose.model(name);
+  } catch {
+    try {
+      require(file);
+      return mongoose.model(name);
+    } catch {
+      return null;
+    }
+  }
+}
+
+/** Live current active headcount for a branch (+ optional department) + per-dept breakdown. */
+async function currentHeadcount({ branchId, department = null } = {}) {
+  const Employee = getModel('Employee', '../../models/HR/Employee');
+  if (!Employee) {
+    const e = new Error('Employee model unavailable');
+    e.code = 'MODEL_UNAVAILABLE';
+    throw e;
+  }
+  const filter = { status: 'active', deleted_at: null };
+  if (branchId) filter.branch_id = branchId; // branch isolation (caller-resolved)
+  if (department) filter.department = department;
+  const total = await Employee.countDocuments(filter);
+  let byDepartment = [];
+  if (!department) {
+    byDepartment = await Employee.aggregate([
+      { $match: filter },
+      { $group: { _id: '$department', count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+    ]).then(rows => rows.map(r => ({ department: r._id || '(غير محدّد)', count: r.count })));
+  }
+  return { branchId: branchId || null, department: department || null, total, byDepartment };
+}
+
+/** Build + persist a supply plan; current headcount is pulled LIVE (not caller-supplied). */
+async function buildPlan({ branchId, department = null, planLabel, targetHeadcount, attritionRatePct, periods, createdBy = null } = {}) {
+  const HeadcountPlan = getModel('HeadcountPlan', '../../models/HR/HeadcountPlan');
+  if (!HeadcountPlan) {
+    const e = new Error('HeadcountPlan model unavailable');
+    e.code = 'MODEL_UNAVAILABLE';
+    throw e;
+  }
+  if (!planLabel) {
+    const e = new Error('planLabel is required');
+    e.code = 'VALIDATION';
+    throw e;
+  }
+  const { total: current } = await currentHeadcount({ branchId, department });
+  const forecast = lib.forecastHeadcount({
+    current,
+    target: targetHeadcount,
+    attritionRatePct,
+    periods,
+  });
+  const doc = await HeadcountPlan.create({
+    branchId,
+    department,
+    planLabel,
+    currentHeadcount: current,
+    targetHeadcount: forecast.target,
+    attritionRatePct: forecast.attritionRatePct,
+    periods: forecast.periods,
+    forecast,
+    createdBy,
+  });
+  return doc;
+}
+
+/** Live what-if forecast WITHOUT persisting (uses live current headcount). */
+async function previewForecast({ branchId, department = null, targetHeadcount, attritionRatePct, periods } = {}) {
+  const { total: current } = await currentHeadcount({ branchId, department });
+  return { current, ...lib.forecastHeadcount({ current, target: targetHeadcount, attritionRatePct, periods }) };
+}
+
+async function listPlans({ branchId, department = null, limit = 50 } = {}) {
+  const HeadcountPlan = getModel('HeadcountPlan', '../../models/HR/HeadcountPlan');
+  if (!HeadcountPlan) return [];
+  const filter = {};
+  if (branchId) filter.branchId = branchId;
+  if (department) filter.department = department;
+  return HeadcountPlan.find(filter).sort({ createdAt: -1 }).limit(Math.min(Number(limit) || 50, 200)).lean();
+}
+
+module.exports = { currentHeadcount, buildPlan, previewForecast, listPlans };

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -859,3 +859,6 @@ __tests__/skills-gap-routes-wave1201.test.js
 __tests__/skills-gap-behavioral-wave1201.test.js
 __tests__/user-login-attempts-behavioral-wave1221.test.js
 __tests__/seed-hr-intelligence-wave1202.test.js
+__tests__/headcount-forecast-lib-wave1203.test.js
+__tests__/headcount-planning-routes-wave1203.test.js
+__tests__/headcount-plan-behavioral-wave1203.test.js


### PR DESCRIPTION
## What

Audit-first: workforce-analytics' `createForecast` / `createHeadcountPlan` are **stubs** (echo caller-supplied numbers, in-memory, no `Employee` read). This is a real, **data-driven** supply planner — the **supply** counterpart to the demand/talent analytics: *"to reach a target headcount with attrition A over N periods, how many must we hire?"*

## What it computes — `intelligence/headcount-forecast.lib.js` (pure, explainable)

- **survivors** = `current × (1 − attrition)^periods` (compound retention) + per-period trajectory
- **growthHires** = `max(0, target − current)`
- **replacementHires** = first-order attrition losses (conservative — flagged in `assumptions`)
- **totalHiringNeed**, **gapToTargetNoAction**, **annualHiringPace**, org **rollup**
- inputs clamped (attrition 0-100, periods 1-10)

## Stack

- **`models/HR/HeadcountPlan.js`** — branch-scoped plan (current snapshot + inputs + computed forecast) + Wave-18 invariants (attrition / periods / headcount ranges).
- **`services/hr/headcountPlanningService.js`** — `currentHeadcount` **live from Employee** (`countDocuments` + per-department aggregate), `previewForecast` (what-if, no persist), `buildPlan` (pulls current live — **never trusts a caller-supplied count**), `listPlans`.
- **`routes/hr/headcount-planning.routes.js`** — 4 endpoints, self-authed, **branch-isolated** (`effectiveBranchScope`), role-gated (plan creation = `WRITE_ROLES`). Mounted in `hr.registry`.

**Endpoints:** `GET /current` · `POST /preview` · `POST /plans` · `GET /plans` — under `/api/(v1/)?hr/headcount-planning`.

## Tests — 15 assertions / 3 sprint-enumerated files

lib unit (survivors / hires / gap / clamps / rollup) + routes static (auth / W269 / role gating / mount) + behavioral MMS (invariants on save **and** update-save).

## Verified locally

`check:routes-load` · `check:hook-style` · `check:sprint-paths` in sync · `check:gitignored-sources` · `no-broken-requires` + `no-duplicate-model-registration` + `canonical-beneficiary-ref` (model clean) · 15/15 green.

> Note: main has two unrelated **pre-existing** reds (Sprint Tests yml paths-limit + ~35 phantom refs from the parallel forms merges) — inherited; verified independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)