### PR TITLE
feat(supervisor-ops): wire dormant Tier-3 anomaly engine — productivity-anomalies (W1215)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1684,6 +1684,8 @@ on:
       - 'backend/__tests__/headcount-forecast-lib-wave1203.test.js'
       - 'backend/__tests__/headcount-planning-routes-wave1203.test.js'
       - 'backend/__tests__/headcount-plan-behavioral-wave1203.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/productivity-anomalies-wave1215.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3351,6 +3353,8 @@ on:
       - 'backend/__tests__/headcount-forecast-lib-wave1203.test.js'
       - 'backend/__tests__/headcount-planning-routes-wave1203.test.js'
       - 'backend/__tests__/headcount-plan-behavioral-wave1203.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/productivity-anomalies-wave1215.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/productivity-anomalies-wave1215.test.js
+++ b/backend/__tests__/productivity-anomalies-wave1215.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+/**
+ * productivity-anomalies-wave1215.test.js — unit tests for the READ-ONLY Tier-3
+ * multivariate productivity anomaly scan (services/operationsAnomaly.service.js)
+ * + a static guard for its route (GET /supervisor-ops/productivity-anomalies).
+ *
+ * Wires the previously-dormant isolation-forest engine. Pure logic — no DB.
+ *
+ * Run: cd backend && npx jest --config=jest.config.js __tests__/productivity-anomalies-wave1215.test.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {
+  detectProductivityAnomalies,
+  productivityFeatureExtractor,
+  PRODUCTIVITY_FEATURES,
+  MIN_THERAPISTS,
+} = require('../services/operationsAnomaly.service');
+
+function normalTeam(n) {
+  const byTherapist = {};
+  for (let i = 0; i < n; i++) {
+    byTherapist['t' + i] = {
+      completed: 10 + (i % 3),
+      deliveredMinutes: 450 + i * 5,
+      documentedRate: 88 + (i % 5),
+      noShow: 1,
+    };
+  }
+  return byTherapist;
+}
+
+describe('operationsAnomaly — detectProductivityAnomalies (pure, Tier-3 IF)', () => {
+  test('requiring the service does NOT open a DB connection + exposes the surface', () => {
+    expect(typeof detectProductivityAnomalies).toBe('function');
+    expect(PRODUCTIVITY_FEATURES).toContain('documentedRate');
+    expect(MIN_THERAPISTS).toBe(8);
+  });
+
+  test('flags the multivariate outlier among a normal team', () => {
+    const byTherapist = normalTeam(8);
+    byTherapist['OUTLIER'] = {
+      completed: 80,
+      deliveredMinutes: 60,
+      documentedRate: 0,
+      noShow: 25,
+    };
+    const r = detectProductivityAnomalies({ byTherapist });
+    expect(r.eligible).toBe(true);
+    expect(r.scanned).toBe(9);
+    expect(r.anomalies.some((a) => a.therapistId === 'OUTLIER')).toBe(true);
+    const top = r.anomalies[0];
+    expect(top.score).toBeGreaterThan(r.threshold);
+    expect(top.features).toHaveProperty('documentedRate');
+  });
+
+  test('anomalies are sorted most-anomalous-first', () => {
+    const byTherapist = normalTeam(10);
+    byTherapist['BAD1'] = { completed: 90, deliveredMinutes: 30, documentedRate: 0, noShow: 30 };
+    byTherapist['BAD2'] = { completed: 5, deliveredMinutes: 2000, documentedRate: 100, noShow: 0 };
+    const r = detectProductivityAnomalies({ byTherapist });
+    for (let i = 1; i < r.anomalies.length; i++) {
+      expect(r.anomalies[i - 1].score).toBeGreaterThanOrEqual(r.anomalies[i].score);
+    }
+  });
+
+  test('a uniform team produces no anomalies', () => {
+    const byTherapist = {};
+    for (let i = 0; i < 10; i++) {
+      byTherapist['u' + i] = { completed: 12, deliveredMinutes: 480, documentedRate: 95, noShow: 1 };
+    }
+    const r = detectProductivityAnomalies({ byTherapist });
+    expect(r.eligible).toBe(true);
+    expect(r.anomalies).toEqual([]);
+  });
+
+  test('< 8 therapists → not eligible (a small team is not a population)', () => {
+    const r = detectProductivityAnomalies({ byTherapist: { a: { completed: 5 }, b: { completed: 6 } } });
+    expect(r.eligible).toBe(false);
+    expect(r.reason).toMatch(/insufficient_therapists:2\/8/);
+    expect(r.anomalies).toEqual([]);
+  });
+
+  test('deterministic — same input + seed yields the same flagged set', () => {
+    const byTherapist = normalTeam(8);
+    byTherapist['X'] = { completed: 70, deliveredMinutes: 50, documentedRate: 5, noShow: 20 };
+    const a = detectProductivityAnomalies({ byTherapist, seed: 7 });
+    const b = detectProductivityAnomalies({ byTherapist, seed: 7 });
+    expect(a.anomalies.map((x) => x.therapistId)).toEqual(b.anomalies.map((x) => x.therapistId));
+  });
+
+  test('feature extractor: documentedRate defaults to 100 (no-sessions ≠ under-documenting)', () => {
+    expect(productivityFeatureExtractor({ completed: 0 })).toEqual([0, 0, 100, 0]);
+    expect(productivityFeatureExtractor({ completed: 5, deliveredMinutes: 200, documentedRate: 80, noShow: 2 })).toEqual([
+      5, 200, 80, 2,
+    ]);
+  });
+});
+
+describe('productivity-anomalies route (W1215) — static guard', () => {
+  const ROUTE_SRC = fs.readFileSync(
+    path.join(__dirname, '..', 'domains', 'goals', 'routes', 'supervisor-ops.routes.js'),
+    'utf-8'
+  );
+
+  test('declares GET /supervisor-ops/productivity-anomalies', () => {
+    expect(ROUTE_SRC).toMatch(/router\.get\(\s*['"]\/supervisor-ops\/productivity-anomalies['"]/);
+  });
+  test('W269 branch scoping + ObjectId validation + 400 reject', () => {
+    expect(ROUTE_SRC).toMatch(/effectiveBranchScope\(\s*req\s*\)/);
+    expect(ROUTE_SRC).not.toMatch(/req\.branchId/);
+    expect(ROUTE_SRC).toMatch(/branchId required/);
+  });
+  test('delegates to branchProductivity → detectProductivityAnomalies', () => {
+    expect(ROUTE_SRC).toMatch(/branchProductivity\(/);
+    expect(ROUTE_SRC).toMatch(/detectProductivityAnomalies\(/);
+  });
+  test('READ-ONLY — no mutation', () => {
+    expect(ROUTE_SRC).not.toMatch(
+      /\.(save|create|updateOne|updateMany|deleteOne|deleteMany|insertMany|findOneAndUpdate)\(/
+    );
+  });
+});

--- a/backend/domains/goals/routes/supervisor-ops.routes.js
+++ b/backend/domains/goals/routes/supervisor-ops.routes.js
@@ -28,6 +28,7 @@ const {
 const reassessmentLifecycleService = require('../../../services/reassessmentLifecycle.service');
 const { gatherBranchHealth } = require('../../../services/operationsHealth.service');
 const { reviewWorklist } = require('../../../services/rehabPlanHealth.service');
+const { detectProductivityAnomalies } = require('../../../services/operationsAnomaly.service');
 
 function asyncHandler(fn) {
   return (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
@@ -200,6 +201,40 @@ router.get(
     }
     const data = await dailyBoardForTherapist(therapistId, date ? { date } : {});
     return res.json({ success: true, data });
+  })
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /supervisor-ops/productivity-anomalies[?branchId=&days=]
+//   Tier-3 MULTIVARIATE anomaly scan (W1215): flags therapists whose COMBINATION
+//   of productivity metrics (sessions / minutes / documentation-rate / no-show)
+//   is anomalous vs their branch peers — a signal the univariate productivity
+//   view cannot see. Runs the (formerly dormant) isolation-forest engine over
+//   the W1173 branchProductivity output. Needs ≥8 therapists (else not eligible).
+//   Same W269 branch scoping. READ-ONLY.
+// ═══════════════════════════════════════════════════════════════════════════
+router.get(
+  '/supervisor-ops/productivity-anomalies',
+  asyncHandler(async (req, res) => {
+    const scoped = effectiveBranchScope(req);
+    let branchId = scoped || null;
+    if (!branchId && req.query.branchId && mongoose.isValidObjectId(req.query.branchId)) {
+      branchId = req.query.branchId;
+    }
+    if (!branchId) {
+      return res.status(400).json({
+        success: false,
+        error: 'branchId required — a cross-branch role must specify ?branchId.',
+      });
+    }
+
+    const sinceDays = Math.min(parseInt(req.query.days, 10) || 7, 90);
+    const prod = await branchProductivity({ branchId, sinceDays });
+    const data = detectProductivityAnomalies({ byTherapist: prod.byTherapist });
+    return res.json({
+      success: true,
+      data: { branchId: String(branchId), windowDays: prod.windowDays, ...data },
+    });
   })
 );
 

--- a/backend/services/operationsAnomaly.service.js
+++ b/backend/services/operationsAnomaly.service.js
@@ -1,0 +1,105 @@
+'use strict';
+
+/**
+ * operationsAnomaly.service.js — READ-ONLY Tier-3 multivariate anomaly scan (W1215).
+ * ════════════════════════════════════════════════════════════════════════════
+ * Wires the previously-dormant Tier-3 engine (services/isolationForest.service —
+ * "wire OR delete") into a concrete, useful, READ-ONLY operational surface: it
+ * flags therapists whose *combination* of productivity metrics is anomalous vs
+ * their peers — a multivariate signal the univariate supervisor views (each
+ * metric alone) cannot see. Examples it catches: high session count but very low
+ * documentation rate; unusual no-show pattern; minutes-vs-sessions mismatch.
+ *
+ * It does NOT touch the LIVE Tier-2 dashboard-KPI anomaly path (anomalyDetector
+ * .service) — it is an additive, self-contained scan over the W1173
+ * branchProductivity output. Pure given the productivity map; no DB here.
+ */
+
+const { buildIsolationForestDetector } = require('./isolationForest.service');
+
+// The 4 productivity features the isolation forest scores over. Order matters
+// (the vector is positional). Documentation rate defaults to 100 (a therapist
+// with no completed sessions is not "under-documenting").
+const PRODUCTIVITY_FEATURES = Object.freeze([
+  'completed',
+  'deliveredMinutes',
+  'documentedRate',
+  'noShow',
+]);
+
+function productivityFeatureExtractor(rec = {}) {
+  return [
+    Number(rec.completed) || 0,
+    Number(rec.deliveredMinutes) || 0,
+    typeof rec.documentedRate === 'number' ? rec.documentedRate : 100,
+    Number(rec.noShow) || 0,
+  ];
+}
+
+// The isolation forest needs ≥8 points to train a meaningful sub-sampled forest.
+const MIN_THERAPISTS = 8;
+
+/**
+ * PURE — given the W1173 branchProductivity `byTherapist` map, score each
+ * therapist's productivity vector against the whole-branch population via the
+ * Tier-3 isolation forest and return the anomalous ones (most-anomalous first).
+ *
+ * Degrades to `{ eligible:false }` when there are too few therapists for the
+ * forest — a small team is not a statistical population.
+ *
+ * @param {{ byTherapist?: Record<string, object>, threshold?: number, seed?: number }} opts
+ * @returns {{ eligible:boolean, reason?:string, scanned:number, threshold:number, anomalies:object[] }}
+ */
+function detectProductivityAnomalies(opts = {}) {
+  const byTherapist = opts.byTherapist || {};
+  const threshold = typeof opts.threshold === 'number' ? opts.threshold : 0.6;
+  const seed = typeof opts.seed === 'number' ? opts.seed : 1;
+
+  const records = Object.entries(byTherapist).map(([therapistId, stats]) => ({
+    therapistId,
+    ...stats,
+  }));
+
+  if (records.length < MIN_THERAPISTS) {
+    return {
+      eligible: false,
+      reason: `insufficient_therapists:${records.length}/${MIN_THERAPISTS}`,
+      scanned: records.length,
+      threshold,
+      anomalies: [],
+    };
+  }
+
+  const detector = buildIsolationForestDetector({
+    threshold,
+    seed,
+    featureExtractor: productivityFeatureExtractor,
+  });
+
+  const anomalies = [];
+  for (const rec of records) {
+    const verdict = detector.detect({ history: records, current: rec });
+    if (verdict.anomaly && typeof verdict.score === 'number') {
+      anomalies.push({
+        therapistId: rec.therapistId,
+        score: Math.round(verdict.score * 1000) / 1000,
+        features: {
+          completed: Number(rec.completed) || 0,
+          deliveredMinutes: Number(rec.deliveredMinutes) || 0,
+          documentedRate: typeof rec.documentedRate === 'number' ? rec.documentedRate : 100,
+          noShow: Number(rec.noShow) || 0,
+        },
+      });
+    }
+  }
+
+  anomalies.sort((a, b) => b.score - a.score);
+  return { eligible: true, scanned: records.length, threshold, anomalies };
+}
+
+module.exports = {
+  PRODUCTIVITY_FEATURES,
+  MIN_THERAPISTS,
+  productivityFeatureExtractor,
+  detectProductivityAnomalies,
+};

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1008,3 +1008,4 @@ __tests__/seed-hr-intelligence-wave1202.test.js
 __tests__/headcount-forecast-lib-wave1203.test.js
 __tests__/headcount-planning-routes-wave1203.test.js
 __tests__/headcount-plan-behavioral-wave1203.test.js
+__tests__/productivity-anomalies-wave1215.test.js


### PR DESCRIPTION
Closes the dormant-module audit's one genuine new-capability item: `services/isolationForest.service` (Tier-3 multivariate anomaly ML) was built but unwired ("wire OR delete"). This takes the **wire** option into a concrete READ-ONLY surface.

- **`GET /goals/supervisor-ops/productivity-anomalies`** — runs the isolation forest over the W1173 `branchProductivity` output, flagging therapists whose **combination** of (completed / minutes / documentedRate / noShow) is anomalous vs branch peers — a multivariate signal the univariate productivity view cannot see (e.g. many sessions but 0% documentation). Needs ≥8 therapists → else `eligible:false`. Deterministic (seeded). W269 branch-scoped, READ-ONLY.
- **Does NOT touch the live Tier-2 dashboard-KPI path** (`anomalyDetector.service`) — additive, self-contained.
- 11 assertions (outlier flagged · sorted · uniform→none · <8→not-eligible · deterministic · feature extractor · route guard). routes-load(567) + sprint green.

Reduces the dormant baseline by genuinely wiring (not deleting) the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)