### PR TITLE
fix(hr): W1228 — QR letter-verify must live outside /hr (prefix-wide authenticate)

### DIFF
--- a/backend/__tests__/official-letters-routes-wave1224.test.js
+++ b/backend/__tests__/official-letters-routes-wave1224.test.js
@@ -80,6 +80,16 @@ describe('W1224 registry mount', () => {
       /app\.use\('\/api\/v1\/hr\/official-letters', officialLettersRouter\)/
     );
   });
+
+  test('W1228: QR verify is ALSO mounted publicly OUTSIDE /hr (app.js gates /api/v1/hr with authenticate)', () => {
+    expect(routeSrc).toMatch(/module\.exports\.verifyLetterHandler = verifyLetterHandler/);
+    expect(registrySrc).toMatch(
+      /app\.get\('\/api\/public\/letter-verify\/:token', officialLettersRouter\.verifyLetterHandler\)/
+    );
+    expect(registrySrc).toMatch(
+      /app\.get\('\/api\/v1\/public\/letter-verify\/:token', officialLettersRouter\.verifyLetterHandler\)/
+    );
+  });
 });
 
 describe('W1224 OfficialLetter model — contract', () => {

--- a/backend/routes/hr/official-letters.routes.js
+++ b/backend/routes/hr/official-letters.routes.js
@@ -37,8 +37,14 @@ const WRITE_ROLES = [
 ];
 const REVOKE_ROLES = ['admin', 'superadmin', 'super_admin', 'hr_manager', 'hr_director'];
 
-// ─── PUBLIC: QR verification (declared BEFORE authenticateToken) ──────────
-router.get('/verify/:token', async (req, res) => {
+// ─── PUBLIC: QR verification ───────────────────────────────────────────────
+// Declared BEFORE authenticateToken inside this router AND exported so the
+// registry can additionally mount it at /api/(v1/)?public/letter-verify/:token
+// — app.js gates the whole /api/v1/hr prefix with `authenticate` (multiple
+// `app.use('/api/v1/hr', authenticate, …)` sites), so a public endpoint can
+// never be reached under the /hr prefix. The /public mount is the real
+// QR-facing URL; the in-router copy stays for completeness.
+async function verifyLetterHandler(req, res) {
   try {
     const token = String(req.params.token || '');
     if (!/^[a-f0-9]{32}$/.test(token)) {
@@ -67,7 +73,9 @@ router.get('/verify/:token', async (req, res) => {
   } catch (err) {
     safeError(res, err, 'official-letters:verify');
   }
-});
+}
+
+router.get('/verify/:token', verifyLetterHandler);
 
 // ─── Everything below requires auth + branch context ──────────────────────
 router.use(authenticateToken);
@@ -236,3 +244,4 @@ router.post('/:id/revoke', requireRole(REVOKE_ROLES), async (req, res) => {
 });
 
 module.exports = router;
+module.exports.verifyLetterHandler = verifyLetterHandler;

--- a/backend/routes/registries/hr.registry.js
+++ b/backend/routes/registries/hr.registry.js
@@ -229,7 +229,15 @@ module.exports = function registerHrRoutes(app, { safeRequire, dualMount, safeMo
   if (officialLettersRouter) {
     app.use('/api/hr/official-letters', officialLettersRouter);
     app.use('/api/v1/hr/official-letters', officialLettersRouter);
-    logger.info('[HR] Official-letters registry mounted (/api/(v1/)?hr/official-letters)');
+    // The QR-facing verify endpoint must live OUTSIDE /hr — app.js wraps the
+    // whole /api/v1/hr prefix in `authenticate` (W1228 fix).
+    if (typeof officialLettersRouter.verifyLetterHandler === 'function') {
+      app.get('/api/public/letter-verify/:token', officialLettersRouter.verifyLetterHandler);
+      app.get('/api/v1/public/letter-verify/:token', officialLettersRouter.verifyLetterHandler);
+    }
+    logger.info(
+      '[HR] Official-letters registry mounted (/api/(v1/)?hr/official-letters + public /api/(v1/)?public/letter-verify/:token)'
+    );
   } else {
     logger.warn('[HR] Official-letters routes not mounted (module missing)');
   }


### PR DESCRIPTION
Live probe after W1224 deploy: the public verify endpoint returned **401 anonymously** — `app.js` mounts several routers at `/api/v1/hr` with inline `authenticate`, which Express runs for every path under the prefix. A public endpoint under /hr is unreachable by design.

Fix: export `verifyLetterHandler` + mount it at `GET /api/(v1/)?public/letter-verify/:token` (public-forms precedent). Drift guard extended to lock the public mounts. 23/23 tests green + `check:routes-load` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)