### PR TITLE
feat(cctv): W1230 — fast cross-camera reports (employees / plates / visitors / AI overview)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1696,6 +1696,9 @@ on:
       - 'backend/__tests__/expense-anomaly-wave1218.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/seed-goal-bank-wave1223.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/cctv-reports-wave1230.test.js'
+      - 'backend/__tests__/cctv-reports-behavioral-wave1230.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3375,6 +3378,9 @@ on:
       - 'backend/__tests__/expense-anomaly-wave1218.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/seed-goal-bank-wave1223.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/cctv-reports-wave1230.test.js'
+      - 'backend/__tests__/cctv-reports-behavioral-wave1230.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/cctv-reports-behavioral-wave1230.test.js
+++ b/backend/__tests__/cctv-reports-behavioral-wave1230.test.js
@@ -1,0 +1,428 @@
+'use strict';
+
+/**
+ * cctv-reports-behavioral-wave1230.test.js — behavioral counterpart to the
+ * static guard `cctv-reports-wave1230.test.js` (W356-W384 pairing doctrine).
+ *
+ * Seeds real CctvCamera / CctvEvent / CctvAnpr / TransportVehicle /
+ * HikvisionProcessedEvent rows into MongoMemoryServer and asserts the actual
+ * aggregation output of every report family:
+ *   • employeesReport / employeeTimeline (decision filtering, day bucketing)
+ *   • platesReport / plateHistory (registry + fleet join, normalisation)
+ *   • visitorsReport (ownership partition: clients vs unknown vs denylist)
+ *   • aiOverview (type×severity rollup, safety totals, fleet + capabilities)
+ *   • window helpers (defaults, 92-day cap, invalid input → status 400)
+ *
+ * Run: cd backend && npx jest --config=jest.config.js __tests__/cctv-reports-behavioral-wave1230.test.js --runInBand
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(60000);
+
+const fs = require('fs');
+const path = require('path');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongod;
+let reports;
+let CctvCamera, CctvEvent, CctvAnpr;
+let HikvisionProcessedEvent;
+let TransportVehicle;
+let reg;
+
+const NOW = new Date('2026-06-10T09:00:00.000Z');
+const hoursAgo = h => new Date(NOW.getTime() - h * 3_600_000);
+const daysAgo = d => new Date(NOW.getTime() - d * 86_400_000);
+
+const BRANCH = 'RYD01';
+const branchOid = new mongoose.Types.ObjectId();
+const emp1 = new mongoose.Types.ObjectId();
+const emp2 = new mongoose.Types.ObjectId();
+
+let seq = 0;
+const eid = () => `w1230-ev-${++seq}`;
+
+beforeAll(async () => {
+  const URI_FILE = path.join(__dirname, '..', '.test-mongo-uri');
+  let uri;
+  if (fs.existsSync(URI_FILE)) {
+    uri = fs.readFileSync(URI_FILE, 'utf-8').trim();
+  } else {
+    mongod = await MongoMemoryServer.create({ instance: { dbName: 'w1230-behavioral-test' } });
+    uri = mongod.getUri();
+  }
+  await mongoose.connect(uri);
+
+  // Minimal Employee stand-in so the service's lazyModel('Employee') hit
+  // avoids dragging the full HR model graph into this suite.
+  mongoose.model(
+    'Employee',
+    new mongoose.Schema({
+      employee_number: String,
+      name_ar: String,
+      name_en: String,
+      department: String,
+      branch_id: mongoose.Schema.Types.ObjectId,
+    })
+  );
+
+  ({ CctvCamera, CctvEvent, CctvAnpr } = require('../models/cctv'));
+  HikvisionProcessedEvent = require('../models/HikvisionProcessedEvent');
+  TransportVehicle = require('../models/transport/Vehicle');
+  reg = require('../intelligence/hikvision.registry');
+  reports = require('../services/cctv/reports.service');
+
+  await seed();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect().catch(() => null);
+  if (mongod) await mongod.stop().catch(() => null);
+});
+
+async function seed() {
+  const gate = await CctvCamera.create({
+    code: 'CAM-GATE-01',
+    branchCode: BRANCH,
+    name_ar: 'بوابة رئيسية',
+    ip: '10.0.0.11',
+    status: 'online',
+    capabilities: { anpr: true },
+  });
+  const hall = await CctvCamera.create({
+    code: 'CAM-HALL-02',
+    branchCode: BRANCH,
+    name_ar: 'صالة الاستقبال',
+    ip: '10.0.0.12',
+    status: 'online',
+    capabilities: { faceDetection: true },
+  });
+
+  const ev = (camera, type, startedAt, extra = {}) => ({
+    eventId: eid(),
+    cameraId: camera._id,
+    cameraCode: camera.code,
+    branchCode: BRANCH,
+    type,
+    startedAt,
+    severity: 'info',
+    ...extra,
+  });
+
+  await CctvEvent.create([
+    // ABC123 — registered parent plate, 3 visits (one denied)
+    ev(gate, 'anpr_plate', hoursAgo(2), { aiResult: { plate: 'ABC123', label: 'allowed' } }),
+    ev(gate, 'anpr_plate', daysAgo(1), { aiResult: { plate: 'ABC123', label: 'allowed' } }),
+    ev(gate, 'anpr_plate', daysAgo(2), {
+      aiResult: { plate: 'ABC123', label: 'out_of_schedule' },
+      payload: { plateMatch: 'denied' },
+    }),
+    // XYZ999 — unknown visitor, 2 visits
+    ev(gate, 'anpr_plate', hoursAgo(5), { aiResult: { plate: 'XYZ999', label: 'unknown_visitor' } }),
+    ev(gate, 'anpr_plate', daysAgo(3), { aiResult: { plate: 'XYZ999', label: 'unknown_visitor' } }),
+    // DEN666 — denylist hit
+    ev(gate, 'anpr_plate', hoursAgo(1), {
+      aiResult: { plate: 'DEN666', label: 'denylist_hit' },
+      severity: 'critical',
+    }),
+    // FLT001 — fleet vehicle, 2 visits
+    ev(gate, 'anpr_plate', hoursAgo(8), { aiResult: { plate: 'FLT001', label: 'allowed' } }),
+    ev(gate, 'anpr_plate', daysAgo(2), { aiResult: { plate: 'FLT001', label: 'allowed' } }),
+    // Faces + safety + noise
+    ev(hall, 'face_unknown', hoursAgo(3), { severity: 'medium' }),
+    ev(hall, 'face_unknown', daysAgo(1), { severity: 'medium' }),
+    ev(hall, 'intrusion', hoursAgo(4), { severity: 'high' }),
+    ev(hall, 'fall_detected', hoursAgo(6), { severity: 'critical' }),
+    ev(hall, 'motion', hoursAgo(7)),
+    ev(hall, 'motion', daysAgo(1)),
+    ev(hall, 'motion', daysAgo(2)),
+    // OUTSIDE the default 7-day window — must never appear
+    ev(gate, 'anpr_plate', daysAgo(10), { aiResult: { plate: 'OLD777', label: 'allowed' } }),
+  ]);
+
+  await CctvAnpr.create([
+    { plate: 'ABC123', ownerKind: 'parent', label: 'ولي أمر — أحمد' },
+    { plate: 'DEN666', ownerKind: 'denylist', label: 'محظورة' },
+    { plate: 'FLT001', ownerKind: 'employee', employeeId: emp1 },
+  ]);
+
+  await TransportVehicle.create({
+    vehicle_number: 'VH-901',
+    license_plate: 'FLT001',
+    branch_id: branchOid,
+    vehicle_type: 'bus',
+  });
+
+  const Employee = mongoose.model('Employee');
+  await Employee.create({
+    _id: emp1,
+    employee_number: 'EMP-0001',
+    name_ar: 'موظف الاختبار',
+    department: 'transport',
+    branch_id: branchOid,
+  });
+
+  const device = new mongoose.Types.ObjectId();
+  const raw = () => new mongoose.Types.ObjectId();
+  const processed = (employeeId, capturedAt, decision, extra = {}) => ({
+    rawEventId: raw(),
+    deviceId: device,
+    branchId: branchOid,
+    eventKind: reg.RAW_EVENT_KIND.FACE_MATCH,
+    source: reg.ATTENDANCE_SOURCE.FACE_TERMINAL,
+    matchedEmployeeId: employeeId,
+    confidence: 90,
+    capturedAt,
+    processedAt: capturedAt,
+    decision,
+    ...extra,
+  });
+
+  await HikvisionProcessedEvent.create([
+    processed(emp1, hoursAgo(2), reg.GATE_DECISION.AUTO_ACCEPT),
+    processed(emp1, hoursAgo(9), reg.GATE_DECISION.AUTO_ACCEPT),
+    processed(emp1, daysAgo(1), reg.GATE_DECISION.AUTO_ACCEPT),
+    processed(emp1, daysAgo(2), reg.GATE_DECISION.REVIEW, {
+      reviewReason: reg.REVIEW_REASONS[0],
+      reviewQueue: reg.REVIEW_QUEUES[0],
+    }),
+    // Suppressed duplicate — excluded from every report
+    processed(emp1, hoursAgo(2), reg.GATE_DECISION.SUPPRESSED, {
+      linkedSuppressedFromEventId: new mongoose.Types.ObjectId(),
+    }),
+    processed(emp2, daysAgo(1), reg.GATE_DECISION.AUTO_ACCEPT),
+    // Unmatched capture — excluded from the employee report
+    processed(null, hoursAgo(1), reg.GATE_DECISION.REJECT, {
+      reviewReason: reg.REVIEW_REASONS[0],
+    }),
+  ]);
+}
+
+// ─── Window helpers ──────────────────────────────────────────────
+
+describe('W1230 behavioral — window helpers', () => {
+  test('defaults to a 7-day window ending now', () => {
+    const win = reports.resolveWindow({});
+    expect(win.to.getTime() - win.from.getTime()).toBeCloseTo(7 * 86_400_000, -4);
+  });
+
+  test('caps the window at 92 days', () => {
+    const win = reports.resolveWindow({ from: '2020-01-01', to: NOW.toISOString() });
+    expect(win.to.getTime() - win.from.getTime()).toBe(92 * 86_400_000);
+  });
+
+  test('rejects garbage dates with status 400', () => {
+    expect(() => reports.resolveWindow({ from: 'not-a-date' })).toThrow();
+    try {
+      reports.resolveWindow({ from: 'not-a-date' });
+    } catch (err) {
+      expect(err.status).toBe(400);
+    }
+  });
+
+  test('rejects inverted windows', () => {
+    expect(() =>
+      reports.resolveWindow({ from: '2026-06-10', to: '2026-06-01' })
+    ).toThrow('INVALID_WINDOW');
+  });
+
+  test('riyadhDayKey shifts UTC into the +03:00 day', () => {
+    expect(reports.riyadhDayKey(new Date('2026-01-01T22:30:00.000Z'))).toBe('2026-01-02');
+    expect(reports.riyadhDayKey(new Date('2026-01-01T10:00:00.000Z'))).toBe('2026-01-01');
+  });
+
+  test('clampLimit floors garbage and enforces the max', () => {
+    expect(reports.clampLimit('abc', 500)).toBe(100);
+    expect(reports.clampLimit(9999, 500)).toBe(500);
+    expect(reports.clampLimit(30, 500)).toBe(30);
+  });
+});
+
+// ─── Employees ───────────────────────────────────────────────────
+
+describe('W1230 behavioral — employeesReport', () => {
+  test('groups by employee, counts decisions, excludes suppressed + unmatched', async () => {
+    const out = await reports.employeesReport({ from: daysAgo(7), to: NOW });
+    expect(out.count).toBe(2);
+
+    const e1 = out.employees.find(e => String(e.employeeId) === String(emp1));
+    expect(e1).toBeDefined();
+    expect(e1.captures).toBe(4); // 3 auto-accept + 1 review; suppressed excluded
+    expect(e1.autoAccepted).toBe(3);
+    expect(e1.underReview).toBe(1);
+    expect(e1.firstSeen.getTime()).toBeLessThan(e1.lastSeen.getTime());
+    expect(e1.employee).not.toBeNull();
+    expect(e1.employee.name_ar).toBe('موظف الاختبار');
+
+    const e2 = out.employees.find(e => String(e.employeeId) === String(emp2));
+    expect(e2.captures).toBe(1);
+    expect(e2.employee).toBeNull(); // no identity row seeded for emp2
+  });
+
+  test('rejects malformed branchId with status 400', async () => {
+    await expect(reports.employeesReport({ branchId: 'nope' })).rejects.toMatchObject({
+      status: 400,
+      code: 'INVALID_BRANCH_ID',
+    });
+  });
+});
+
+describe('W1230 behavioral — employeeTimeline', () => {
+  test('buckets by Riyadh day with first-in / last-out', async () => {
+    const out = await reports.employeeTimeline({
+      employeeId: String(emp1),
+      from: daysAgo(7),
+      to: NOW,
+    });
+    expect(out.events).toHaveLength(4); // suppressed excluded
+    expect(out.employee.employee_number).toBe('EMP-0001');
+
+    const twoCaptureDay = out.days.find(d => d.captures === 2);
+    expect(twoCaptureDay).toBeDefined();
+    expect(new Date(twoCaptureDay.firstIn).getTime()).toBeLessThan(
+      new Date(twoCaptureDay.lastOut).getTime()
+    );
+    expect(out.days.reduce((s, d) => s + d.captures, 0)).toBe(4);
+  });
+
+  test('rejects malformed employeeId with status 400', async () => {
+    await expect(reports.employeeTimeline({ employeeId: 'nope' })).rejects.toMatchObject({
+      status: 400,
+      code: 'INVALID_EMPLOYEE_ID',
+    });
+  });
+});
+
+// ─── Plates ──────────────────────────────────────────────────────
+
+describe('W1230 behavioral — platesReport', () => {
+  let out;
+  beforeAll(async () => {
+    out = await reports.platesReport({ branchCode: BRANCH, from: daysAgo(7), to: NOW });
+  });
+
+  test('aggregates per plate inside the window only', () => {
+    expect(out.count).toBe(4); // OLD777 (10 days ago) excluded
+    expect(out.plates.map(p => p.plate)).not.toContain('OLD777');
+    const abc = out.plates.find(p => p.plate === 'ABC123');
+    expect(abc.visits).toBe(3);
+    expect(abc.deniedVisits).toBe(1);
+    expect(abc.cameras).toContain('CAM-GATE-01');
+  });
+
+  test('joins the ANPR registry for ownership', () => {
+    const abc = out.plates.find(p => p.plate === 'ABC123');
+    expect(abc.owner).toMatchObject({ ownerKind: 'parent' });
+    const xyz = out.plates.find(p => p.plate === 'XYZ999');
+    expect(xyz.owner).toBeNull();
+    expect(xyz.unknownVisits).toBe(2);
+  });
+
+  test('joins the transport fleet by license_plate', () => {
+    const flt = out.plates.find(p => p.plate === 'FLT001');
+    expect(flt.fleetVehicle).toMatchObject({ vehicleNumber: 'VH-901', vehicleType: 'bus' });
+  });
+
+  test('summary partitions registered / unknown / denylist / fleet', () => {
+    expect(out.summary).toEqual({ registered: 3, unknown: 1, denylist: 1, fleetMatches: 1 });
+    const den = out.plates.find(p => p.plate === 'DEN666');
+    expect(den.denylistHits).toBe(1);
+  });
+
+  test('branchCode filter isolates foreign branches', async () => {
+    const other = await reports.platesReport({ branchCode: 'OTHER', from: daysAgo(7), to: NOW });
+    expect(other.count).toBe(0);
+  });
+});
+
+describe('W1230 behavioral — plateHistory', () => {
+  test('normalises the plate, returns events + per-day counts + ownership', async () => {
+    const out = await reports.plateHistory({
+      plate: ' abc123 ',
+      branchCode: BRANCH,
+      from: daysAgo(7),
+      to: NOW,
+    });
+    expect(out.plate).toBe('ABC123');
+    expect(out.events).toHaveLength(3);
+    expect(out.owner).toMatchObject({ ownerKind: 'parent' });
+    expect(out.perDay.reduce((s, d) => s + d.visits, 0)).toBe(3);
+  });
+
+  test('rejects an empty plate with status 400', async () => {
+    await expect(reports.plateHistory({ plate: '  ' })).rejects.toMatchObject({
+      status: 400,
+      code: 'INVALID_PLATE',
+    });
+  });
+});
+
+// ─── Visitors ────────────────────────────────────────────────────
+
+describe('W1230 behavioral — visitorsReport', () => {
+  let out;
+  beforeAll(async () => {
+    out = await reports.visitorsReport({ branchCode: BRANCH, from: daysAgo(7), to: NOW });
+  });
+
+  test('clients bucket holds parent/visitor/vendor plates only', () => {
+    expect(out.clients.map(p => p.plate)).toEqual(['ABC123']);
+    // employee-owned fleet plate is staff, not a client
+    expect(out.clients.map(p => p.plate)).not.toContain('FLT001');
+  });
+
+  test('unknown + denylist buckets partition correctly', () => {
+    expect(out.unknownPlates.map(p => p.plate)).toEqual(['XYZ999']);
+    expect(out.denylist.map(p => p.plate)).toEqual(['DEN666']);
+  });
+
+  test('unknown-face rollup counts per camera', () => {
+    expect(out.summary.unknownFaceDetections).toBe(2);
+    expect(out.unknownFaces).toEqual([{ cameraCode: 'CAM-HALL-02', detections: 2 }]);
+  });
+});
+
+// ─── AI overview ─────────────────────────────────────────────────
+
+describe('W1230 behavioral — aiOverview', () => {
+  let out;
+  beforeAll(async () => {
+    out = await reports.aiOverview({ branchCode: BRANCH, from: daysAgo(7), to: NOW });
+  });
+
+  test('totals cover every in-window event', () => {
+    expect(out.totals.events).toBe(15); // 16 seeded minus OLD777 outside the window
+    expect(out.totals.safetyEvents).toBe(2); // intrusion + fall_detected
+    expect(out.totals.unacknowledgedHighCritical).toBe(3); // intrusion + fall + denylist anpr
+  });
+
+  test('byType rollup carries severity breakdown', () => {
+    expect(out.byType.anpr_plate.total).toBe(8);
+    expect(out.byType.fall_detected.bySeverity.critical).toBe(1);
+    expect(out.byType.motion.total).toBe(3);
+  });
+
+  test('daily series is chronological with face/plate/safety lanes', () => {
+    expect(out.daily.length).toBeGreaterThanOrEqual(3);
+    const dates = out.daily.map(d => d.date);
+    expect([...dates].sort()).toEqual(dates);
+    expect(out.daily.reduce((s, d) => s + d.plates, 0)).toBe(8);
+    expect(out.daily.reduce((s, d) => s + d.safety, 0)).toBe(2);
+  });
+
+  test('topCameras joins camera metadata', () => {
+    const gate = out.topCameras.find(c => c.cameraCode === 'CAM-GATE-01');
+    expect(gate.events).toBe(8);
+    expect(gate.camera.name_ar).toBe('بوابة رئيسية');
+  });
+
+  test('camera fleet status + AI capability coverage', () => {
+    expect(out.cameraFleet.byStatus.online).toBe(2);
+    expect(out.cameraFleet.capabilities).toMatchObject({
+      total: 2,
+      anpr: 1,
+      faceDetection: 1,
+    });
+  });
+});

--- a/backend/__tests__/cctv-reports-wave1230.test.js
+++ b/backend/__tests__/cctv-reports-wave1230.test.js
@@ -1,0 +1,121 @@
+'use strict';
+
+/**
+ * cctv-reports-wave1230.test.js — static drift guard for the W1230 fast-reports
+ * surface (/api(/v1)/cctv/reports — employees / plates / visitors / AI overview).
+ *
+ * Pure source-text analysis (fs.readFileSync — no mongoose, no DB). The
+ * behavioral counterpart `cctv-reports-behavioral-wave1230.test.js` exercises
+ * the aggregations against MongoMemoryServer.
+ *
+ * Locks:
+ *   1. cctv.registry.js mounts /cctv/reports (and documents it in the header)
+ *   2. Route file is authenticated + role-gated + READ-ONLY (GET only)
+ *   3. Route file has no req.branchId reads (W269h class) + no ...req.body spread
+ *   4. Service is read-only (no save/create/update/delete calls)
+ *   5. Service uses reg.GATE_DECISION constants (no hardcoded decision strings)
+ *   6. Window cap + ObjectId validation present
+ *
+ * Run: cd backend && npx jest --config=jest.config.js __tests__/cctv-reports-wave1230.test.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const read = p => fs.readFileSync(path.join(__dirname, '..', p), 'utf8');
+
+const registrySrc = read('routes/registries/cctv.registry.js');
+const routeSrc = read('routes/cctv/reports.routes.js');
+const serviceSrc = read('services/cctv/reports.service.js');
+
+describe('W1230 — registry mounts the reports surface', () => {
+  test('mount tuple present', () => {
+    expect(registrySrc).toMatch(/\['\/cctv\/reports',\s*'\.\.\/cctv\/reports\.routes'\]/);
+  });
+
+  test('header comment documents /cctv/reports', () => {
+    expect(registrySrc).toMatch(/\*\s+\/cctv\/reports\s+—/);
+  });
+});
+
+describe('W1230 — route surface shape', () => {
+  test('authenticated at router level', () => {
+    expect(routeSrc).toMatch(/router\.use\(authenticateToken\)/);
+  });
+
+  test('role-gated at router level (admin + security_officer at minimum)', () => {
+    const gate = routeSrc.match(/router\.use\(requireRole\(\[([^\]]+)\]\)\)/);
+    expect(gate).not.toBeNull();
+    expect(gate[1]).toContain("'admin'");
+    expect(gate[1]).toContain("'security_officer'");
+  });
+
+  test.each([
+    '/employees',
+    '/employees/:employeeId',
+    '/plates',
+    '/plates/:plate',
+    '/visitors',
+    '/ai-overview',
+  ])('declares GET %s', endpoint => {
+    expect(routeSrc).toContain(`'${endpoint}'`);
+  });
+
+  test('surface is READ-ONLY — no mutating verbs', () => {
+    expect(routeSrc).not.toMatch(/router\.(post|put|patch|delete)\(/);
+  });
+
+  test('no req.branchId reads (W269h class)', () => {
+    expect(routeSrc).not.toMatch(/req\.branchId/);
+    expect(serviceSrc).not.toMatch(/req\.branchId/);
+  });
+
+  test('no mass-assignment spread of req.body', () => {
+    expect(routeSrc).not.toMatch(/\.\.\.req\.body/);
+  });
+});
+
+describe('W1230 — service is a pure read layer', () => {
+  test.each([
+    'employeesReport',
+    'employeeTimeline',
+    'platesReport',
+    'plateHistory',
+    'visitorsReport',
+    'aiOverview',
+  ])('exports %s', fn => {
+    expect(serviceSrc).toMatch(new RegExp(`async function ${fn}\\(`));
+    expect(serviceSrc).toMatch(new RegExp(`^\\s+${fn},`, 'm'));
+  });
+
+  test('no write operations anywhere in the service', () => {
+    expect(serviceSrc).not.toMatch(
+      /\.(save|create|insertMany|updateOne|updateMany|findOneAndUpdate|findByIdAndUpdate|deleteOne|deleteMany|bulkWrite)\(/
+    );
+  });
+
+  test('gate decisions come from the hikvision registry, not hardcoded strings', () => {
+    expect(serviceSrc).toMatch(/reg\.GATE_DECISION\.AUTO_ACCEPT/);
+    expect(serviceSrc).toMatch(/reg\.GATE_DECISION\.REVIEW/);
+    expect(serviceSrc).not.toMatch(/'auto-accept'|'suppressed'/);
+  });
+
+  test('window is capped (MAX_WINDOW_DAYS)', () => {
+    expect(serviceSrc).toMatch(/MAX_WINDOW_DAYS\s*=\s*92/);
+  });
+
+  test('ObjectId inputs are validated before querying', () => {
+    expect(serviceSrc).toMatch(/isValidObjectId\(branchId\)/);
+    expect(serviceSrc).toMatch(/isValidObjectId\(employeeId\)/);
+  });
+
+  test('plate reports join the ANPR registry + transport fleet', () => {
+    expect(serviceSrc).toMatch(/CctvAnpr\.find\(/);
+    expect(serviceSrc).toMatch(/TransportVehicle/);
+    expect(serviceSrc).toMatch(/license_plate/);
+  });
+
+  test('per-day bucketing uses the Riyadh offset', () => {
+    expect(serviceSrc).toMatch(/\+03:00/);
+  });
+});

--- a/backend/routes/cctv/reports.routes.js
+++ b/backend/routes/cctv/reports.routes.js
@@ -1,0 +1,119 @@
+/**
+ * CCTV fast-reports routes — Wave 1230.
+ *
+ * Read-only report surface over the IP-cam subsystems. Mounted at
+ * /api/cctv/reports + /api/v1/cctv/reports by cctv.registry.js.
+ *
+ *   GET /employees                 — recognised-staff summary (face terminals)
+ *   GET /employees/:employeeId     — per-employee timeline (first-in / last-out per day)
+ *   GET /plates                    — ANPR plates seen, registry + fleet joined
+ *   GET /plates/:plate             — single-plate movement history
+ *   GET /visitors                  — clients / visitors / vendors / unknown plates
+ *   GET /ai-overview               — unified analysis across every IP cam
+ *
+ * Common filters: ?from=ISO&to=ISO (max 92-day window) &branchCode= &limit=
+ * Employee endpoints additionally accept ?branchId= (Hikvision side is
+ * branchId-keyed; the CCTV event side is branchCode-keyed).
+ */
+'use strict';
+
+const express = require('express');
+const reports = require('../../services/cctv/reports.service');
+const { authenticateToken, requireRole } = require('../../middleware/auth');
+
+const router = express.Router();
+router.use(authenticateToken);
+router.use(requireRole(['admin', 'manager', 'security_officer', 'hr_manager']));
+
+function branchOf(req) {
+  return req.query.branchCode || req.user?.branchCode || '';
+}
+
+function wrap(fn) {
+  return async (req, res) => {
+    try {
+      const data = await fn(req);
+      res.json({ success: true, data });
+    } catch (err) {
+      const status = err.status || 500;
+      res.status(status).json({
+        success: false,
+        message: err.code || (status === 500 ? 'REPORT_FAILED' : err.message),
+      });
+    }
+  };
+}
+
+router.get(
+  '/employees',
+  wrap(req =>
+    reports.employeesReport({
+      branchId: req.query.branchId,
+      from: req.query.from,
+      to: req.query.to,
+      limit: req.query.limit,
+    })
+  )
+);
+
+router.get(
+  '/employees/:employeeId',
+  wrap(req =>
+    reports.employeeTimeline({
+      employeeId: req.params.employeeId,
+      from: req.query.from,
+      to: req.query.to,
+      limit: req.query.limit,
+    })
+  )
+);
+
+router.get(
+  '/plates',
+  wrap(req =>
+    reports.platesReport({
+      branchCode: branchOf(req),
+      from: req.query.from,
+      to: req.query.to,
+      limit: req.query.limit,
+    })
+  )
+);
+
+router.get(
+  '/plates/:plate',
+  wrap(req =>
+    reports.plateHistory({
+      plate: req.params.plate,
+      branchCode: branchOf(req),
+      from: req.query.from,
+      to: req.query.to,
+      limit: req.query.limit,
+    })
+  )
+);
+
+router.get(
+  '/visitors',
+  wrap(req =>
+    reports.visitorsReport({
+      branchCode: branchOf(req),
+      from: req.query.from,
+      to: req.query.to,
+      limit: req.query.limit,
+    })
+  )
+);
+
+router.get(
+  '/ai-overview',
+  wrap(req =>
+    reports.aiOverview({
+      branchCode: branchOf(req),
+      from: req.query.from,
+      to: req.query.to,
+    })
+  )
+);
+
+module.exports = router;

