### PR TITLE
feat(finance): expense anomaly scan — extend Tier-3 engine to a gap domain (W1218)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1689,13 +1689,11 @@ on:
       - 'backend/__tests__/official-letters-routes-wave1224.test.js'
       - 'backend/__tests__/official-letters-behavioral-wave1224.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
-<<<<<<< HEAD
-      - 'backend/__tests__/expense-anomaly-wave1218.test.js'
-=======
       - 'backend/__tests__/succession-readiness-lib-wave1207.test.js'
       - 'backend/__tests__/succession-readiness-routes-wave1207.test.js'
       - 'backend/__tests__/succession-readiness-service-wave1207.test.js'
->>>>>>> origin/main
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/expense-anomaly-wave1218.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3368,13 +3366,11 @@ on:
       - 'backend/__tests__/official-letters-routes-wave1224.test.js'
       - 'backend/__tests__/official-letters-behavioral-wave1224.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
-<<<<<<< HEAD
-      - 'backend/__tests__/expense-anomaly-wave1218.test.js'
-=======
       - 'backend/__tests__/succession-readiness-lib-wave1207.test.js'
       - 'backend/__tests__/succession-readiness-routes-wave1207.test.js'
       - 'backend/__tests__/succession-readiness-service-wave1207.test.js'
->>>>>>> origin/main
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/expense-anomaly-wave1218.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1688,6 +1688,8 @@ on:
       - 'backend/__tests__/productivity-anomalies-wave1215.test.js'
       - 'backend/__tests__/official-letters-routes-wave1224.test.js'
       - 'backend/__tests__/official-letters-behavioral-wave1224.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/expense-anomaly-wave1218.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3359,6 +3361,8 @@ on:
       - 'backend/__tests__/productivity-anomalies-wave1215.test.js'
       - 'backend/__tests__/official-letters-routes-wave1224.test.js'
       - 'backend/__tests__/official-letters-behavioral-wave1224.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/expense-anomaly-wave1218.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/expense-anomaly-wave1218.test.js
