### PR TITLE
feat(hr): W1207 — computed succession readiness (9-box + skills-gap + tenure)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1688,6 +1688,10 @@ on:
       - 'backend/__tests__/productivity-anomalies-wave1215.test.js'
       - 'backend/__tests__/official-letters-routes-wave1224.test.js'
       - 'backend/__tests__/official-letters-behavioral-wave1224.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/succession-readiness-lib-wave1207.test.js'
+      - 'backend/__tests__/succession-readiness-routes-wave1207.test.js'
+      - 'backend/__tests__/succession-readiness-service-wave1207.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3359,6 +3363,10 @@ on:
       - 'backend/__tests__/productivity-anomalies-wave1215.test.js'
       - 'backend/__tests__/official-letters-routes-wave1224.test.js'
       - 'backend/__tests__/official-letters-behavioral-wave1224.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/succession-readiness-lib-wave1207.test.js'
+      - 'backend/__tests__/succession-readiness-routes-wave1207.test.js'
+      - 'backend/__tests__/succession-readiness-service-wave1207.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/succession-readiness-lib-wave1207.test.js
+++ b/backend/__tests__/succession-readiness-lib-wave1207.test.js
@@ -1,0 +1,75 @@
+/**
+ * W1207 — pure unit tests for intelligence/succession-readiness.lib.
+ */
+
+'use strict';
+
+const L = require('../intelligence/succession-readiness.lib');
+
+describe('W1207 succession-readiness.lib — components', () => {
+  test('talentScore is potential-weighted (band 1→0, band 3→100)', () => {
+    expect(L.talentScore({ performanceBand: 3, potentialBand: 3 })).toBe(100);
+    expect(L.talentScore({ performanceBand: 1, potentialBand: 1 })).toBe(0);
+    // high performer / low potential < low performer / high potential (potential weighted higher)
+    expect(L.talentScore({ performanceBand: 3, potentialBand: 1 })).toBe(40);
+    expect(L.talentScore({ performanceBand: 1, potentialBand: 3 })).toBe(60);
+  });
+  test('tenureScore ramps linearly to full at 3 years', () => {
+    expect(L.tenureScore(0)).toBe(0);
+    expect(L.tenureScore(1.5)).toBe(50);
+    expect(L.tenureScore(3)).toBe(100);
+    expect(L.tenureScore(10)).toBe(100); // capped
+  });
+  test('levelOf bands', () => {
+    expect(L.levelOf(85).key).toBe('ready_now');
+    expect(L.levelOf(65).key).toBe('ready_1_2y');
+    expect(L.levelOf(45).key).toBe('ready_3y_plus');
+    expect(L.levelOf(20).key).toBe('not_ready');
+  });
+});
+
+describe('W1207 succession-readiness.lib — composite readiness', () => {
+  test('a star + high competency + tenured → ready_now', () => {
+    const r = L.readiness({ talentBands: { performanceBand: 3, potentialBand: 3 }, targetCompetencyReadinessPct: 90, tenureYears: 4 });
+    expect(r.score).toBe(96); // 100*.4 + 90*.4 + 100*.2
+    expect(r.level.key).toBe('ready_now');
+    expect(r.coverage.hasTalentReview).toBe(true);
+    expect(r.coverage.hasRoleBaseline).toBe(true);
+  });
+
+  test('low across the board → not_ready', () => {
+    const r = L.readiness({ talentBands: { performanceBand: 1, potentialBand: 1 }, targetCompetencyReadinessPct: 30, tenureYears: 1 });
+    expect(r.level.key).toBe('not_ready');
+  });
+
+  test('a MISSING component re-weights over the rest (does not zero the score)', () => {
+    // no role baseline (competency null) → weight redistributes to talent + tenure
+    const r = L.readiness({ talentBands: { performanceBand: 2, potentialBand: 3 }, targetCompetencyReadinessPct: null, tenureYears: 3 });
+    expect(r.components.competency).toBeNull();
+    expect(r.coverage.hasRoleBaseline).toBe(false);
+    // (talent 80 *.4 + tenure 100 *.2) / (.4+.2) = 86.7
+    expect(r.score).toBeCloseTo(86.7, 0);
+  });
+
+  test('no talent review AND no baseline → tenure-only', () => {
+    const r = L.readiness({ talentBands: null, targetCompetencyReadinessPct: null, tenureYears: 3 });
+    expect(r.score).toBe(100); // only tenure component, full
+    expect(r.coverage.hasTalentReview).toBe(false);
+  });
+
+  test('clamps competency input to [0,100]', () => {
+    const r = L.readiness({ talentBands: { performanceBand: 1, potentialBand: 1 }, targetCompetencyReadinessPct: 150, tenureYears: 0 });
+    expect(r.components.competency).toBe(100);
+  });
+});
+
+describe('W1207 succession-readiness.lib — ranking', () => {
+  test('rankCandidates sorts by score descending', () => {
+    const ranked = L.rankCandidates([
+      { employeeId: 'a', readiness: { score: 40 } },
+      { employeeId: 'b', readiness: { score: 85 } },
+      { employeeId: 'c', readiness: { score: 60 } },
+    ]);
+    expect(ranked.map(r => r.employeeId)).toEqual(['b', 'c', 'a']);
+  });
+});

