### PR TITLE
W1225: widen 3 pathway-bundles' measure categories to match the live instrument catalog (+seeder dotenv)

### DIFF
--- a/backend/intelligence/disability-pathway-bundles.registry.js
+++ b/backend/intelligence/disability-pathway-bundles.registry.js
@@ -33,7 +33,17 @@ const DISABILITY_PATHWAY_BUNDLES = Object.freeze({
     pathwayType: 'AUTISM_EARLY_INTERVENTION',
     guidanceAssessments: Object.freeze(['M-CHAT-R/F', 'CARS-2', 'Vineland-3']),
     measureTargetPopulations: Object.freeze(['autism', 'intellectual_disability', 'down_syndrome']),
-    measureCategories: Object.freeze(['developmental', 'behavioral', 'adaptive', 'social']),
+    // W1225 — include screening/diagnostic: the canonical autism instruments
+    // (M-CHAT-R, CARS-2) are catalogued under those categories, so the
+    // original list resolved ZERO measures against the live prod library.
+    measureCategories: Object.freeze([
+      'developmental',
+      'behavioral',
+      'adaptive',
+      'social',
+      'screening',
+      'diagnostic',
+    ]),
     goalBankDomains: Object.freeze(['BEHAVIORAL', 'SPECIAL_EDU', 'SPEECH']),
     interventionsAr: Object.freeze(['ABA/DTT', 'AAC', 'حمية حسية', 'خطة سلوك']),
     defaultStages: Object.freeze([
@@ -100,7 +110,14 @@ const DISABILITY_PATHWAY_BUNDLES = Object.freeze({
     pathwayType: 'SPEECH_LANGUAGE',
     guidanceAssessments: Object.freeze(['تقييم النطق واللغة', 'تقييم البلع (IDDSI)', 'MLU']),
     measureTargetPopulations: Object.freeze(['language_delay', 'autism']),
-    measureCategories: Object.freeze(['speech_language', 'developmental']),
+    // W1225 — +screening/quality_of_life so 'all'-population screens (SDQ,
+    // PedsQL) and autism-population screens resolve for speech intakes.
+    measureCategories: Object.freeze([
+      'speech_language',
+      'developmental',
+      'screening',
+      'quality_of_life',
+    ]),
     goalBankDomains: Object.freeze(['SPEECH']),
     interventionsAr: Object.freeze(['علاج نطق', 'AAC', 'حمية بلع IDDSI']),
     defaultStages: Object.freeze([
@@ -128,7 +145,16 @@ const DISABILITY_PATHWAY_BUNDLES = Object.freeze({
     pathwayType: 'GENERIC_REHAB',
     guidanceAssessments: Object.freeze(['تقييم نفسي-تربوي', 'Vineland-3']),
     measureTargetPopulations: Object.freeze(['learning_disability']),
-    measureCategories: Object.freeze(['academic', 'cognitive', 'adaptive']),
+    // W1225 — +screening/quality_of_life: no live instrument carries the
+    // learning_disability population yet, so 'all'-population screens (SDQ,
+    // PedsQL) are the realistic intake set for this bundle.
+    measureCategories: Object.freeze([
+      'academic',
+      'cognitive',
+      'adaptive',
+      'screening',
+      'quality_of_life',
+    ]),
     goalBankDomains: Object.freeze(['SPECIAL_EDU']),
     interventionsAr: Object.freeze(['تربية خاصة', 'مهارات حياتية', 'دعم أكاديمي']),
     defaultStages: Object.freeze([

--- a/backend/scripts/seed-goal-bank.js
+++ b/backend/scripts/seed-goal-bank.js
@@ -125,6 +125,14 @@ async function main() {
     process.exit(0);
   }
 
+  // W1225 — load backend/.env like the app does, so `npm run seed:goal-bank`
+  // works on the VPS without a `-r dotenv/config` preload (the gap the first
+  // prod run hit). Lazy + best-effort: an exported MONGODB_URI still wins.
+  try {
+    require('dotenv').config();
+  } catch (_e) {
+    /* dotenv optional in stripped environments */
+  }
   const mongoose = require('mongoose');
   const uri = process.env.MONGODB_URI || process.env.MONGO_URI;
   if (!uri) {


### PR DESCRIPTION
Prod showcase matrix after goal-bank seeding: every bundle resolves goals, but **mental/speech/learning resolved 0 measures** — only 8 instruments are active and the canonical autism tools (M-CHAT-R, CARS-2) are catalogued `screening`/`diagnostic`, which the original category filters excluded; nothing live carries the `learning_disability` population.

| bundle | added categories | now resolves |
|---|---|---|
| mental | screening, diagnostic | M-CHAT-R, CARS-2 (+SDQ/PedsQL via 'all') |
| speech | screening, quality_of_life | autism-pop + 'all'-pop screens |
| learning | screening, quality_of_life | SDQ, PedsQL |

All additions are valid `Measure.category` enums — the wave1205 registry guard re-verifies. Plus: `seed-goal-bank.js` best-effort loads dotenv (first prod run needed a manual preload).

32 local assertions green (wave1205 + wave1212 behavioral + wave1223).

🤖 Generated with [Claude Code](https://claude.com/claude-code)