### PR TITLE
fix(perf): W1229 — exempt letter-verify from the global Redis GET cache (revoked letters kept verifying VALID)

### DIFF
--- a/backend/__tests__/official-letters-routes-wave1224.test.js
+++ b/backend/__tests__/official-letters-routes-wave1224.test.js
@@ -81,6 +81,16 @@ describe('W1224 registry mount', () => {
     );
   });
 
+  test('W1229: verify paths are exempt from the global Redis GET cache', () => {
+    const perfSrc = fs.readFileSync(
+      path.join(__dirname, '..', 'config', 'performance.js'),
+      'utf8'
+    );
+    expect(perfSrc).toMatch(/NO_CACHE_RE/);
+    expect(perfSrc).toMatch(/letter-verify/);
+    expect(perfSrc).toMatch(/official-letters\\\/verify/);
+  });
+
   test('W1228: QR verify is ALSO mounted publicly OUTSIDE /hr (app.js gates /api/v1/hr with authenticate)', () => {
     expect(routeSrc).toMatch(/module\.exports\.verifyLetterHandler = verifyLetterHandler/);
     expect(registrySrc).toMatch(

--- a/backend/config/performance.js
+++ b/backend/config/performance.js
@@ -106,8 +106,19 @@ const initializeRedis = () => {
  * @param {number} ttl - Time to live in seconds
  * @param {string} prefix - Cache key prefix
  */
+// W1229: verification / anti-fraud endpoints must NEVER serve stale state.
+// Caught live on prod: a freshly REVOKED official letter kept verifying as
+// VALID for up to the 300s TTL, because the write-side invalidation strips
+// only a trailing /:objectId (the revoke URL ends in /revoke, and the verify
+// URL is keyed by token — they never match). Status-flipping verify reads
+// bypass the cache entirely.
+const NO_CACHE_RE = /\/letter-verify\/|\/official-letters\/verify\//;
+
 const cacheMiddleware = (ttl = 300, prefix = 'cache:') => {
   return async (req, res, next) => {
+    if (req.method === 'GET' && NO_CACHE_RE.test((req.originalUrl || req.url || '').split('?')[0])) {
+      return next();
+    }
     if (!redis || req.method !== 'GET') {
       // For write operations (POST/PUT/PATCH/DELETE), invalidate related cache
       if (redis && req.method !== 'GET' && req.method !== 'OPTIONS' && req.method !== 'HEAD') {


### PR DESCRIPTION
Caught during **live E2E** of W1224 on prod: issued `EC-2026-0001` → revoked it → the verify endpoint **still returned `valid:true` from cache**. The app-wide `cacheMiddleware(300,'api')` caches every GET in Redis; its write-side invalidation strips only a trailing `/:objectId`, so a `/revoke` POST never busts the token-keyed verify entry → up to 5 minutes of a revoked letter verifying as genuine.

Fix: `NO_CACHE_RE` bypass for `/letter-verify/` + `/official-letters/verify/` GETs. Drift guard extended.

Note: the same stale-window applies to ANY status-flipping GET under the global cache — broader audit is a follow-up candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)