--- a/backend/__tests__/succession-readiness-routes-wave1207.test.js
+++ b/backend/__tests__/succession-readiness-routes-wave1207.test.js
@@ -1,0 +1,43 @@
+/**
+ * W1207 — static drift guard for the succession-readiness route surface + mount.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROUTE = path.join(__dirname, '..', 'routes', 'hr', 'succession-readiness.routes.js');
+const REGISTRY = path.join(__dirname, '..', 'routes', 'registries', 'hr.registry.js');
+const src = fs.readFileSync(ROUTE, 'utf8');
+const reg = fs.readFileSync(REGISTRY, 'utf8');
+
+describe('W1207 succession-readiness routes — auth + isolation', () => {
+  test('self-authenticates + requireBranchAccess', () => {
+    expect(src).toMatch(/router\.use\(\s*authenticateToken\s*\)/);
+    expect(src).toMatch(/router\.use\(\s*requireBranchAccess\s*\)/);
+  });
+  test('W269: effectiveBranchScope + enforceEmployeeBranch, never req.branchId', () => {
+    expect(src).toMatch(/effectiveBranchScope\(req\)/);
+    expect(src).toMatch(/enforceEmployeeBranch/);
+    expect(src).not.toMatch(/req\.branchId/);
+  });
+  test('every route is role-gated; per-employee read goes through guardEmployee', () => {
+    const verbs = [...src.matchAll(/router\.(get|post)\(\s*'[^']+'\s*,\s*([A-Za-z_$][\w$]*)/g)];
+    expect(verbs.length).toBe(2);
+    for (const m of verbs) expect(m[2]).toBe('requireRole');
+    expect(src).toMatch(/guardEmployee\(req,\s*res,\s*req\.params\.employeeId\)/);
+  });
+});
+
+describe('W1207 succession-readiness routes — endpoints + mount', () => {
+  test('exposes the 2 endpoints', () => {
+    expect(src).toMatch(/router\.get\(\s*'\/employee\/:employeeId'/);
+    expect(src).toMatch(/router\.get\(\s*'\/candidates'/);
+  });
+  test('mounted in hr.registry at /api(/v1)?/hr/succession-readiness', () => {
+    expect(reg).toMatch(/succession-readiness\.routes/);
+    expect(reg).toMatch(/app\.use\(\s*'\/api\/hr\/succession-readiness'/);
+    expect(reg).toMatch(/app\.use\(\s*'\/api\/v1\/hr\/succession-readiness'/);
+  });
+});

--- a/backend/__tests__/succession-readiness-service-wave1207.test.js
+++ b/backend/__tests__/succession-readiness-service-wave1207.test.js
@@ -1,0 +1,93 @@
+/**
+ * W1207 — successionReadinessService integration (models mocked via mongoose.model).
+ * Verifies employeeReadiness fuses 9-box + target-role competency + tenure, and
+ * candidatesForRole ranks. No DB.
+ */
+
+'use strict';
+
+const mongoose = require('mongoose');
+
+// chainable query stubs
+const lean = (val) => ({ lean: async () => val });
+const selectLean = (val) => ({ select: () => lean(val) });
+const sortSelectLean = (val) => ({ sort: () => selectLean(val) });
+
+function installModels({ emp, tr, reqs, comps }) {
+  jest.spyOn(mongoose, 'model').mockImplementation((name) => {
+    if (name === 'Employee') {
+      return {
+        findById: () => selectLean(emp),
+        find: () => ({ select: () => ({ limit: () => lean([{ _id: 'e1' }]) }) }),
+      };
+    }
+    if (name === 'TalentReview') return { findOne: () => sortSelectLean(tr) };
+    if (name === 'RoleCompetencyRequirement') return { find: () => lean(reqs) };
+    if (name === 'EmployeeCompetency') return { find: () => selectLean(comps) };
+    throw new Error(`unexpected model ${name}`);
+  });
+}
+
+const svc = require('../services/hr/successionReadinessService');
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('W1207 successionReadinessService.employeeReadiness', () => {
+  test('fuses talent + target competency + tenure into a ready_now score', () => {
+    installModels({
+      emp: { _id: 'e1', full_name: 'سارة', job_title_en: 'Therapist', hire_date: new Date('2021-01-01'), department: 'PT' },
+      tr: { performanceBand: 3, potentialBand: 3, box: 9 },
+      // target role 'Senior' requires assessment@4 — she has it at 4 → 100% readiness
+      reqs: [{ competencyKey: 'assessment', competencyNameAr: 'التقييم', requiredLevel: 4, criticality: 'core' }],
+      comps: [{ competencyKey: 'assessment', currentLevel: 4 }],
+    });
+    return svc.employeeReadiness({ employeeId: 'e1', targetJobTitle: 'Senior' }).then((r) => {
+      expect(r.name).toBe('سارة');
+      expect(r.box).toBe(9);
+      expect(r.components.competency).toBe(100);
+      expect(r.components.talent).toBe(100);
+      expect(r.level.key).toBe('ready_now');
+      expect(r.score).toBeGreaterThanOrEqual(80);
+    });
+  });
+
+  test('no TalentReview + no role baseline → tenure-only, graceful', () => {
+    installModels({
+      emp: { _id: 'e1', name: 'X', hire_date: new Date('2024-01-01') },
+      tr: null,
+      reqs: [], // no baseline for target → competency null
+      comps: [],
+    });
+    return svc.employeeReadiness({ employeeId: 'e1', targetJobTitle: 'Unknown' }).then((r) => {
+      expect(r.coverage.hasTalentReview).toBe(false);
+      expect(r.coverage.hasRoleBaseline).toBe(false);
+      expect(typeof r.score).toBe('number');
+    });
+  });
+
+  test('returns null when the employee is missing', () => {
+    installModels({ emp: null, tr: null, reqs: [], comps: [] });
+    return svc.employeeReadiness({ employeeId: 'nope' }).then((r) => expect(r).toBeNull());
+  });
+});
+
+describe('W1207 successionReadinessService.candidatesForRole', () => {
+  test('requires a targetJobTitle', async () => {
+    installModels({ emp: null, tr: null, reqs: [], comps: [] });
+    await expect(svc.candidatesForRole({ branchId: 'b1' })).rejects.toThrow(/targetJobTitle/);
+  });
+  test('ranks the branch workforce for a target role', () => {
+    installModels({
+      emp: { _id: 'e1', name: 'X', hire_date: new Date('2022-01-01') },
+      tr: { performanceBand: 2, potentialBand: 2, box: 5 },
+      reqs: [{ competencyKey: 'k', competencyNameAr: 'ك', requiredLevel: 3, criticality: 'core' }],
+      comps: [{ competencyKey: 'k', currentLevel: 2 }],
+    });
+    return svc.candidatesForRole({ branchId: 'b1', targetJobTitle: 'Senior' }).then((d) => {
+      expect(d.targetJobTitle).toBe('Senior');
+      expect(d.assessed).toBe(1);
+      expect(d.candidates).toHaveLength(1);
+      expect(typeof d.candidates[0].score).toBe('number');
+    });
+  });
+});

