### PR TITLE
docs: W1237 — correct runbook session reco; surface ClinicalSession/TherapySession write-read split (launch blocker)

### DIFF
--- a/docs/GO_LIVE_RUNBOOK_2026-06-11.md
+++ b/docs/GO_LIVE_RUNBOOK_2026-06-11.md
@@ -32,29 +32,47 @@ model instead of fragmenting across two. Three decisions; two already recorded:
 | **Care plan** | `UnifiedCarePlan` / `CarePlanVersion` | IEP/IFSP kept + cross-linked (regulatory) | ✅ ADR-026 DECIDED (Approach B) |
 | **Goal** | `TherapeuticGoal` | `SmartGoal` = qualitative-suggestion tier | ✅ ADR-040 DECIDED (Approach B) |
 | **IEP** | `SmartIEP` (`/api/v1/smart-iep`) | `IndividualEducationPlan` (`/api/v1/iep`) = deprecation candidate, gated on the MoE-Nafath-signature capability question | ✅ ADR-026 addendum (W1232–W1234) |
-| **Clinical session** | **`TherapySession`** | `ClinicalSession` + `DisabilitySession` = deprecation candidates | 🟡 **recommended below — decide before launch** |
+| **Clinical session** | ⚠️ **UNRESOLVED — write/read split (see below)** | not a simple pick — `ClinicalSession` (UI+360) vs `TherapySession` (analytics+56) | 🔴 **LAUNCH BLOCKER — resolve before sessions are logged at scale** |
 
-### Clinical-session recommendation (new — evidence-backed)
+### Clinical-session — CORRECTION + launch-blocker (W1237)
 
-Three general session models coexist (the `04-programs-sessions-progress-engine`
-prompt warns "do NOT add a 4th"). The evidence is now decisive:
+> **Retraction:** an earlier draft of this runbook called `TherapySession`
+> "canonical" from consumer-count alone (56 vs 8 vs 3). Tracing the **actual data
+> flow** (the W1231→W1232 lesson — consumer-count ≠ canonical) shows that was
+> **wrong**. There is a genuine **write/read split**, not a simple winner.
 
-- **Consumers (source):** `TherapySession` **56** · `ClinicalSession` **8** ·
-  `DisabilitySession` **3**.
-- **Prod data:** `therapysessions` = **1** (demo) · `clinicalsessions` = **0** ·
-  `disabilitysessions` = **0**.
+What the trace actually shows:
 
-→ **`TherapySession` is canonical** by a wide margin (7× the consumers, the only
-populated one). `ClinicalSession` + `DisabilitySession` are **deprecation
-candidates** — fold any distinctive fields into `TherapySession` (free: both
-empty) and stop adding consumers to them.
+| Path | Model | Collection (prod) |
+| --- | --- | --- |
+| **UI writes** a session (`POST /api/v1/sessions`, `domains/sessions`) | **`ClinicalSession`** | `clinical_sessions` = **0** |
+| **Beneficiary-360** "sessions" widget (`beneficiary360.service.js:391`) | **`ClinicalSession`** | (same — consistent ✅) |
+| **Session-Center KPIs** (`sessionCenter.service.js` — _"facade فوق TherapySession"_) | **`TherapySession`** | `therapysessions` = **1** (demo) |
+| **Episodes, goal-progress, appointments, NPHIES claims, ICF, pain** (the 56 consumers) | **`TherapySession`** | (same) |
 
