### PR TITLE
fix(test): W1226 — deflake skills-gap behavioral suite (autoIndex race; deploy gate red)

### DIFF
--- a/backend/__tests__/skills-gap-behavioral-wave1201.test.js
+++ b/backend/__tests__/skills-gap-behavioral-wave1201.test.js
@@ -22,6 +22,12 @@ beforeAll(async () => {
   await mongoose.connect(mongod.getUri());
   EC = require('../models/HR/EmployeeCompetency');
   RCR = require('../models/HR/RoleCompetencyRequirement');
+  // Build indexes NOW instead of racing autoIndex (W1222 lesson, inverse
+  // direction): the unique-index test needs the index to EXIST before the
+  // duplicate insert — on fast CI runners autoIndex sometimes hadn't
+  // finished and both inserts succeeded → flaky deploy-gate red.
+  await EC.init();
+  await RCR.init();
 });
 afterAll(async () => {
   await mongoose.disconnect();


### PR DESCRIPTION
Same flake class as W1222 (PR #396), inverse direction: the unique-index test needs the index to EXIST before the duplicate insert; autoIndex raced and lost on shard 3 of run 27362046998 → Deploy-to-VPS skipped. Fix: `Model.init()` in `beforeAll`. Suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)