### PR TITLE
feat(hr): W1224 — official-letters issuance registry (atomic ref numbers + public QR verify)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1684,6 +1684,9 @@ on:
       - 'backend/__tests__/headcount-forecast-lib-wave1203.test.js'
       - 'backend/__tests__/headcount-planning-routes-wave1203.test.js'
       - 'backend/__tests__/headcount-plan-behavioral-wave1203.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/official-letters-routes-wave1224.test.js'
+      - 'backend/__tests__/official-letters-behavioral-wave1224.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3351,6 +3354,9 @@ on:
       - 'backend/__tests__/headcount-forecast-lib-wave1203.test.js'
       - 'backend/__tests__/headcount-planning-routes-wave1203.test.js'
       - 'backend/__tests__/headcount-plan-behavioral-wave1203.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/official-letters-routes-wave1224.test.js'
+      - 'backend/__tests__/official-letters-behavioral-wave1224.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/official-letters-behavioral-wave1224.test.js
+++ b/backend/__tests__/official-letters-behavioral-wave1224.test.js
@@ -1,0 +1,173 @@
+'use strict';
+
+/**
+ * official-letters-behavioral-wave1224.test.js — OfficialLetter against
+ * MongoMemoryServer (real driver, no mocks).
+ *
+ * Covers the issuance contract: atomic per-type/per-year sequencing,
+ * official refNumber format, verifyToken uniqueness, revocation
+ * invariants (Wave-18), and parallel-issue safety (no duplicate seq under
+ * concurrency — the whole reason the counter is a findOneAndUpdate $inc).
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(120000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let OfficialLetter;
+
+const YEAR = new Date().getFullYear();
+
+function subject(over = {}) {
+  return {
+    kind: 'employee',
+    refId: new mongoose.Types.ObjectId(),
+    nameAr: 'موظف اختبار',
+    nameEn: 'Test Employee',
+    number: 'EMP-2026-0001',
+    jobTitle: 'أخصائي علاج طبيعي',
+    ...over,
+  };
+}
+
+function issuer() {
+  return { userId: new mongoose.Types.ObjectId(), name: 'HR Tester' };
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { dbName: 'w1224-letters' } });
+  await mongoose.connect(mongod.getUri());
+  OfficialLetter = require('../models/OfficialLetter');
+  await OfficialLetter.init();
+  await OfficialLetter.OfficialLetterCounter.init();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+});
+
+afterEach(async () => {
+  await OfficialLetter.deleteMany({});
+  await OfficialLetter.OfficialLetterCounter.deleteMany({});
+});
+
+describe('W1224 OfficialLetter.issue — sequencing + format', () => {
+  test('first issue gets seq 1 and a formatted refNumber', async () => {
+    const letter = await OfficialLetter.issue({
+      letterType: 'employment_certificate',
+      subject: subject(),
+      issuer: issuer(),
+    });
+    expect(letter.seq).toBe(1);
+    expect(letter.refNumber).toBe(`EC-${YEAR}-0001`);
+    expect(letter.status).toBe('issued');
+    expect(letter.verifyToken).toMatch(/^[a-f0-9]{32}$/);
+    expect(letter.addressee).toBe('إلى من يهمه الأمر');
+  });
+
+  test('sequences are independent per letterType', async () => {
+    const a = await OfficialLetter.issue({
+      letterType: 'employment_certificate',
+      subject: subject(),
+      issuer: issuer(),
+    });
+    const b = await OfficialLetter.issue({
+      letterType: 'salary_certificate',
+      subject: subject(),
+      issuer: issuer(),
+      payload: { salary: { basic: 8000, housing: 2000, transport: 500, other: 0, total: 10500 } },
+    });
+    expect(a.refNumber).toBe(`EC-${YEAR}-0001`);
+    expect(b.refNumber).toBe(`SC-${YEAR}-0001`);
+    expect(b.payload.salary.total).toBe(10500);
+  });
+
+  test('10 PARALLEL issues never collide on seq (atomic $inc counter)', async () => {
+    const letters = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        OfficialLetter.issue({
+          letterType: 'employment_certificate',
+          subject: subject(),
+          issuer: issuer(),
+        })
+      )
+    );
+    const seqs = letters.map((l) => l.seq).sort((x, y) => x - y);
+    expect(seqs).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    const refs = new Set(letters.map((l) => l.refNumber));
+    expect(refs.size).toBe(10);
+  });
+
+  test('unknown letterType throws INVALID_LETTER_TYPE', async () => {
+    await expect(
+      OfficialLetter.issue({ letterType: 'nope', subject: subject(), issuer: issuer() })
+    ).rejects.toMatchObject({ code: 'INVALID_LETTER_TYPE' });
+  });
+
+  test('verifyTokens are unique across letters', async () => {
+    const a = await OfficialLetter.issue({
+      letterType: 'employment_certificate',
+      subject: subject(),
+      issuer: issuer(),
+    });
+    const b = await OfficialLetter.issue({
+      letterType: 'employment_certificate',
+      subject: subject(),
+      issuer: issuer(),
+    });
+    expect(a.verifyToken).not.toBe(b.verifyToken);
+  });
+});
+
+describe('W1224 OfficialLetter — revocation invariants (Wave-18)', () => {
+  test('revoking without a reason fails validation', async () => {
+    const letter = await OfficialLetter.issue({
+      letterType: 'employment_certificate',
+      subject: subject(),
+      issuer: issuer(),
+    });
+    letter.status = 'revoked';
+    letter.revokedAt = new Date();
+    await expect(letter.save()).rejects.toThrow(/revokeReason/);
+  });
+
+  test('revoking with reason + revokedAt persists', async () => {
+    const letter = await OfficialLetter.issue({
+      letterType: 'employment_certificate',
+      subject: subject(),
+      issuer: issuer(),
+    });
+    letter.status = 'revoked';
+    letter.revokedAt = new Date();
+    letter.revokedBy = new mongoose.Types.ObjectId();
+    letter.revokeReason = 'صدر بالخطأ';
+    await letter.save();
+    const row = await OfficialLetter.findById(letter._id).lean();
+    expect(row.status).toBe('revoked');
+    expect(row.revokeReason).toBe('صدر بالخطأ');
+  });
+
+  test('issued letters must not carry revocation fields', async () => {
+    const letter = await OfficialLetter.issue({
+      letterType: 'employment_certificate',
+      subject: subject(),
+      issuer: issuer(),
+    });
+    letter.revokeReason = 'leftover';
+    await expect(letter.save()).rejects.toThrow(/revocation/);
+  });
+
+  test('subject snapshot is required and shaped', async () => {
+    await expect(
+      OfficialLetter.issue({
+        letterType: 'employment_certificate',
+        subject: { kind: 'employee' }, // missing refId + nameAr
+        issuer: issuer(),
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/backend/__tests__/official-letters-routes-wave1224.test.js
+++ b/backend/__tests__/official-letters-routes-wave1224.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+/**
+ * official-letters-routes-wave1224.test.js — static drift guard for the
+ * official-letters route + registry mount + model contract.
+ *
+ * Locks the security-relevant source shape (the W1179 lesson: routes
+ * written against an imagined schema ship silently broken):
+ *   1. public verify endpoint is declared BEFORE authenticateToken;
+ *   2. issue path snapshots the employee SERVER-SIDE (no client-trusted
+ *      subject), and never spreads req.body;
+ *   3. list applies branchFilter (W269);
+ *   4. registry mounts both /api and /api/v1 paths;
+ *   5. model keeps canonical refs (User / Branch — W324) + the revocation
+ *      invariants + the atomic counter.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const routeSrc = fs.readFileSync(
+  path.join(__dirname, '..', 'routes', 'hr', 'official-letters.routes.js'),
+  'utf8'
+);
+const modelSrc = fs.readFileSync(
+  path.join(__dirname, '..', 'models', 'OfficialLetter.js'),
+  'utf8'
+);
+const registrySrc = fs.readFileSync(
+  path.join(__dirname, '..', 'routes', 'registries', 'hr.registry.js'),
+  'utf8'
+);
+
+describe('W1224 official-letters route — source contract', () => {
+  test('verify endpoint is PUBLIC: declared before router.use(authenticateToken)', () => {
+    const verifyIdx = routeSrc.indexOf("router.get('/verify/:token'");
+    const authIdx = routeSrc.indexOf('router.use(authenticateToken)');
+    expect(verifyIdx).toBeGreaterThan(-1);
+    expect(authIdx).toBeGreaterThan(-1);
+    expect(verifyIdx).toBeLessThan(authIdx);
+  });
+
+  test('verify endpoint validates token shape and never exposes internal ids', () => {
+    expect(routeSrc).toMatch(/\^?\[a-f0-9\]\{32\}/);
+    // The verify projection must not select _id-bearing relations or payload.
+    const sel = routeSrc.match(/findOne\(\{ verifyToken: token \}\)\s*\.select\('([^']+)'\)/);
+    expect(sel).not.toBeNull();
+    expect(sel[1]).not.toMatch(/payload/);
+    expect(sel[1]).not.toMatch(/issuedBy/);
+  });
+
+  test('issue path snapshots employee server-side and never spreads req.body', () => {
+    expect(routeSrc).toMatch(/mongoose\.model\('Employee'\)/);
+    expect(routeSrc).toMatch(/name_ar name_en employee_number/);
+    expect(routeSrc).not.toMatch(/\.\.\.req\.body/);
+    expect(routeSrc).not.toMatch(/Object\.assign\([^)]*req\.body/);
+  });
+
+  test('list + detail are branch-scoped via branchFilter (W269)', () => {
+    const listCount = (routeSrc.match(/branchFilter\(req\)/g) || []).length;
+    expect(listCount).toBeGreaterThanOrEqual(3); // list + detail + revoke
+    expect(routeSrc).not.toMatch(/req\.branchId/); // W269h class
+  });
+
+  test('revoke requires a reason and stricter roles', () => {
+    expect(routeSrc).toMatch(/REVOKE_ROLES/);
+    expect(routeSrc).toMatch(/reason \(≥5 chars\) is required|reason.+required/);
+  });
+
+  test('all mutations are explicit-field (anti mass-assignment)', () => {
+    expect(routeSrc).not.toMatch(/new OfficialLetter\(req\.body\)/);
+    expect(routeSrc).not.toMatch(/create\(req\.body\)/);
+  });
+});
+
+describe('W1224 registry mount', () => {
+  test('hr.registry mounts both /api and /api/v1 paths', () => {
+    expect(registrySrc).toMatch(/app\.use\('\/api\/hr\/official-letters', officialLettersRouter\)/);
+    expect(registrySrc).toMatch(
+      /app\.use\('\/api\/v1\/hr\/official-letters', officialLettersRouter\)/
+    );
+  });
+});
+
+describe('W1224 OfficialLetter model — contract', () => {
+  test('canonical refs only (W324): User + Branch', () => {
+    expect(modelSrc).toMatch(/ref: 'User'/);
+    expect(modelSrc).toMatch(/ref: 'Branch'/);
+    expect(modelSrc).not.toMatch(/ref: 'Admin'/);
+    expect(modelSrc).not.toMatch(/ref: 'Center'/);
+  });
+
+  test('atomic counter uses findOneAndUpdate + $inc + upsert', () => {
+    expect(modelSrc).toMatch(/OfficialLetterCounter\.findOneAndUpdate/);
+    expect(modelSrc).toMatch(/\$inc: \{ seq: 1 \}/);
+    expect(modelSrc).toMatch(/upsert: true/);
+  });
+
+  test('revocation invariants declared via pre-validate invalidate calls', () => {
+    expect(modelSrc).toMatch(/invalidate\('revokeReason'/);
+    expect(modelSrc).toMatch(/invalidate\('revokedAt'/);
+    expect(modelSrc).toMatch(/invalidate\('status'/);
+  });
+
+  test('Mongoose-9 hook style: async pre-validate, no next callback (W946 class)', () => {
+    expect(modelSrc).toMatch(/pre\('validate', async function \(\)/);
+    expect(modelSrc).not.toMatch(/pre\('validate', function \(next\)/);
+    expect(modelSrc).not.toMatch(/pre\('save', function \(next\)/);
+  });
+
+  test('unique compound index on (letterType, year, seq) + unique refNumber/verifyToken', () => {
+    expect(modelSrc).toMatch(/\{ letterType: 1, year: 1, seq: 1 \}, \{ unique: true \}/);
+    expect(modelSrc).toMatch(/refNumber: \{ type: String, required: true, unique: true \}/);
+    expect(modelSrc).toMatch(/verifyToken: \{[\s\S]*?unique: true/);
+  });
+
+  test('no TTL on the issuance log (official records persist)', () => {
+    expect(modelSrc).not.toMatch(/expireAfterSeconds|expires:/);
+  });
+});

--- a/backend/models/OfficialLetter.js
+++ b/backend/models/OfficialLetter.js
@@ -1,0 +1,174 @@
+'use strict';
+
+/**
+ * OfficialLetter — سجل إصدار الخطابات الرسمية (W1224).
+ *
+ * Every certificate letter printed from web-admin (/hr/forms/
+ * employment-certificate, salary-certificate, …) is ISSUED here first:
+ * an atomic per-type/per-year sequence assigns the official reference
+ * number (e.g. `EC-2026-0007`), the subject identity is SNAPSHOTTED from
+ * the system of record at issue time (letters must stay verifiable even
+ * if the employee record later changes), and a random `verifyToken`
+ * backs the QR code printed in the letter footer — any bank or authority
+ * can scan it and hit the PUBLIC verify endpoint to confirm the letter
+ * is genuine and not revoked.
+ *
+ * Lifecycle: issued → (optionally) revoked. No deletes — this is an
+ * audit log. No TTL — official issuance records persist.
+ */
+
+const crypto = require('crypto');
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const LETTER_TYPES = Object.freeze({
+  employment_certificate: { prefix: 'EC', labelAr: 'خطاب تعريف بالعمل' },
+  salary_certificate: { prefix: 'SC', labelAr: 'خطاب تعريف بالراتب' },
+  beneficiary_certificate: { prefix: 'BC', labelAr: 'خطاب تعريف بمستفيد' },
+});
+
+// ─── Atomic sequence counter (one doc per letterType+year) ────────────────
+const counterSchema = new Schema(
+  {
+    _id: { type: String, required: true }, // `${letterType}:${year}`
+    seq: { type: Number, required: true, default: 0 },
+  },
+  { collection: 'official_letter_counters', versionKey: false }
+);
+
+const OfficialLetterCounter =
+  mongoose.models.OfficialLetterCounter ||
+  mongoose.model('OfficialLetterCounter', counterSchema);
+
+// ─── Letter schema ─────────────────────────────────────────────────────────
+const subjectSchema = new Schema(
+  {
+    kind: { type: String, enum: ['employee', 'beneficiary'], required: true },
+    refId: { type: Schema.Types.ObjectId, required: true },
+    nameAr: { type: String, required: true },
+    nameEn: { type: String, default: null },
+    number: { type: String, default: null }, // employee_number / file number
+    jobTitle: { type: String, default: null },
+    hireDate: { type: Date, default: null },
+  },
+  { _id: false }
+);
+
+const officialLetterSchema = new Schema(
+  {
+    letterType: {
+      type: String,
+      enum: Object.keys(LETTER_TYPES),
+      required: true,
+      index: true,
+    },
+    year: { type: Number, required: true },
+    seq: { type: Number, required: true },
+    refNumber: { type: String, required: true, unique: true }, // EC-2026-0007
+    verifyToken: {
+      type: String,
+      required: true,
+      unique: true,
+      default: () => crypto.randomBytes(16).toString('hex'),
+    },
+
+    status: {
+      type: String,
+      enum: ['issued', 'revoked'],
+      default: 'issued',
+      index: true,
+    },
+    revokedAt: { type: Date, default: null },
+    revokedBy: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+    revokeReason: { type: String, default: null },
+
+    subject: { type: subjectSchema, required: true },
+    addressee: { type: String, default: 'إلى من يهمه الأمر' },
+    // Letter-type-specific snapshot (e.g. salary breakdown for SC letters).
+    payload: { type: Schema.Types.Mixed, default: null },
+
+    issuedBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    issuedByName: { type: String, default: null },
+    branchId: { type: Schema.Types.ObjectId, ref: 'Branch', default: null },
+  },
+  { timestamps: true, collection: 'official_letters' }
+);
+
+officialLetterSchema.index({ letterType: 1, year: 1, seq: 1 }, { unique: true });
+officialLetterSchema.index({ branchId: 1, createdAt: -1 });
+officialLetterSchema.index({ 'subject.refId': 1, createdAt: -1 });
+
+// ─── Wave-18 cross-field invariants ────────────────────────────────────────
+// Declared in a pre('validate') hook (async, Mongoose-9 style — W946/W483)
+// so they run on EVERY save path, including update-saves (W1123 lesson:
+// select:false virtual validators silently skip update-saves).
+officialLetterSchema.pre('validate', async function () {
+  // Update-saves skip select:false validators unless marked (W1123 lesson) —
+  // __invariants here is a plain virtual + pre('validate') hook, so it runs
+  // on every save path.
+  if (this.status === 'revoked' && !this.revokeReason) {
+    this.invalidate('revokeReason', 'revokeReason is required when status is revoked');
+  }
+  if (this.status === 'revoked' && !this.revokedAt) {
+    this.invalidate('revokedAt', 'revokedAt is required when status is revoked');
+  }
+  if (this.status === 'issued' && (this.revokedAt || this.revokeReason)) {
+    this.invalidate('status', 'issued letters must not carry revocation fields');
+  }
+});
+
+/**
+ * Atomically issue a letter: claim the next sequence for (type, year),
+ * format the official reference number, and persist the snapshot.
+ *
+ * @param {object} args
+ * @param {string} args.letterType  one of LETTER_TYPES keys
+ * @param {object} args.subject     snapshot ({kind, refId, nameAr, ...})
+ * @param {string} [args.addressee]
+ * @param {object} [args.payload]
+ * @param {object} args.issuer      { userId, name }
+ * @param {string|null} [args.branchId]
+ * @returns {Promise<import('mongoose').Document>}
+ */
+officialLetterSchema.statics.issue = async function issue({
+  letterType,
+  subject,
+  addressee,
+  payload,
+  issuer,
+  branchId,
+}) {
+  if (!LETTER_TYPES[letterType]) {
+    const err = new Error(`Unknown letterType: ${letterType}`);
+    err.code = 'INVALID_LETTER_TYPE';
+    throw err;
+  }
+  const year = new Date().getFullYear();
+  const counter = await OfficialLetterCounter.findOneAndUpdate(
+    { _id: `${letterType}:${year}` },
+    { $inc: { seq: 1 } },
+    { upsert: true, returnDocument: 'after' }
+  );
+  const seq = counter.seq;
+  const refNumber = `${LETTER_TYPES[letterType].prefix}-${year}-${String(seq).padStart(4, '0')}`;
+
+  return this.create({
+    letterType,
+    year,
+    seq,
+    refNumber,
+    subject,
+    addressee: addressee || 'إلى من يهمه الأمر',
+    payload: payload ?? null,
+    issuedBy: issuer.userId,
+    issuedByName: issuer.name ?? null,
+    branchId: branchId ?? null,
+  });
+};
+
+const OfficialLetter =
+  mongoose.models.OfficialLetter || mongoose.model('OfficialLetter', officialLetterSchema);
+
+module.exports = OfficialLetter;
+module.exports.OfficialLetterCounter = OfficialLetterCounter;
+module.exports.LETTER_TYPES = LETTER_TYPES;

