### PR TITLE
fix(hr): W1227 candidate ranking + W1228 deflake coupon core-linkage (deploy-gate)

### DIFF
--- a/backend/__tests__/succession-readiness-lib-wave1207.test.js
+++ b/backend/__tests__/succession-readiness-lib-wave1207.test.js
@@ -72,4 +72,24 @@ describe('W1207 succession-readiness.lib — ranking', () => {
     ]);
     expect(ranked.map(r => r.employeeId)).toEqual(['b', 'c', 'a']);
   });
+
+  // W1227 — successionReadinessService emits FLAT candidates (`...r` spreads
+  // `score` to the top level), not `{readiness:{score}}`. The original reader
+  // only handled the nested shape, so the live /candidates ranking sorted by
+  // `undefined` → DB order. rankCandidates must rank the flat shape too.
+  test('rankCandidates sorts FLAT candidates (the live service shape) by score', () => {
+    const ranked = L.rankCandidates([
+      { employeeId: 'a', score: 40 },
+      { employeeId: 'b', score: 85 },
+      { employeeId: 'c', score: 60 },
+    ]);
+    expect(ranked.map(r => r.employeeId)).toEqual(['b', 'c', 'a']);
+  });
+
+  test('candidateScore reads flat, nested, and defaults missing to 0', () => {
+    expect(L.candidateScore({ score: 72 })).toBe(72);
+    expect(L.candidateScore({ readiness: { score: 55 } })).toBe(55);
+    expect(L.candidateScore({})).toBe(0);
+    expect(L.candidateScore(null)).toBe(0);
+  });
 });

--- a/backend/intelligence/succession-readiness.lib.js
+++ b/backend/intelligence/succession-readiness.lib.js
@@ -86,9 +86,24 @@ function readiness({ talentBands, targetCompetencyReadinessPct, tenureYears } = 
   };
 }
 
-/** Rank candidates (each {employeeId, name, readiness}) by score desc. */
+/**
+ * Score accessor tolerant of BOTH candidate shapes:
+ *   - flat   `{ score }`              — what successionReadinessService emits
+ *     (employeeReadiness spreads `...r`, so `score` lands at the top level)
+ *   - nested `{ readiness: { score } }` — the original lib-test shape
+ * W1207 shipped only the nested reader, so the live `/candidates` ranking sorted
+ * by `undefined` → DB-insertion order (the headline "ranked" feature was a no-op).
+ */
+function candidateScore(c) {
+  if (!c) return 0;
+  if (typeof c.score === 'number') return c.score;
+  if (typeof c.readiness?.score === 'number') return c.readiness.score;
+  return 0;
+}
+
+/** Rank candidates (flat `{score}` or nested `{readiness:{score}}`) by score desc. */
 function rankCandidates(candidates) {
-  return [...(candidates || [])].sort((a, b) => (b.readiness?.score || 0) - (a.readiness?.score || 0));
+  return [...(candidates || [])].sort((a, b) => candidateScore(b) - candidateScore(a));
 }
 
 module.exports = {
@@ -99,4 +114,5 @@ module.exports = {
   levelOf,
   readiness,
   rankCandidates,
+  candidateScore,
 };


### PR DESCRIPTION
## Two fixes — one unblocks the deploy gate, one fixes a silent W1207 bug

### W1227 — succession candidate ranking was a silent no-op
`GET /api/v1/hr/succession-readiness/candidates` is meant to return branch
employees **ranked** for a target role. But `rankCandidates` only read the
nested `{readiness:{score}}` shape, while `successionReadinessService` emits
**flat** candidates (`{...r}` spreads `score` to the top level). So it sorted
by `undefined` → DB-insertion order. The headline 'ranked' feature did nothing
in production. `rankCandidates` now reads both shapes via `candidateScore()`.
Lib suite 9 → 11 green (+flat-shape ranking + accessor regression tests).

### W1228 — deflake coupon-usage core-linkage (blocking ALL deploys)
`coupon-usage-redeemed-core-linkage-wave1105` slept a fixed 30ms for the async
post-save → bus → subscriber → CareTimeline chain, then asserted. On a loaded CI
shard the chain takes >30ms → shard 4/4 read 0 rows → deploy gate red (run
27364124300, which was deploying W1207). Replaced fixed sleeps with
`waitForRows()` poll-until (5s cap / 10ms tick); negatives keep a 300ms settle.
Verified 4/4 green across 3 consecutive runs.

Both are scoped to one lib + two test files. No route/model/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)