--- a/backend/intelligence/succession-readiness.lib.js
+++ b/backend/intelligence/succession-readiness.lib.js
@@ -1,0 +1,102 @@
+/**
+ * succession-readiness.lib.js — pure data-driven succession readiness (W1207).
+ *
+ * The INTEGRATIVE layer: combines an employee's 9-box placement (W1198 talent),
+ * their competency coverage of the TARGET role (W1201 skills-gap, against the
+ * target's RoleCompetencyRequirement — not their current role), and their tenure
+ * into a readiness score + level. Distinct from the existing succession feature,
+ * which only stores a MANUALLY-entered readinessPercentage.
+ *
+ * All pure (no DB, no Date). Score 0-100, three weighted components:
+ *   - talent      (40%): leans on POTENTIAL (can they grow into a bigger role?)
+ *                        plus PERFORMANCE (do they deliver today?), from the 9-box bands
+ *   - competency  (40%): % of the TARGET role's competency requirement they meet
+ *   - tenure      (20%): enough experience to step up (ramps to full by ~3 years)
+ */
+
+'use strict';
+
+const WEIGHTS = Object.freeze({ talent: 0.4, competency: 0.4, tenure: 0.2 });
+const TENURE_FULL_YEARS = 3; // tenure at/above this contributes 100% of its component
+
+function clamp01to100(n) {
+  const v = Number(n);
+  if (!Number.isFinite(v) || v < 0) return 0;
+  if (v > 100) return 100;
+  return v;
+}
+function round(n, dp = 1) {
+  const f = 10 ** dp;
+  return Math.round((Number(n) || 0) * f) / f;
+}
+
+/** 9-box bands (1-3 each) → a 0-100 talent component (potential-weighted). */
+function talentScore({ performanceBand, potentialBand } = {}) {
+  const perf = Math.min(3, Math.max(1, Math.round(Number(performanceBand) || 1)));
+  const pot = Math.min(3, Math.max(1, Math.round(Number(potentialBand) || 1)));
+  // potential 0.6 / performance 0.4, normalised from band-1 (so band 1→0, band 3→100)
+  const weighted = (pot - 1) * 0.6 + (perf - 1) * 0.4; // 0..2
+  return round((weighted / 2) * 100);
+}
+
+/** tenure years → 0-100, ramps linearly to full by TENURE_FULL_YEARS. */
+function tenureScore(tenureYears) {
+  const y = Math.max(0, Number(tenureYears) || 0);
+  return round(Math.min(1, y / TENURE_FULL_YEARS) * 100);
+}
+
+function levelOf(score) {
+  if (score >= 80) return { key: 'ready_now', ar: 'جاهز الآن' };
+  if (score >= 60) return { key: 'ready_1_2y', ar: 'جاهز خلال 1-2 سنة' };
+  if (score >= 40) return { key: 'ready_3y_plus', ar: 'جاهز بعد 3+ سنوات' };
+  return { key: 'not_ready', ar: 'غير جاهز' };
+}
+
+/**
+ * @param {object} p
+ * @param {object} [p.talentBands] { performanceBand, potentialBand } — null if no 9-box review
+ * @param {number} [p.targetCompetencyReadinessPct] 0-100 — coverage of the TARGET role (null if no baseline)
+ * @param {number} [p.tenureYears]
+ */
+function readiness({ talentBands, targetCompetencyReadinessPct, tenureYears } = {}) {
+  const components = {
+    talent: talentBands ? talentScore(talentBands) : null,
+    competency: targetCompetencyReadinessPct == null ? null : clamp01to100(targetCompetencyReadinessPct),
+    tenure: tenureScore(tenureYears),
+  };
+  // re-weight over only the components we actually have (a missing 9-box review or
+  // role baseline shouldn't zero the score — it widens the others' weight).
+  let wSum = 0;
+  let acc = 0;
+  for (const [k, w] of Object.entries(WEIGHTS)) {
+    if (components[k] == null) continue;
+    wSum += w;
+    acc += components[k] * w;
+  }
+  const score = wSum ? round(acc / wSum) : 0;
+  return {
+    score,
+    level: levelOf(score),
+    components,
+    coverage: {
+      hasTalentReview: components.talent != null,
+      hasRoleBaseline: components.competency != null,
+    },
+    weights: WEIGHTS,
+  };
+}
+
+/** Rank candidates (each {employeeId, name, readiness}) by score desc. */
+function rankCandidates(candidates) {
+  return [...(candidates || [])].sort((a, b) => (b.readiness?.score || 0) - (a.readiness?.score || 0));
+}
+
+module.exports = {
+  WEIGHTS,
+  TENURE_FULL_YEARS,
+  talentScore,
+  tenureScore,
+  levelOf,
+  readiness,
+  rankCandidates,
+};