--- a/backend/routes/hr/official-letters.routes.js
+++ b/backend/routes/hr/official-letters.routes.js
@@ -1,0 +1,238 @@
+'use strict';
+
+/**
+ * official-letters.routes.js — issuance registry for certificate letters (W1224).
+ *
+ * Mount: /api/hr/official-letters + /api/v1/hr/official-letters (self-authed,
+ * same pattern as workforce-intelligence W1200).
+ *
+ *   GET  /verify/:token   PUBLIC — QR verification for banks/authorities.
+ *                         Declared BEFORE the auth middleware on purpose.
+ *   POST /                issue a letter (atomic ref number; employee subjects
+ *                         are snapshotted SERVER-SIDE from the Employee record —
+ *                         the client only names the employeeId).
+ *   GET  /                issuance log (branch-scoped, paginated).
+ *   GET  /:id             single letter detail.
+ *   POST /:id/revoke      revoke (reason required; letter stays in the log and
+ *                         the public verify endpoint reports REVOKED).
+ *
+ * Security: no raw request-body spread (W506/W507 doctrine); explicit field
+ * picks; branchFilter on the log (W269); verify endpoint returns the minimum
+ * a verifier needs (type, ref, date, subject name, status) — no internal ids.
+ */
+
+const express = require('express');
+const mongoose = require('mongoose');
+const router = express.Router();
+
+const { authenticateToken, requireRole } = require('../../middleware/auth');
+const { requireBranchAccess, branchFilter } = require('../../middleware/branchScope.middleware');
+const safeError = require('../../utils/safeError');
+const OfficialLetter = require('../../models/OfficialLetter');
+const { LETTER_TYPES } = require('../../models/OfficialLetter');
+
+const WRITE_ROLES = [
+  'admin', 'superadmin', 'super_admin', 'hr_manager', 'hr_director', 'hr',
+  'hr_officer', 'hr_specialist',
+];
+const REVOKE_ROLES = ['admin', 'superadmin', 'super_admin', 'hr_manager', 'hr_director'];
+
+// ─── PUBLIC: QR verification (declared BEFORE authenticateToken) ──────────
+router.get('/verify/:token', async (req, res) => {
+  try {
+    const token = String(req.params.token || '');
+    if (!/^[a-f0-9]{32}$/.test(token)) {
+      return res.status(400).json({ success: false, valid: false, message: 'Malformed token' });
+    }
+    const letter = await OfficialLetter.findOne({ verifyToken: token })
+      .select('letterType refNumber status createdAt revokedAt subject.nameAr subject.nameEn')
+      .lean();
+    if (!letter) {
+      return res.status(404).json({ success: false, valid: false, message: 'No such letter' });
+    }
+    return res.json({
+      success: true,
+      valid: letter.status === 'issued',
+      data: {
+        letterType: letter.letterType,
+        letterLabelAr: LETTER_TYPES[letter.letterType]?.labelAr ?? letter.letterType,
+        refNumber: letter.refNumber,
+        status: letter.status,
+        issuedAt: letter.createdAt,
+        revokedAt: letter.revokedAt,
+        subjectNameAr: letter.subject?.nameAr ?? null,
+        subjectNameEn: letter.subject?.nameEn ?? null,
+      },
+    });
+  } catch (err) {
+    safeError(res, err, 'official-letters:verify');
+  }
+});
+
+// ─── Everything below requires auth + branch context ──────────────────────
+router.use(authenticateToken);
+router.use(requireBranchAccess);
+
+/** POST / — issue a letter. */
+router.post('/', requireRole(WRITE_ROLES), async (req, res) => {
+  try {
+    const letterType = String(req.body.letterType || '');
+    if (!LETTER_TYPES[letterType]) {
+      return res.status(400).json({ success: false, message: 'Invalid letterType' });
+    }
+
+    // Subject snapshot — employee letters snapshot from the system of record.
+    let subject = null;
+    let branchId = null;
+    if (letterType === 'employment_certificate' || letterType === 'salary_certificate') {
+      const employeeId = String(req.body.employeeId || '');
+      if (!mongoose.isValidObjectId(employeeId)) {
+        return res.status(400).json({ success: false, message: 'employeeId is required' });
+      }
+      let Employee;
+      try {
+        Employee = mongoose.model('Employee');
+      } catch {
+        return res.status(503).json({ success: false, message: 'Employee model unavailable' });
+      }
+      const emp = await Employee.findById(employeeId)
+        .select('name_ar name_en employee_number job_title_ar job_title_en hire_date branch_id')
+        .lean();
+      if (!emp) {
+        return res.status(404).json({ success: false, message: 'Employee not found' });
+      }
+      subject = {
+        kind: 'employee',
+        refId: emp._id,
+        nameAr: emp.name_ar,
+        nameEn: emp.name_en ?? null,
+        number: emp.employee_number ?? null,
+        jobTitle: emp.job_title_ar ?? emp.job_title_en ?? null,
+        hireDate: emp.hire_date ?? null,
+      };
+      branchId = emp.branch_id ?? null;
+    } else {
+      return res.status(400).json({ success: false, message: 'Unsupported letterType' });
+    }
+
+    // Salary letters carry an explicit HR-entered breakdown (no compensation
+    // source of record exists) — validated, never spread from req.body.
+    let payload = null;
+    if (letterType === 'salary_certificate') {
+      const num = (v) => {
+        const n = Number(v);
+        return Number.isFinite(n) && n >= 0 ? n : 0;
+      };
+      const salary = req.body.salary || {};
+      payload = {
+        salary: {
+          basic: num(salary.basic),
+          housing: num(salary.housing),
+          transport: num(salary.transport),
+          other: num(salary.other),
+        },
+      };
+      payload.salary.total =
+        payload.salary.basic + payload.salary.housing + payload.salary.transport + payload.salary.other;
+      if (payload.salary.basic <= 0) {
+        return res.status(400).json({ success: false, message: 'salary.basic must be > 0' });
+      }
+    }
+
+    const letter = await OfficialLetter.issue({
+      letterType,
+      subject,
+      addressee: req.body.addressee ? String(req.body.addressee).slice(0, 300) : null,
+      payload,
+      issuer: {
+        userId: req.user._id || req.user.id || req.user.userId,
+        name: req.user.fullName || req.user.name || req.user.email || null,
+      },
+      branchId,
+    });
+
+    res.status(201).json({
+      success: true,
+      data: {
+        id: letter._id,
+        refNumber: letter.refNumber,
+        verifyToken: letter.verifyToken,
+        issuedAt: letter.createdAt,
+      },
+    });
+  } catch (err) {
+    safeError(res, err, 'official-letters:issue');
+  }
+});
+
+/** GET / — issuance log (branch-scoped, newest first). */
+router.get('/', requireRole(WRITE_ROLES), async (req, res) => {
+  try {
+    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit, 10) || 25));
+    const filter = { ...branchFilter(req) };
+    if (req.query.letterType && LETTER_TYPES[String(req.query.letterType)]) {
+      filter.letterType = String(req.query.letterType);
+    }
+    if (req.query.status === 'issued' || req.query.status === 'revoked') {
+      filter.status = req.query.status;
+    }
+    const [rows, total] = await Promise.all([
+      OfficialLetter.find(filter)
+        .sort({ createdAt: -1 })
+        .skip((page - 1) * limit)
+        .limit(limit)
+        .select('-payload')
+        .lean(),
+      OfficialLetter.countDocuments(filter),
+    ]);
+    res.json({ success: true, data: rows, pagination: { page, limit, total } });
+  } catch (err) {
+    safeError(res, err, 'official-letters:list');
+  }
+});
+
+/** GET /:id — letter detail (includes payload for re-print). */
+router.get('/:id', requireRole(WRITE_ROLES), async (req, res) => {
+  try {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'Invalid id' });
+    }
+    const letter = await OfficialLetter.findOne({
+      _id: req.params.id,
+      ...branchFilter(req),
+    }).lean();
+    if (!letter) return res.status(404).json({ success: false, message: 'Not found' });
+    res.json({ success: true, data: letter });
+  } catch (err) {
+    safeError(res, err, 'official-letters:detail');
+  }
+});
+
+/** POST /:id/revoke — revoke an issued letter (reason required). */
+router.post('/:id/revoke', requireRole(REVOKE_ROLES), async (req, res) => {
+  try {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: 'Invalid id' });
+    }
+    const reason = String(req.body.reason || '').trim();
+    if (reason.length < 5) {
+      return res.status(400).json({ success: false, message: 'reason (≥5 chars) is required' });
+    }
+    const letter = await OfficialLetter.findOne({ _id: req.params.id, ...branchFilter(req) });
+    if (!letter) return res.status(404).json({ success: false, message: 'Not found' });
+    if (letter.status === 'revoked') {
+      return res.status(409).json({ success: false, message: 'Already revoked' });
+    }
+    letter.status = 'revoked';
+    letter.revokedAt = new Date();
+    letter.revokedBy = req.user._id || req.user.id || req.user.userId;
+    letter.revokeReason = reason;
+    await letter.save();
+    res.json({ success: true, data: { id: letter._id, status: letter.status } });
+  } catch (err) {
+    safeError(res, err, 'official-letters:revoke');
+  }
+});
+
+module.exports = router;