-**Out of scope / KEEP:** `DttSession` is a **specialized Discrete-Trial-Training
-(ABA) session sub-type**, not one of the three general models — keep it.
-⚠️ **Coordination note:** the `DttSession` ↔ `CareTimeline` core-linkage is under
-**active parallel development** (`feat/w928-core-linkage`). Do **not** edit session
-models or their event wiring until that branch merges; this recommendation is a
-**docs decision only** and changes no session code.
+**There is NO sync between `ClinicalSession` and `TherapySession`.** Consequence at
+launch: a session logged through the UI lands in `ClinicalSession` → **shows on the
+360 ✅ but is INVISIBLE** to Session-Center KPIs, episode session-lists,
+goal-progress linkage, claims, and outcome reporting (all read `TherapySession`).
+That is a **day-1 data-integrity failure** for the session spine, not a cosmetic
+fragmentation.
+
+**This is now a 🔴 launch blocker, not a "decide later."** Resolution options
+(decide before real sessions are logged):
+
+1. **Bridge on write** — `domains/sessions` also upserts/forwards to
+   `TherapySession` (or emits an event the analytics side consumes). Lowest-risk;
+   keeps both surfaces working.
+2. **Re-point reads** — move Session-Center + episodes + goal-progress to read
+   `ClinicalSession` (the UI/360 model). Larger blast radius (56 consumers).
+3. **Consolidate** to one model (free today — both effectively empty).
+
+⚠️ **Coordination — do NOT fix this in isolation.** Session core-linkage
+(`DttSession`/`CareTimeline`/cross-module subscribers) is the **active domain of
+`feat/w928-core-linkage`** (the parallel effort). Its event-bridge work may already
+address (1). This runbook records the blocker + options as a **docs finding only**
+— the fix must be coordinated with that branch, not raced. `DttSession` itself is a
+specialized DTT/ABA sub-type and is out of scope of the 3-general-session question.
 
 ---
 
@@ -88,8 +106,11 @@ hold**, then smooth the rough edges:
 2. **Register → `Beneficiary`** — Arabic disability labels must pass the English
    `category`/`disability.type` enum via the W926 normalizer bridge. Verify a real
    Arabic-form registration persists (not 500). [[project_beneficiary_registration_enum_mismatch_2026-06-05]]
-3. **Log a session → `TherapySession`** (the canonical session per Phase C) —
-   verify create + the goal-progress write path.
+3. **Log a session** — the UI writes **`ClinicalSession`** (`POST /api/v1/sessions`),
+   which the 360 reads ✅ but Session-Center/episodes/goal-progress/claims do **not**
+   (they read `TherapySession`). **Resolve the Phase-C session split FIRST** (it is a
+   launch blocker) — otherwise verifying "create" passes while the session silently
+   never reaches analytics/goal-progress.
 4. **Forms** — catalog is seeded (83 `formtemplates`); W1179 (catalog visibility) +
    W1186 (approval-chain persistence) fixed. Verify submit → `formsubmissions`.
 
@@ -115,7 +136,8 @@ constraint; adoption is.
 - [ ] A real beneficiary registered via the Arabic form (persists, no 500).
 - [ ] A real therapy session logged against that beneficiary with goal progress.
 - [ ] The four Phase-B paths pass for a non-demo account.
-- [ ] Phase-C canonical models confirmed (no new writes to deprecated session/IEP/goal models).
+- [ ] **Session write/read split RESOLVED** (UI-logged `ClinicalSession` reaches Session-Center/episodes/goal-progress, not only the 360) — coordinated with `feat/w928-core-linkage`.
+- [ ] Other canonical models confirmed (no new writes to deprecated IEP/goal models).
 - [ ] Demo-showcase data decision made (kept-and-tagged or cleared).
 
 ---


### PR DESCRIPTION
## Self-correction (the W1231→W1232 discipline applied again)
W1236 called `TherapySession` "canonical" from **consumer-count alone** (56 vs 8 vs 3). Tracing the **actual data flow** shows that was wrong — there is a **write/read split**, not a winner:

| Path | Model | Prod |
|---|---|---|
| UI writes a session (`POST /api/v1/sessions`, `domains/sessions`) | **ClinicalSession** | `clinical_sessions`=0 |
| Beneficiary-360 sessions widget (`beneficiary360.service.js:391`) | **ClinicalSession** | consistent ✅ |
| Session-Center KPIs (`sessionCenter.service`) + episodes + goal-progress + NPHIES claims + ICF + pain (the 56) | **TherapySession** | `therapysessions`=1 (demo) |

**No sync between them.** So a session logged at launch → lands in `ClinicalSession` → shows on the 360 but is **invisible to analytics/episodes/goal-progress/claims**. That's a **day-1 data-integrity failure** for the session spine.

## Change
- Reclassified the session decision from "🟡 decide later (TherapySession)" to **🔴 LAUNCH BLOCKER** with 3 resolution options (bridge-on-write / re-point-reads / consolidate).
- Fixed the Phase-B and "definition of launched" lines that assumed a single canonical session.

## Coordination
The fix is in `feat/w928-core-linkage`'s active domain (session↔CareTimeline event bridge) — recorded as a **docs finding to coordinate**, not raced. `DttSession` (ABA) stays out of scope.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)