--- a/backend/routes/hr/succession-readiness.routes.js
+++ b/backend/routes/hr/succession-readiness.routes.js
@@ -1,0 +1,77 @@
+'use strict';
+
+/**
+ * succession-readiness.routes.js — computed succession readiness surface (W1207).
+ *
+ * Mount: /api/hr/succession-readiness + /api/v1/... (self-authed → safe under the
+ * plain hr.registry app.use mount, W1190/W1191).
+ *
+ *   GET /employee/:employeeId?targetRole=...  — computed readiness for one employee
+ *   GET /candidates?targetRole=...            — branch employees ranked for a target role
+ *
+ * The data-driven SUGGESTION (9-box + target-role competency + tenure) the manual
+ * succession-planning feature lacks. Branch isolation: enforceEmployeeBranch on the
+ * per-employee read, effectiveBranchScope on the candidate ranking (W269 — caller's
+ * own branch). Identity-bearing leadership data → role-gated.
+ */
+
+const express = require('express');
+const router = express.Router();
+
+const { authenticateToken, requireRole } = require('../../middleware/auth');
+const { requireBranchAccess } = require('../../middleware/branchScope.middleware');
+const { effectiveBranchScope, enforceEmployeeBranch } = require('../../middleware/assertBranchMatch');
+const safeError = require('../../utils/safeError');
+const svc = require('../../services/hr/successionReadinessService');
+
+const READ_ROLES = ['admin', 'superadmin', 'super_admin', 'hr_manager', 'hr_director', 'manager'];
+
+router.use(authenticateToken);
+router.use(requireBranchAccess);
+
+function mapErr(res, err, ctx) {
+  if (err && err.code === 'MODEL_UNAVAILABLE') return res.status(503).json({ success: false, error: err.message });
+  if (err && err.code === 'VALIDATION') return res.status(400).json({ success: false, error: err.message });
+  return safeError(res, err, ctx);
+}
+
+async function guardEmployee(req, res, employeeId) {
+  try {
+    await enforceEmployeeBranch(req, employeeId); // W269 — throws 403/404 cross-branch
+    return false;
+  } catch (err) {
+    res.status(err.status || 403).json({ success: false, error: err.message });
+    return true;
+  }
+}
+
+/** GET /employee/:employeeId — computed readiness for one employee. */
+router.get('/employee/:employeeId', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    if (await guardEmployee(req, res, req.params.employeeId)) return; // W269
+    const data = await svc.employeeReadiness({
+      employeeId: req.params.employeeId,
+      targetJobTitle: req.query.targetRole ? String(req.query.targetRole) : null,
+    });
+    if (!data) return res.status(404).json({ success: false, error: 'employee not found' });
+    res.json({ success: true, data });
+  } catch (err) {
+    mapErr(res, err, 'succession-readiness:employee');
+  }
+});
+
+/** GET /candidates?targetRole=... — branch employees ranked for a target role. */
+router.get('/candidates', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    if (!req.query.targetRole) {
+      return res.status(400).json({ success: false, error: 'targetRole query param required' });
+    }
+    const branchId = effectiveBranchScope(req); // W269 — own branch or null (HQ)
+    const data = await svc.candidatesForRole({ branchId, targetJobTitle: String(req.query.targetRole) });
+    res.json({ success: true, data });
+  } catch (err) {
+    mapErr(res, err, 'succession-readiness:candidates');
+  }
+});
+
+module.exports = router;