--- a/backend/routes/registries/hr.registry.js
+++ b/backend/routes/registries/hr.registry.js
@@ -222,6 +222,18 @@ module.exports = function registerHrRoutes(app, { safeRequire, dualMount, safeMo
     logger.warn('[HR] Skills-gap routes not mounted (module missing)');
   }
 
+  // ── Official letters issuance registry (W1224 — certificates + QR verify) ──
+  // Self-authenticating EXCEPT GET /verify/:token which is deliberately public
+  // (banks/authorities scan the QR printed on the letter to confirm issuance).
+  const officialLettersRouter = safeRequire('../routes/hr/official-letters.routes');
+  if (officialLettersRouter) {
+    app.use('/api/hr/official-letters', officialLettersRouter);
+    app.use('/api/v1/hr/official-letters', officialLettersRouter);
+    logger.info('[HR] Official-letters registry mounted (/api/(v1/)?hr/official-letters)');
+  } else {
+    logger.warn('[HR] Official-letters routes not mounted (module missing)');
+  }
+
   // ── Headcount planning & forecasting (W1203 — supply planning + hiring need) ──
   // Self-authenticating; live current headcount from Employee + branch-isolated.
   const headcountRouter = safeRequire('../routes/hr/headcount-planning.routes');

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1008,3 +1008,5 @@ __tests__/seed-hr-intelligence-wave1202.test.js
 __tests__/headcount-forecast-lib-wave1203.test.js
 __tests__/headcount-planning-routes-wave1203.test.js
 __tests__/headcount-plan-behavioral-wave1203.test.js
+__tests__/official-letters-routes-wave1224.test.js
+__tests__/official-letters-behavioral-wave1224.test.js


### PR DESCRIPTION
## What

Backend half of the professional letters upgrade: every certificate letter printed from web-admin becomes an **issued, registered, verifiable official document**.

### Endpoints — `/api/(v1/)?hr/official-letters`
| Method | Path | Behavior |
|---|---|---|
| POST | `/` | Issue: atomic per-type/per-year sequence (`OfficialLetterCounter` `findOneAndUpdate $inc` upsert) → `EC-2026-0007` style refNumber. Employee subject snapshotted **server-side** from the Employee record. Salary breakdown validated field-by-field. |
| GET | `/` | Issuance log — `branchFilter` (W269), paginated, payload excluded. |
| GET | `/:id` | Detail incl. payload (re-print). |
| POST | `/:id/revoke` | Reason required, stricter `REVOKE_ROLES`; letter stays in the log. |
| GET | `/verify/:token` | **PUBLIC** (declared before `authenticateToken`) — banks/authorities scan the QR on the letter → `{valid, refNumber, status, issuedAt, subjectName}`. No internal ids. |

### Model
Wave-18 revocation invariants (async `pre('validate')`, Mongoose-9 style), canonical refs `User`/`Branch` (W324), unique `(letterType, year, seq)` + unique `refNumber` + unique 32-hex `verifyToken`, **no TTL** (issuance log is an audit record).

## Tests
- Behavioral (MongoMemoryServer): **10-parallel-issue atomicity** (seq 1..10, zero collisions), per-type sequence independence, revocation invariants, token uniqueness — 9 tests.
- Static drift guard: public-verify-before-auth ordering, server-side snapshot, no body spread, branchFilter coverage, mount shape, model contract — 13 tests.
- Both sprint-enumerated; `check:routes-load` + `check:phantom-writes` clean.

Frontend flow (QR in DocFooter, letters log page, public verify page) follows in `alawael-rehab-platform` W1225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)