--- a/backend/routes/registries/cctv.registry.js
+++ b/backend/routes/registries/cctv.registry.js
@@ -17,6 +17,7 @@
  *   /cctv/audit           — PDPL audit + grants
  *   /cctv/parent-portal   — parent live-only access
  *   /cctv/admin           — ops dashboards + probe + reaper
+ *   /cctv/reports         — fast reports: employees / plates / visitors / AI overview (W1230)
  */
 'use strict';
 
@@ -115,6 +116,7 @@ function registerCctvRoutes(app, opts = {}) {
     ['/cctv/audit', '../cctv/audit.routes'],
     ['/cctv/parent-portal', '../cctv/parent-portal.routes'],
     ['/cctv/admin', '../cctv/admin.routes'],
+    ['/cctv/reports', '../cctv/reports.routes'],
   ];
   let ok = 0;
   for (const [base, mod] of mounts) {

--- a/backend/services/cctv/reports.service.js
+++ b/backend/services/cctv/reports.service.js
@@ -1,0 +1,499 @@
+/**
+ * reports.service — fast cross-camera reports (Wave 1230).
+ *
+ * Read-only aggregation layer over the two camera subsystems:
+ *   • CctvEvent / CctvCamera / CctvAnpr  — Phase 27 IP-cam surface (branchCode-keyed)
+ *   • HikvisionProcessedEvent            — face-terminal recognition (branchId-keyed)
+ *
+ * Report families:
+ *   employeesReport / employeeTimeline   — recognised staff, first-in / last-out per day
+ *   platesReport / plateHistory          — ANPR plate movements + registry/fleet join
+ *   visitorsReport                       — parents / visitors / vendors / unknown plates
+ *   aiOverview                           — unified analysis across every IP cam
+ *
+ * Nothing in this file mutates state. Invalid input throws Error with
+ * `.status = 400` + `.code` so the route layer can map it directly.
+ */
+'use strict';
+
+const mongoose = require('mongoose');
+const { CctvEvent, CctvCamera, CctvAnpr } = require('../../models/cctv');
+const HikvisionProcessedEvent = require('../../models/HikvisionProcessedEvent');
+const reg = require('../../intelligence/hikvision.registry');
+
+const DEFAULT_WINDOW_DAYS = 7;
+const MAX_WINDOW_DAYS = 92;
+const DAY_MS = 86_400_000;
+// Riyadh is fixed UTC+3 (no DST) — used for per-day bucketing.
+const RIYADH_TZ = '+03:00';
+const RIYADH_OFFSET_MS = 3 * 3_600_000;
+
+const SAFETY_TYPES = Object.freeze([
+  'intrusion',
+  'fall_detected',
+  'fight_detected',
+  'fire_smoke',
+  'object_left',
+  'tampering',
+  'audio_alarm',
+]);
+
+function badRequest(code) {
+  const err = new Error(code);
+  err.status = 400;
+  err.code = code;
+  return err;
+}
+
+function clampLimit(limit, max) {
+  const n = Number(limit);
+  if (!Number.isFinite(n) || n <= 0) return Math.min(100, max);
+  return Math.min(Math.floor(n), max);
+}
+
+function resolveWindow({ from, to } = {}) {
+  const end = to ? new Date(to) : new Date();
+  if (Number.isNaN(end.getTime())) throw badRequest('INVALID_DATE');
+  let start = from ? new Date(from) : new Date(end.getTime() - DEFAULT_WINDOW_DAYS * DAY_MS);
+  if (Number.isNaN(start.getTime())) throw badRequest('INVALID_DATE');
+  if (start > end) throw badRequest('INVALID_WINDOW');
+  const floor = new Date(end.getTime() - MAX_WINDOW_DAYS * DAY_MS);
+  if (start < floor) start = floor;
+  return { from: start, to: end };
+}
+
+function riyadhDayKey(date) {
+  return new Date(date.getTime() + RIYADH_OFFSET_MS).toISOString().slice(0, 10);
+}
+
+function lazyModel(name) {
+  try {
+    return mongoose.model(name);
+  } catch {
+    return null;
+  }
+}
+
+function branchCodeMatch(branchCode) {
+  return branchCode ? { branchCode: String(branchCode).toUpperCase() } : {};
+}
+
+async function loadEmployees(ids) {
+  if (!ids.length) return new Map();
+  const Employee = lazyModel('Employee') || require('../../models/HR/Employee');
+  const rows = await Employee.find({ _id: { $in: ids } })
+    .select('employee_number name_ar name_en department branch_id')
+    .lean();
+  return new Map(rows.map(r => [String(r._id), r]));
+}
+
+// ─── Employees ────────────────────────────────────────────────────
+
+async function employeesReport({ branchId, from, to, limit } = {}) {
+  const win = resolveWindow({ from, to });
+  const match = {
+    matchedEmployeeId: { $ne: null },
+    capturedAt: { $gte: win.from, $lte: win.to },
+    decision: { $in: [reg.GATE_DECISION.AUTO_ACCEPT, reg.GATE_DECISION.REVIEW] },
+  };
+  if (branchId) {
+    if (!mongoose.isValidObjectId(branchId)) throw badRequest('INVALID_BRANCH_ID');
+    match.branchId = new mongoose.Types.ObjectId(String(branchId));
+  }
+  const rows = await HikvisionProcessedEvent.aggregate([
+    { $match: match },
+    {
+      $group: {
+        _id: '$matchedEmployeeId',
+        captures: { $sum: 1 },
+        autoAccepted: {
+          $sum: { $cond: [{ $eq: ['$decision', reg.GATE_DECISION.AUTO_ACCEPT] }, 1, 0] },
+        },
+        underReview: {
+          $sum: { $cond: [{ $eq: ['$decision', reg.GATE_DECISION.REVIEW] }, 1, 0] },
+        },
+        firstSeen: { $min: '$capturedAt' },
+        lastSeen: { $max: '$capturedAt' },
+        avgConfidence: { $avg: '$confidence' },
+        devices: { $addToSet: '$deviceId' },
+        branches: { $addToSet: '$branchId' },
+      },
+    },
+    { $sort: { captures: -1 } },
+    { $limit: clampLimit(limit, 500) },
+  ]);
+
+  const employees = await loadEmployees(rows.map(r => r._id));
+  return {
+    window: win,
+    count: rows.length,
+    employees: rows.map(r => ({
+      employeeId: r._id,
+      employee: employees.get(String(r._id)) || null,
+      captures: r.captures,
+      autoAccepted: r.autoAccepted,
+      underReview: r.underReview,
+      firstSeen: r.firstSeen,
+      lastSeen: r.lastSeen,
+      avgConfidence: r.avgConfidence == null ? null : Math.round(r.avgConfidence * 10) / 10,
+      deviceCount: r.devices.length,
+      branchCount: r.branches.length,
+    })),
+  };
+}
+
+async function employeeTimeline({ employeeId, from, to, limit } = {}) {
+  if (!mongoose.isValidObjectId(employeeId)) throw badRequest('INVALID_EMPLOYEE_ID');
+  const win = resolveWindow({ from, to });
+  const rows = await HikvisionProcessedEvent.find({
+    matchedEmployeeId: employeeId,
+    capturedAt: { $gte: win.from, $lte: win.to },
+    decision: { $ne: reg.GATE_DECISION.SUPPRESSED },
+  })
+    .select('capturedAt decision confidence eventKind source deviceId branchId zoneId')
+    .sort({ capturedAt: -1 })
+    .limit(clampLimit(limit, 1000))
+    .lean();
+
+  const byDay = new Map();
+  for (const ev of rows) {
+    const key = riyadhDayKey(ev.capturedAt);
+    const day = byDay.get(key) || { date: key, firstIn: ev.capturedAt, lastOut: ev.capturedAt, captures: 0 };
+    if (ev.capturedAt < day.firstIn) day.firstIn = ev.capturedAt;
+    if (ev.capturedAt > day.lastOut) day.lastOut = ev.capturedAt;
+    day.captures += 1;
+    byDay.set(key, day);
+  }
+
+  const employees = await loadEmployees([employeeId]);
+  return {
+    window: win,
+    employee: employees.get(String(employeeId)) || null,
+    days: [...byDay.values()].sort((a, b) => (a.date < b.date ? 1 : -1)),
+    events: rows,
+  };
+}
+
+// ─── Plates ───────────────────────────────────────────────────────
+
+async function aggregatePlates({ branchCode, win, plate, limit }) {
+  const match = {
+    type: 'anpr_plate',
+    startedAt: { $gte: win.from, $lte: win.to },
+    'aiResult.plate': plate ? String(plate).toUpperCase().trim() : { $type: 'string', $ne: '' },
+    ...branchCodeMatch(branchCode),
+  };
+  return CctvEvent.aggregate([
+    { $match: match },
+    {
+      $group: {
+        _id: '$aiResult.plate',
+        visits: { $sum: 1 },
+        firstSeen: { $min: '$startedAt' },
+        lastSeen: { $max: '$startedAt' },
+        cameras: { $addToSet: '$cameraCode' },
+        branches: { $addToSet: '$branchCode' },
+        denylistHits: {
+          $sum: { $cond: [{ $eq: ['$aiResult.label', 'denylist_hit'] }, 1, 0] },
+        },
+        deniedVisits: {
+          $sum: { $cond: [{ $eq: ['$payload.plateMatch', 'denied'] }, 1, 0] },
+        },
+        unknownVisits: {
+          $sum: { $cond: [{ $eq: ['$aiResult.label', 'unknown_visitor'] }, 1, 0] },
+        },
+      },
+    },
+    { $sort: { visits: -1 } },
+    { $limit: clampLimit(limit, 500) },
+  ]);
+}
+
+async function joinPlateOwnership(plates) {
+  if (!plates.length) return { registry: new Map(), fleet: new Map() };
+  const regRows = await CctvAnpr.find({ plate: { $in: plates } })
+    .select('plate ownerKind label status employeeId vendorName autoOpenGate validUntil')
+    .lean();
+  const TransportVehicle =
+    lazyModel('TransportVehicle') || require('../../models/transport/Vehicle');
+  const fleetRows = await TransportVehicle.find({ license_plate: { $in: plates } })
+    .select('license_plate vehicle_number vehicle_type status')
+    .lean();
+  return {
+    registry: new Map(regRows.map(r => [r.plate, r])),
+    fleet: new Map(fleetRows.map(r => [r.license_plate, r])),
+  };
+}
+
+function decoratePlateRow(r, registry, fleet) {
+  const owner = registry.get(r._id) || null;
+  const vehicle = fleet.get(r._id) || null;
+  return {
+    plate: r._id,
+    visits: r.visits,
+    firstSeen: r.firstSeen,
+    lastSeen: r.lastSeen,
+    cameras: r.cameras,
+    branches: r.branches,
+    denylistHits: r.denylistHits,
+    deniedVisits: r.deniedVisits,
+    unknownVisits: r.unknownVisits,
+    owner: owner
+      ? {
+          ownerKind: owner.ownerKind,
+          label: owner.label || owner.vendorName || null,
+          status: owner.status,
+          employeeId: owner.employeeId || null,
+          autoOpenGate: !!owner.autoOpenGate,
+          validUntil: owner.validUntil || null,
+        }
+      : null,
+    fleetVehicle: vehicle
+      ? {
+          vehicleNumber: vehicle.vehicle_number,
+          vehicleType: vehicle.vehicle_type,
+          status: vehicle.status,
+        }
+      : null,
+  };
+}
+
+async function platesReport({ branchCode, from, to, limit } = {}) {
+  const win = resolveWindow({ from, to });
+  const rows = await aggregatePlates({ branchCode, win, limit });
+  const { registry, fleet } = await joinPlateOwnership(rows.map(r => r._id));
+  const plates = rows.map(r => decoratePlateRow(r, registry, fleet));
+  return {
+    window: win,
+    count: plates.length,
+    summary: {
+      registered: plates.filter(p => p.owner).length,
+      unknown: plates.filter(p => !p.owner).length,
+      denylist: plates.filter(p => p.owner?.ownerKind === 'denylist' || p.denylistHits > 0).length,
+      fleetMatches: plates.filter(p => p.fleetVehicle).length,
+    },
+    plates,
+  };
+}
+
+async function plateHistory({ plate, branchCode, from, to, limit } = {}) {
+  const normalised = String(plate || '').toUpperCase().trim();
+  if (!normalised) throw badRequest('INVALID_PLATE');
+  const win = resolveWindow({ from, to });
+  const events = await CctvEvent.find({
+    type: 'anpr_plate',
+    'aiResult.plate': normalised,
+    startedAt: { $gte: win.from, $lte: win.to },
+    ...branchCodeMatch(branchCode),
+  })
+    .select('eventId cameraCode branchCode severity startedAt aiResult payload snapshot')
+    .sort({ startedAt: -1 })
+    .limit(clampLimit(limit, 1000))
+    .lean();
+
+  const { registry, fleet } = await joinPlateOwnership([normalised]);
+  const byDay = new Map();
+  for (const ev of events) {
+    const key = riyadhDayKey(ev.startedAt);
+    byDay.set(key, (byDay.get(key) || 0) + 1);
+  }
+  return {
+    window: win,
+    plate: normalised,
+    owner: registry.get(normalised) || null,
+    fleetVehicle: fleet.get(normalised) || null,
+    perDay: [...byDay.entries()]
+      .map(([date, visits]) => ({ date, visits }))
+      .sort((a, b) => (a.date < b.date ? 1 : -1)),
+    events,
+  };
+}
+
+// ─── Visitors / clients ──────────────────────────────────────────
+
+const CLIENT_OWNER_KINDS = Object.freeze(['parent', 'visitor', 'vendor']);
+
+async function visitorsReport({ branchCode, from, to, limit } = {}) {
+  const win = resolveWindow({ from, to });
+  const rows = await aggregatePlates({ branchCode, win, limit: clampLimit(limit, 500) });
+  const { registry, fleet } = await joinPlateOwnership(rows.map(r => r._id));
+  const decorated = rows.map(r => decoratePlateRow(r, registry, fleet));
+
+  const clients = decorated.filter(p => p.owner && CLIENT_OWNER_KINDS.includes(p.owner.ownerKind));
+  const denylist = decorated.filter(p => p.owner?.ownerKind === 'denylist' || p.denylistHits > 0);
+  const unknownPlates = decorated.filter(p => !p.owner);
+
+  const faceUnknownAgg = await CctvEvent.aggregate([
+    {
+      $match: {
+        type: 'face_unknown',
+        startedAt: { $gte: win.from, $lte: win.to },
+        ...branchCodeMatch(branchCode),
+      },
+    },
+    { $group: { _id: '$cameraCode', n: { $sum: 1 } } },
+    { $sort: { n: -1 } },
+    { $limit: 10 },
+  ]);
+
+  return {
+    window: win,
+    summary: {
+      clientPlates: clients.length,
+      unknownPlates: unknownPlates.length,
+      denylistPlates: denylist.length,
+      unknownFaceDetections: faceUnknownAgg.reduce((s, r) => s + r.n, 0),
+    },
+    clients,
+    unknownPlates,
+    denylist,
+    unknownFaces: faceUnknownAgg.map(r => ({ cameraCode: r._id, detections: r.n })),
+  };
+}
+
+// ─── Unified AI overview ─────────────────────────────────────────
+
+async function aiOverview({ branchCode, from, to } = {}) {
+  const win = resolveWindow({ from, to });
+  const evMatch = { startedAt: { $gte: win.from, $lte: win.to }, ...branchCodeMatch(branchCode) };
+  const camMatch = { isDeleted: { $ne: true }, ...branchCodeMatch(branchCode) };
+
+  const [byTypeSev, topCameras, daily, unacknowledged, fleetStatus, capabilities] =
+    await Promise.all([
+      CctvEvent.aggregate([
+        { $match: evMatch },
+        { $group: { _id: { type: '$type', severity: '$severity' }, n: { $sum: 1 } } },
+        { $sort: { n: -1 } },
+      ]),
+      CctvEvent.aggregate([
+        { $match: evMatch },
+        {
+          $group: {
+            _id: '$cameraCode',
+            events: { $sum: 1 },
+            lastEventAt: { $max: '$startedAt' },
+            types: { $addToSet: '$type' },
+          },
+        },
+        { $sort: { events: -1 } },
+        { $limit: 20 },
+      ]),
+      CctvEvent.aggregate([
+        { $match: evMatch },
+        {
+          $group: {
+            _id: {
+              $dateToString: { format: '%Y-%m-%d', date: '$startedAt', timezone: RIYADH_TZ },
+            },
+            events: { $sum: 1 },
+            safety: { $sum: { $cond: [{ $in: ['$type', SAFETY_TYPES] }, 1, 0] } },
+            faces: {
+              $sum: {
+                $cond: [
+                  { $in: ['$type', ['face_detected', 'face_match', 'face_unknown']] },
+                  1,
+                  0,
+                ],
+              },
+            },
+            plates: { $sum: { $cond: [{ $eq: ['$type', 'anpr_plate'] }, 1, 0] } },
+          },
+        },
+        { $sort: { _id: 1 } },
+      ]),
+      CctvEvent.countDocuments({
+        ...evMatch,
+        severity: { $in: ['high', 'critical'] },
+        acknowledgedAt: null,
+      }),
+      CctvCamera.aggregate([
+        { $match: camMatch },
+        { $group: { _id: '$status', n: { $sum: 1 } } },
+      ]),
+      CctvCamera.aggregate([
+        { $match: camMatch },
+        {
+          $group: {
+            _id: null,
+            total: { $sum: 1 },
+            anpr: { $sum: { $cond: ['$capabilities.anpr', 1, 0] } },
+            faceDetection: { $sum: { $cond: ['$capabilities.faceDetection', 1, 0] } },
+            intrusion: { $sum: { $cond: ['$capabilities.intrusion', 1, 0] } },
+            ptz: { $sum: { $cond: ['$capabilities.ptz', 1, 0] } },
+            thermal: { $sum: { $cond: ['$capabilities.thermal', 1, 0] } },
+          },
+        },
+      ]),
+    ]);
+
+  const byType = {};
+  let totalEvents = 0;
+  for (const row of byTypeSev) {
+    const t = row._id.type;
+    totalEvents += row.n;
+    if (!byType[t]) byType[t] = { total: 0, bySeverity: {} };
+    byType[t].total += row.n;
+    byType[t].bySeverity[row._id.severity] = row.n;
+  }
+
+  const cameraCodes = topCameras.map(c => c._id);
+  const cameraMeta = cameraCodes.length
+    ? await CctvCamera.find({ code: { $in: cameraCodes } })
+        .select('code name_ar name_en status location.area branchCode')
+        .lean()
+    : [];
+  const metaByCode = new Map(cameraMeta.map(c => [c.code, c]));
+
+  return {
+    window: win,
+    totals: {
+      events: totalEvents,
+      safetyEvents: Object.entries(byType)
+        .filter(([t]) => SAFETY_TYPES.includes(t))
+        .reduce((s, [, v]) => s + v.total, 0),
+      unacknowledgedHighCritical: unacknowledged,
+    },
+    byType,
+    daily: daily.map(d => ({
+      date: d._id,
+      events: d.events,
+      safety: d.safety,
+      faces: d.faces,
+      plates: d.plates,
+    })),
+    topCameras: topCameras.map(c => ({
+      cameraCode: c._id,
+      events: c.events,
+      lastEventAt: c.lastEventAt,
+      types: c.types,
+      camera: metaByCode.get(c._id) || null,
+    })),
+    cameraFleet: {
+      byStatus: Object.fromEntries(fleetStatus.map(r => [r._id, r.n])),
+      capabilities: capabilities[0]
+        ? {
+            total: capabilities[0].total,
+            anpr: capabilities[0].anpr,
+            faceDetection: capabilities[0].faceDetection,
+            intrusion: capabilities[0].intrusion,
+            ptz: capabilities[0].ptz,
+            thermal: capabilities[0].thermal,
+          }
+        : { total: 0, anpr: 0, faceDetection: 0, intrusion: 0, ptz: 0, thermal: 0 },
+    },
+  };
+}
+
+module.exports = {
+  employeesReport,
+  employeeTimeline,
+  platesReport,
+  plateHistory,
+  visitorsReport,
+  aiOverview,
+  // exported for tests
+  resolveWindow,
+  riyadhDayKey,
+  clampLimit,
+  SAFETY_TYPES,
+};

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1016,3 +1016,5 @@ __tests__/succession-readiness-routes-wave1207.test.js
 __tests__/succession-readiness-service-wave1207.test.js
 __tests__/expense-anomaly-wave1218.test.js
 __tests__/seed-goal-bank-wave1223.test.js
+__tests__/cctv-reports-wave1230.test.js
+__tests__/cctv-reports-behavioral-wave1230.test.js


### PR DESCRIPTION
## What

New **read-only fast-reports surface** at `/api(/v1)/cctv/reports` — the first unified report layer over both camera subsystems (Phase 27 CCTV `branchCode`-keyed + Hikvision face-terminal `branchId`-keyed).

| Endpoint | Report |
|---|---|
| `GET /employees` | Recognised-staff rollup from `HikvisionProcessedEvent` — captures, auto-accepted vs under-review, first/last seen, avg confidence, device/branch spread. Suppressed + unmatched rows excluded. |
| `GET /employees/:employeeId` | Per-day first-in / last-out timeline (Riyadh +03:00 day bucketing) |
| `GET /plates` | ANPR plate rollup joined with `CctvAnpr` registry ownership **and** `TransportVehicle` fleet match by `license_plate` |
| `GET /plates/:plate` | Single-plate movement history + per-day counts |
| `GET /visitors` | Ownership partition: client plates (parent/visitor/vendor) vs unknown vs denylist + `face_unknown` per-camera rollup |
| `GET /ai-overview` | Unified IP-cam analysis: type×severity rollup, daily safety/face/plate lanes, top-20 cameras with metadata join, unacked high/critical count, camera fleet status + AI capability coverage (anpr/face/intrusion/ptz/thermal) |

## How

- Mounted via the existing `cctv.registry.js` `safeMount` pattern (dual `/api` + `/api/v1`), router-level `authenticateToken` + `requireRole(['admin','manager','security_officer','hr_manager'])`.
- `services/cctv/reports.service.js` is a **pure read layer** — drift guard asserts zero mutating calls.
- Gate decisions referenced from `intelligence/hikvision.registry` constants (no hardcoded strings).
- Window capped at 92 days; ObjectId inputs validated (400 `INVALID_BRANCH_ID` / `INVALID_EMPLOYEE_ID` / `INVALID_PLATE`).
- No `req.branchId` reads (W269h class), no `...req.body` spread, literal routes declared before `:param` siblings (gate 7 clean).

## Tests

50 assertions, both sprint-enumerated:
- `cctv-reports-wave1230.test.js` — static drift guard (mount tuple, auth/role gate, READ-ONLY invariant, registry-constant usage, window cap)
- `cctv-reports-behavioral-wave1230.test.js` — MongoMemoryServer behavioral counterpart (W356-W384 pairing doctrine): seeds cameras/events/ANPR registry/fleet vehicle/processed events; asserts every aggregation incl. window exclusion, decision filtering, ownership partition, fleet join, severity rollups.

Local gates green: sprint-paths ✓ routes-load ✓ route-shadowing ✓ phantom-writes ✓ + 488 meta-guard assertions ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)