--- a/backend/routes/registries/hr.registry.js
+++ b/backend/routes/registries/hr.registry.js
@@ -245,5 +245,16 @@ module.exports = function registerHrRoutes(app, { safeRequire, dualMount, safeMo
     logger.warn('[HR] Headcount planning routes not mounted (module missing)');
   }
 
+  // ── Succession readiness (W1207 — computed: 9-box + target-role competency + tenure) ─
+  // Self-authenticating; integrates W1198 talent + W1201 skills-gap. Branch-isolated.
+  const successionReadinessRouter = safeRequire('../routes/hr/succession-readiness.routes');
+  if (successionReadinessRouter) {
+    app.use('/api/hr/succession-readiness', successionReadinessRouter);
+    app.use('/api/v1/hr/succession-readiness', successionReadinessRouter);
+    logger.info('[HR] Succession readiness mounted (/api/(v1/)?hr/succession-readiness)');
+  } else {
+    logger.warn('[HR] Succession readiness routes not mounted (module missing)');
+  }
+
   logger.info('[HR] All ~25 HR/Employee/Workforce modules mounted successfully');
 };

--- a/backend/services/hr/successionReadinessService.js
+++ b/backend/services/hr/successionReadinessService.js
@@ -1,0 +1,120 @@
+'use strict';
+
+/**
+ * successionReadinessService.js — computed succession readiness (W1207).
+ *
+ * Integrates three existing data sources into a data-driven readiness score for an
+ * employee against a TARGET role:
+ *   - 9-box placement      (W1198 TalentReview — latest)
+ *   - target-role competency coverage (W1201: the TARGET jobTitle's
+ *     RoleCompetencyRequirement vs the employee's EmployeeCompetency, via skills-gap.lib)
+ *   - tenure               (Employee.hire_date)
+ *
+ * Complements the existing (manual) succession-planning feature; this is the
+ * data-driven SUGGESTION the manual assessment lacked. Lazy model lookup.
+ */
+
+const readinessLib = require('../../intelligence/succession-readiness.lib');
+const skillsLib = require('../../intelligence/skills-gap.lib');
+
+function getModel(name, file) {
+  const mongoose = require('mongoose');
+  try {
+    return mongoose.model(name);
+  } catch {
+    try {
+      require(file);
+      return mongoose.model(name);
+    } catch {
+      return null;
+    }
+  }
+}
+
+const MS_PER_YEAR = 1000 * 60 * 60 * 24 * 365.25;
+function tenureYears(hireDate) {
+  if (!hireDate) return 0;
+  const t = new Date(hireDate).getTime();
+  if (!Number.isFinite(t)) return 0;
+  return Math.max(0, (Date.now() - t) / MS_PER_YEAR);
+}
+
+/** Latest TalentReview bands for an employee, or null. */
+async function latestBands(TalentReview, employeeId) {
+  if (!TalentReview) return null;
+  const tr = await TalentReview.findOne({ employeeId }).sort({ createdAt: -1 }).select('performanceBand potentialBand box').lean();
+  return tr ? { performanceBand: tr.performanceBand, potentialBand: tr.potentialBand, box: tr.box } : null;
+}
+
+/** Target-role competency readiness % (0-100) for an employee, or null if no baseline. */
+async function targetCompetencyReadiness(RCR, EC, employeeId, targetJobTitle) {
+  if (!RCR || !EC || !targetJobTitle) return null;
+  const reqs = await RCR.find({ jobTitle: targetJobTitle, active: true }).lean();
+  if (!reqs.length) return null;
+  const comps = await EC.find({ employeeId }).select('competencyKey currentLevel').lean();
+  const current = {};
+  for (const c of comps) current[c.competencyKey] = c.currentLevel;
+  return skillsLib.employeeGaps(reqs, current).readinessPct;
+}
+
+/** Computed readiness for one employee against a target role. */
+async function employeeReadiness({ employeeId, targetJobTitle = null } = {}) {
+  const Employee = getModel('Employee', '../../models/HR/Employee');
+  const TalentReview = getModel('TalentReview', '../../models/HR/TalentReview');
+  const RCR = getModel('RoleCompetencyRequirement', '../../models/HR/RoleCompetencyRequirement');
+  const EC = getModel('EmployeeCompetency', '../../models/HR/EmployeeCompetency');
+  if (!Employee) {
+    const e = new Error('Employee model unavailable');
+    e.code = 'MODEL_UNAVAILABLE';
+    throw e;
+  }
+  const emp = await Employee.findById(employeeId).select('job_title_en job_title_ar full_name name department hire_date branch_id').lean();
+  if (!emp) return null;
+
+  const bands = await latestBands(TalentReview, employeeId);
+  const compReadiness = await targetCompetencyReadiness(RCR, EC, employeeId, targetJobTitle);
+  const r = readinessLib.readiness({
+    talentBands: bands,
+    targetCompetencyReadinessPct: compReadiness,
+    tenureYears: tenureYears(emp.hire_date),
+  });
+  return {
+    employeeId,
+    name: emp.full_name || emp.name || null,
+    currentJobTitle: emp.job_title_en || emp.job_title_ar || null,
+    targetJobTitle: targetJobTitle || null,
+    tenureYears: Math.round(tenureYears(emp.hire_date) * 10) / 10,
+    box: bands ? bands.box : null,
+    ...r,
+  };
+}
+
+/** Rank branch employees by readiness for a target role. */
+async function candidatesForRole({ branchId, targetJobTitle, limit = 1000 } = {}) {
+  const Employee = getModel('Employee', '../../models/HR/Employee');
+  if (!Employee) {
+    const e = new Error('Employee model unavailable');
+    e.code = 'MODEL_UNAVAILABLE';
+    throw e;
+  }
+  if (!targetJobTitle) {
+    const e = new Error('targetJobTitle is required');
+    e.code = 'VALIDATION';
+    throw e;
+  }
+  const filter = { status: 'active', deleted_at: null };
+  if (branchId) filter.branch_id = branchId; // branch isolation (caller-resolved)
+  const emps = await Employee.find(filter).select('_id').limit(Math.min(Number(limit) || 1000, 2000)).lean();
+  const results = [];
+  for (const e of emps) {
+    const r = await employeeReadiness({ employeeId: e._id, targetJobTitle });
+    if (r) results.push(r);
+  }
+  return {
+    targetJobTitle,
+    assessed: results.length,
+    candidates: readinessLib.rankCandidates(results).slice(0, 100),
+  };
+}
+
+module.exports = { tenureYears, employeeReadiness, candidatesForRole };

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1011,3 +1011,6 @@ __tests__/headcount-plan-behavioral-wave1203.test.js
 __tests__/official-letters-routes-wave1224.test.js
 __tests__/official-letters-behavioral-wave1224.test.js
 __tests__/productivity-anomalies-wave1215.test.js