+++ b/backend/__tests__/expense-anomaly-wave1218.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+/**
+ * expense-anomaly-wave1218.test.js — unit tests for the READ-ONLY financial
+ * expense anomaly scan (services/financeAnomaly.service.js) — the Tier-3
+ * isolation-forest applied to a domain that had no anomaly detection.
+ *
+ * Pure logic — no DB. Requiring the service/CLI must NOT open a connection.
+ *
+ * Run: cd backend && npx jest --config=jest.config.js __tests__/expense-anomaly-wave1218.test.js
+ */
+
+const {
+  detectExpenseAnomalies,
+  expenseFeatureExtractor,
+  EXPENSE_FEATURES,
+  MIN_EXPENSES,
+} = require('../services/financeAnomaly.service');
+
+// A normal population: card expenses, business-day, varied non-round amounts.
+function normalExpenses(n) {
+  const out = [];
+  // Mondays in Jan 2026 (business days, getDay 1..5)
+  for (let i = 0; i < n; i++) {
+    out.push({
+      _id: 'e' + i,
+      amount: 320 + i * 37, // non-round, moderate
+      date: new Date(2026, 0, 5 + (i % 5)), // Jan 5–9 2026 = Mon–Fri
+      category: 'office_supplies',
+      paymentMethod: 'credit_card',
+    });
+  }
+  return out;
+}
+
+describe('financeAnomaly — detectExpenseAnomalies (pure, Tier-3 IF)', () => {
+  test('requiring the service does NOT open a DB connection + exposes the surface', () => {
+    expect(typeof detectExpenseAnomalies).toBe('function');
+    expect(EXPENSE_FEATURES).toEqual(['amount', 'dayOfWeek', 'isCash', 'isRoundThousand']);
+    expect(MIN_EXPENSES).toBe(8);
+  });
+
+  test('flags a large round-number weekend cash expense among a normal population', () => {
+    const expenses = normalExpenses(9);
+    expenses.push({
+      _id: 'SUSPECT',
+      amount: 50000, // large + round thousand
+      date: new Date(2026, 0, 10), // 2026-01-10 = Saturday
+      category: 'office_supplies',
+      paymentMethod: 'cash',
+    });
+    const r = detectExpenseAnomalies({ expenses });
+    expect(r.eligible).toBe(true);
+    expect(r.scanned).toBe(10);
+    const flagged = r.anomalies.find(a => a.expenseId === 'SUSPECT');
+    expect(flagged).toBeTruthy();
+    expect(flagged.score).toBeGreaterThan(r.threshold);
+    expect(flagged.signals).toEqual(expect.arrayContaining(['cash', 'round_thousand', 'weekend']));
+  });
+
+  test('a uniform population produces no anomalies', () => {
+    const expenses = [];
+    for (let i = 0; i < 10; i++) {
+      expenses.push({
+        _id: 'u' + i,
+        amount: 500,
+        date: new Date(2026, 0, 6), // Tue
+        category: 'rent',
+        paymentMethod: 'bank_transfer',
+      });
+    }
+    const r = detectExpenseAnomalies({ expenses });
+    expect(r.eligible).toBe(true);
+    expect(r.anomalies).toEqual([]);
+  });
+
+  test('< 8 expenses → not eligible (no population)', () => {
+    const r = detectExpenseAnomalies({ expenses: [{ amount: 100 }, { amount: 200 }] });
+    expect(r.eligible).toBe(false);
+    expect(r.reason).toMatch(/insufficient_expenses:2\/8/);
+    expect(r.anomalies).toEqual([]);
+  });
+
+  test('anomalies sorted most-anomalous-first + deterministic (seeded)', () => {
+    const expenses = normalExpenses(9);
+    expenses.push({ _id: 'BIG', amount: 90000, date: new Date(2026, 0, 11), paymentMethod: 'cash', category: 'x' });
+    const a = detectExpenseAnomalies({ expenses, seed: 5 });
+    const b = detectExpenseAnomalies({ expenses, seed: 5 });
+    expect(a.anomalies.map(x => x.expenseId)).toEqual(b.anomalies.map(x => x.expenseId));
+    for (let i = 1; i < a.anomalies.length; i++) {
+      expect(a.anomalies[i - 1].score).toBeGreaterThanOrEqual(a.anomalies[i].score);
+    }
+  });
+
+  test('feature extractor: [amount, dayOfWeek, isCash, isRoundThousand]', () => {
+    // 2026-01-10 = Saturday (getDay 6); 5000 round + cash
+    expect(expenseFeatureExtractor({ amount: 5000, date: new Date(2026, 0, 10), paymentMethod: 'cash' })).toEqual([
+      5000, 6, 1, 1,
+    ]);
+    // 2026-01-06 = Tuesday (getDay 2); 1337 non-round + card
+    expect(expenseFeatureExtractor({ amount: 1337, date: new Date(2026, 0, 6), paymentMethod: 'credit_card' })).toEqual([
+      1337, 2, 0, 0,
+    ]);
+    // missing fields → safe defaults
+    expect(expenseFeatureExtractor({})).toEqual([0, 0, 0, 0]);
+  });
+
+  test('CLI requires the service without connecting (require.main guard)', () => {
+    const cli = require('../scripts/expense-anomaly-scan');
+    expect(typeof cli.detectExpenseAnomalies).toBe('function');
+  });
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -72,6 +72,7 @@
     "audit:goal-consolidation": "node scripts/goal-model-consolidation-readiness.js",
     "audit:operations-health": "node scripts/operations-health.js",
     "consolidate:smartgoal": "node scripts/consolidate-smartgoal.js",
+    "audit:expense-anomalies": "node scripts/expense-anomaly-scan.js",
     "verify:supply-chain-staging": "node scripts/verify-supply-chain-staging.js",
     "verify:supply-chain-staging:json": "node scripts/verify-supply-chain-staging.js --json",
     "backfill:complaint-branchid": "node scripts/backfill-complaint-branchid.js",

--- a/backend/scripts/expense-anomaly-scan.js
+++ b/backend/scripts/expense-anomaly-scan.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * expense-anomaly-scan.js — READ-ONLY financial expense anomaly audit (W1218).
+ * ════════════════════════════════════════════════════════════════════════════
+ * Runs the Tier-3 isolation-forest engine (services/financeAnomaly.service) over
+ * a branch's recent expenses and prints the anomalous ones — expenses whose
+ * COMBINATION of [amount, day-of-week, cash, round-thousand] is unusual vs the
+ * population. Surfaces audit/fraud-review candidates that a flat amount threshold
+ * misses. A single read-only aggregation; mutates nothing. Safe against prod.
+ *
+ * Usage:
+ *   MONGODB_URI=mongodb://... node scripts/expense-anomaly-scan.js --branch=<id>
+ *   MONGODB_URI=mongodb://... node scripts/expense-anomaly-scan.js --branch=<id> --days=180 --json
+ *
+ * Exit codes: 0 = scan ran · 2 = usage/connection error.
+ */
+
+const { detectExpenseAnomalies } = require('../services/financeAnomaly.service');
+
+const JSON_OUT = process.argv.includes('--json');
+const BRANCH_ARG = (process.argv.find(a => a.startsWith('--branch=')) || '').split('=')[1] || null;
+const DAYS_ARG = parseInt((process.argv.find(a => a.startsWith('--days=')) || '').split('=')[1], 10);
+const SINCE_DAYS = Number.isFinite(DAYS_ARG) && DAYS_ARG > 0 ? DAYS_ARG : 90;
+
+function log(...a) {
+  if (!JSON_OUT) console.log(...a);
+}
+
+async function main() {
+  if (!process.env.MONGODB_URI) {
+    console.error('Error: MONGODB_URI environment variable required.');
+    process.exit(2);
+  }
+
+  const mongoose = require('mongoose');
+  await mongoose.connect(process.env.MONGODB_URI);
+
+  let Expense;
+  try {
+    Expense = require('../models/Expense');
+  } catch {
+    console.error('Error: Expense model could not be loaded.');
+    await mongoose.disconnect();
+    process.exit(2);
+  }
+
+  const since = new Date();
+  since.setDate(since.getDate() - SINCE_DAYS);
+  const query = { isDeleted: { $ne: true }, date: { $gte: since } };
+  if (BRANCH_ARG && mongoose.isValidObjectId(BRANCH_ARG)) {
+    query.branchId = new mongoose.Types.ObjectId(BRANCH_ARG);
+  }
+
+  const expenses = await Expense.find(query)
+    .select('amount date category paymentMethod vendor branchId')
+    .lean();
+
+  const result = detectExpenseAnomalies({ expenses });
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify({ branch: BRANCH_ARG || 'all', windowDays: SINCE_DAYS, ...result }, null, 2));
+  } else {
+    log('');
+    log(`Expense anomaly scan (READ-ONLY)${BRANCH_ARG ? ` — branch ${BRANCH_ARG}` : ''}, window ${SINCE_DAYS}d`);
+    log('──────────────────────────────────────────────────────────────────');
+    if (!result.eligible) {
+      log(`  Not eligible: ${result.reason} (need ≥8 expenses for a population).`);
+    } else {
+      log(`  Scanned ${result.scanned} expense(s) · threshold ${result.threshold} · ${result.anomalies.length} anomalous`);
+      log('');
+      for (const a of result.anomalies) {
+        log(
+          `  ⚠ score ${a.score}  amount ${a.amount}  ${a.category || '—'}  ${a.paymentMethod || '—'}` +
+            `${a.signals.length ? `  [${a.signals.join(', ')}]` : ''}${a.vendor ? `  ${a.vendor}` : ''}`
+        );
+      }
+      if (result.anomalies.length === 0) log('  ✓ No anomalous expenses.');
+    }
+    log('');
+    log('  Read-only audit. Flags review candidates by multivariate pattern, not');
+    log('  a flat amount threshold — verify flagged expenses against documentation.');
+    log('');
+  }
+
+  await mongoose.disconnect();
+  process.exit(0);
+}
+
+module.exports = { detectExpenseAnomalies };
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error('expense-anomaly-scan failed:', err.message);
+    process.exit(2);
+  });
+}

--- a/backend/services/financeAnomaly.service.js
+++ b/backend/services/financeAnomaly.service.js
@@ -1,0 +1,106 @@
+'use strict';
+
+/**
+ * financeAnomaly.service.js — READ-ONLY Tier-3 expense anomaly scan (W1218).
+ * ════════════════════════════════════════════════════════════════════════════
+ * Applies the (now-wired, W1215) Tier-3 multivariate isolation-forest engine to
+ * a domain that had NO anomaly detection: financial expenses. It flags expenses
+ * whose feature COMBINATION is anomalous vs the branch's expense population —
+ * the classic audit/fraud signals that a single amount-threshold misses:
+ *
+ *   features = [ amount, dayOfWeek, isCash, isRoundThousand ]
+ *
+ * e.g. a moderate-but-round cash expense on a weekend scores higher than a large
+ * card expense on a normal business day. Pure given the expense array; no DB here
+ * (the CLI/route supplies the rows). Read-only — flags for review, mutates nothing.
+ *
+ * NOTE: this is a complement to, not a replacement of, the Hikvision attendance
+ * fraud detection (a different domain) — financial-transaction anomaly was a
+ * genuine gap (no prior detector).
+ */
+
+const { buildIsolationForestDetector } = require('./isolationForest.service');
+
+const EXPENSE_FEATURES = Object.freeze(['amount', 'dayOfWeek', 'isCash', 'isRoundThousand']);
+
+// Isolation forest needs ≥8 points for a meaningful sub-sampled forest.
+const MIN_EXPENSES = 8;
+
+const CASH_METHODS = new Set(['cash']);
+
+/**
+ * PURE — map one expense (lean doc) to the positional numeric feature vector.
+ * @param {object} e
+ * @returns {number[]}
+ */
+function expenseFeatureExtractor(e = {}) {
+  const amount = Number(e.amount) || 0;
+  const d = e.date ? new Date(e.date) : null;
+  const dayOfWeek = d && !Number.isNaN(d.getTime()) ? d.getDay() : 0; // 0=Sun … 6=Sat
+  const isCash = CASH_METHODS.has(e.paymentMethod) ? 1 : 0;
+  const isRoundThousand = amount > 0 && amount % 1000 === 0 ? 1 : 0;
+  return [amount, dayOfWeek, isCash, isRoundThousand];
+}
+
+/**
+ * PURE — score each expense against the population via the Tier-3 isolation
+ * forest and return the anomalous ones (most-anomalous first). Degrades to
+ * `{ eligible:false }` when there are too few expenses to form a population.
+ *
+ * @param {{ expenses?: object[], threshold?: number, seed?: number }} opts
+ * @returns {{ eligible:boolean, reason?:string, scanned:number, threshold:number, anomalies:object[] }}
+ */
+function detectExpenseAnomalies(opts = {}) {
+  const expenses = Array.isArray(opts.expenses) ? opts.expenses : [];
+  const threshold = typeof opts.threshold === 'number' ? opts.threshold : 0.6;
+  const seed = typeof opts.seed === 'number' ? opts.seed : 1;
+
+  if (expenses.length < MIN_EXPENSES) {
+    return {
+      eligible: false,
+      reason: `insufficient_expenses:${expenses.length}/${MIN_EXPENSES}`,
+      scanned: expenses.length,
+      threshold,
+      anomalies: [],
+    };
+  }
+
+  const detector = buildIsolationForestDetector({
+    threshold,
+    seed,
+    featureExtractor: expenseFeatureExtractor,
+  });
+
+  const anomalies = [];
+  for (const e of expenses) {
+    const verdict = detector.detect({ history: expenses, current: e });
+    if (verdict.anomaly && typeof verdict.score === 'number') {
+      const amount = Number(e.amount) || 0;
+      anomalies.push({
+        expenseId: e._id ? String(e._id) : null,
+        score: Math.round(verdict.score * 1000) / 1000,
+        amount,
+        category: e.category || null,
+        paymentMethod: e.paymentMethod || null,
+        vendor: e.vendor || null,
+        date: e.date || null,
+        // why it's notable (the human-readable multivariate signal)
+        signals: [
+          ...(CASH_METHODS.has(e.paymentMethod) ? ['cash'] : []),
+          ...(amount > 0 && amount % 1000 === 0 ? ['round_thousand'] : []),
+          ...(e.date && [0, 6].includes(new Date(e.date).getDay()) ? ['weekend'] : []),
+        ],
+      });
+    }
+  }
+
+  anomalies.sort((a, b) => b.score - a.score);
+  return { eligible: true, scanned: expenses.length, threshold, anomalies };
+}
+
+module.exports = {
+  EXPENSE_FEATURES,
+  MIN_EXPENSES,
+  expenseFeatureExtractor,
+  detectExpenseAnomalies,
+};

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1011,3 +1011,4 @@ __tests__/headcount-plan-behavioral-wave1203.test.js
 __tests__/official-letters-routes-wave1224.test.js
 __tests__/official-letters-behavioral-wave1224.test.js
 __tests__/productivity-anomalies-wave1215.test.js
+__tests__/expense-anomaly-wave1218.test.js


### PR DESCRIPTION
Honoring "build, don't delete": instead of deleting the dead-dup `zatcaCalculation` (live replacement `zatca-phase2` already exists), this **builds** the higher-value capability — applying the now-wired (W1215) Tier-3 isolation-forest to a domain with **no** anomaly detection: **financial expenses** (audit-first: fraud detection covered only Hikvision attendance, never financial transactions).

- `services/financeAnomaly.service.detectExpenseAnomalies()` flags expenses whose **combination** of [amount, dayOfWeek, isCash, isRoundThousand] is anomalous vs the branch population — the audit/fraud signals a flat threshold misses (e.g. round-number cash weekend expense). ≥8 expenses; deterministic.
- `npm run audit:expense-anomalies` (`--branch= --days= --json`) — READ-ONLY audit CLI. **No route-mount** (avoids the finance-registry collision zone) — matches the golden-thread audit-CLI pattern.
- 7 assertions. Complements (not replaces) Hikvision attendance fraud.

Read-only; flags review candidates, mutates nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)