+__tests__/succession-readiness-lib-wave1207.test.js
+__tests__/succession-readiness-routes-wave1207.test.js
+__tests__/succession-readiness-service-wave1207.test.js


### PR DESCRIPTION
## What

Audit-first: the succession-planning feature **exists** but its readiness is **manually entered** (`readinessPercentage` from `req.body`). This adds the **data-driven suggestion** it lacks — the **integrative capstone** fusing the talent + competency work into one actionable *"who is ready to step up?"* score. New surface; does **not** touch the existing succession routes.

## What it computes — `intelligence/succession-readiness.lib.js` (pure, explainable)

Readiness 0-100 from three weighted components, against a **target role**:

| Component | Weight | Source |
| --- | --- | --- |
| **talent** | 40% | potential-weighted from the 9-box bands (W1198 `TalentReview`) |
| **competency** | 40% | % of the **target** role's `RoleCompetencyRequirement` met (W1201 skills-gap) |
| **tenure** | 20% | ramps to full by 3 years |

A **missing** component (no 9-box review / no role baseline) **re-weights over the rest** rather than zeroing the score. Levels: `ready_now` / `ready_1_2y` / `ready_3y_plus` / `not_ready`.

## Stack — pure orchestration (no new model; computes on-the-fly)

- **`services/hr/successionReadinessService.js`** — `employeeReadiness` (latest `TalentReview` bands + `EmployeeCompetency` vs the **target** jobTitle's `RoleCompetencyRequirement` via `skills-gap.lib` + tenure from `hire_date`), `candidatesForRole` (ranks the branch workforce for a target role). Lazy model lookup.
- **`routes/hr/succession-readiness.routes.js`** — 2 endpoints, self-authed, **branch-isolated** (`enforceEmployeeBranch` on the per-employee read + `effectiveBranchScope` on candidate ranking, no `req.branchId`), role-gated. Mounted in `hr.registry`.

**Endpoints:** `GET /employee/:id?targetRole=` · `GET /candidates?targetRole=` — under `/api/(v1/)?hr/succession-readiness`.

## Tests — 19 assertions / 3 sprint-enumerated files

lib unit (components, composite, re-weighting on missing data, ranking) + routes static (auth / W269 / role gating / mount) + service integration (models mocked via `mongoose.model` — fuses the 3 sources, graceful on missing data, ranks).

## Verified locally

`check:routes-load` · `check:sprint-paths` in sync · `check:gitignored-sources` · `no-broken-requires` · 19/19 green.

> Note: main has unrelated **pre-existing** reds (Sprint Tests yml + phantom refs from the parallel forms merges) — inherited; verified independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)