### PR TITLE
fix(sessions): W1240 — ROOT FIX ClinicalSession↔TherapySession split (CQRS projection)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1699,6 +1699,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/cctv-reports-wave1230.test.js'
       - 'backend/__tests__/cctv-reports-behavioral-wave1230.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/session-therapy-projection-wave1240.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3381,6 +3383,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/cctv-reports-wave1230.test.js'
       - 'backend/__tests__/cctv-reports-behavioral-wave1230.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/session-therapy-projection-wave1240.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/session-therapy-projection-wave1240.test.js
+++ b/backend/__tests__/session-therapy-projection-wave1240.test.js
@@ -1,0 +1,150 @@
+/**
+ * W1240 — behavioral test for the ClinicalSession → TherapySession CQRS projection
+ * (therapySessionProjection.js). Verifies the root fix for the write/read session
+ * split: a session written through the UI model (ClinicalSession) is faithfully
+ * projected into the analytics model (TherapySession) so Session-Center / episodes /
+ * goal-progress / claims (the 56 TherapySession consumers) can see it.
+ *
+ * Asserts: faithful field+enum mapping · faithful-or-null therapist resolution
+ * (User→Employee via Employee.user_id) · idempotent upsert (one projection per
+ * source, re-project updates the same record) · FAIL-SAFE (never throws).
+ */
+
+jest.unmock('mongoose');
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const {
+  mapSessionType,
+  mapStatus,
+  mapClinicalToTherapy,
+  projectClinicalSession,
+} = require('../domains/sessions/services/therapySessionProjection');
+
+let mongod;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  // Real analytics model (validates the schema + the new sourceClinicalSessionId field).
+  require('../models/TherapySession');
+  // Minimal Employee (the projection only needs Employee.findOne({user_id})._id).
+  if (!mongoose.models.Employee) {
+    mongoose.model(
+      'Employee',
+      new mongoose.Schema({ user_id: { type: mongoose.Schema.Types.ObjectId } })
+    );
+  }
+}, 60000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+});
+
+afterEach(async () => {
+  await mongoose.model('TherapySession').deleteMany({});
+  await mongoose.model('Employee').deleteMany({});
+});
+
+function clinicalStub(overrides = {}) {
+  return {
+    _id: new mongoose.Types.ObjectId(),
+    beneficiaryId: new mongoose.Types.ObjectId(),
+    episodeId: new mongoose.Types.ObjectId(),
+    therapistId: new mongoose.Types.ObjectId(),
+    specialty: 'speech_therapy',
+    status: 'scheduled',
+    scheduledDate: new Date('2026-06-12T10:00:00Z'),
+    scheduledDurationMinutes: 45,
+    ...overrides,
+  };
+}
+
+describe('W1240 — pure mappers', () => {
+  test('specialty → Arabic discipline enum (faithful + fallback)', () => {
+    expect(mapSessionType('speech_therapy')).toBe('نطق وتخاطب');
+    expect(mapSessionType('physical_therapy')).toBe('علاج طبيعي');
+    expect(mapSessionType('occupational_therapy')).toBe('علاج وظيفي');
+    expect(mapSessionType('behavioral_therapy')).toBe('علاج سلوكي');
+    expect(mapSessionType('psychological')).toBe('علاج نفسي');
+    expect(mapSessionType('nursing')).toBe('أخرى'); // unmapped → fallback
+    expect(mapSessionType(undefined)).toBe('أخرى');
+  });
+
+  test('status lowercase → UPPERCASE enum (faithful + fallback)', () => {
+    expect(mapStatus('scheduled')).toBe('SCHEDULED');
+    expect(mapStatus('completed')).toBe('COMPLETED');
+    expect(mapStatus('no_show')).toBe('NO_SHOW');
+    expect(mapStatus('cancelled')).toBe('CANCELLED_BY_CENTER');
+    expect(mapStatus('late_cancel')).toBe('CANCELLED_BY_PATIENT');
+    expect(mapStatus('weird')).toBe('SCHEDULED'); // unknown → safe default
+  });
+});
+
+describe('W1240 — projection (faithful field mapping)', () => {
+  test('creates a TherapySession with faithfully mapped fields', async () => {
+    const clinical = clinicalStub();
+    const res = await projectClinicalSession(clinical);
+    expect(res.ok).toBe(true);
+
+    const TherapySession = mongoose.model('TherapySession');
+    const projected = await TherapySession.findOne({ sourceClinicalSessionId: clinical._id }).lean();
+    expect(projected).toBeTruthy();
+    expect(String(projected.beneficiary)).toBe(String(clinical.beneficiaryId));
+    expect(String(projected.episodeOfCare)).toBe(String(clinical.episodeId));
+    expect(projected.sessionType).toBe('نطق وتخاطب');
+    expect(projected.status).toBe('SCHEDULED');
+    expect(new Date(projected.date).toISOString()).toBe(clinical.scheduledDate.toISOString());
+    expect(projected.duration).toBe(45);
+  });
+
+  test('mapClinicalToTherapy always yields a valid Date even with no scheduledDate', async () => {
+    const fields = await mapClinicalToTherapy(clinicalStub({ scheduledDate: undefined }));
+    expect(fields.date instanceof Date).toBe(true);
+  });
+});
+
+describe('W1240 — therapist resolution (faithful-or-null)', () => {
+  test('resolves therapistId(User) → therapist(Employee) via Employee.user_id', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const emp = await mongoose.model('Employee').create({ user_id: userId });
+    const res = await projectClinicalSession(clinicalStub({ therapistId: userId }));
+    expect(res.ok).toBe(true);
+    const doc = await mongoose.model('TherapySession').findById(res.id).lean();
+    expect(String(doc.therapist)).toBe(String(emp._id));
+  });
+
+  test('leaves therapist NULL when no Employee is linked (never wrong attribution)', async () => {
+    const res = await projectClinicalSession(clinicalStub());
+    const doc = await mongoose.model('TherapySession').findById(res.id).lean();
+    expect(doc.therapist == null).toBe(true);
+  });
+});
+
+describe('W1240 — idempotency (one projection per source)', () => {
+  test('re-projecting the same source updates the SAME record, no duplicate', async () => {
+    const clinical = clinicalStub();
+    const r1 = await projectClinicalSession(clinical);
+    const r2 = await projectClinicalSession({ ...clinical, status: 'completed' });
+    expect(String(r1.id)).toBe(String(r2.id));
+
+    const TherapySession = mongoose.model('TherapySession');
+    const count = await TherapySession.countDocuments({ sourceClinicalSessionId: clinical._id });
+    expect(count).toBe(1);
+    const doc = await TherapySession.findById(r1.id).lean();
+    expect(doc.status).toBe('COMPLETED'); // updated in place
+  });
+});
+
+describe('W1240 — FAIL-SAFE (never throws, never breaks the session write)', () => {
+  test('returns {ok:false} for a null / id-less source instead of throwing', async () => {
+    await expect(projectClinicalSession(null)).resolves.toEqual(
+      expect.objectContaining({ ok: false })
+    );
+    await expect(projectClinicalSession({})).resolves.toEqual(
+      expect.objectContaining({ ok: false })
+    );
+  });
+});

--- a/backend/domains/sessions/services/SessionsService.js
+++ b/backend/domains/sessions/services/SessionsService.js
@@ -14,6 +14,11 @@
 
 const mongoose = require('mongoose');
 const { BaseService } = require('../../_base/BaseService');
+// W1240 — CQRS read-model projection: keep the legacy TherapySession analytics model
+// in sync with every ClinicalSession write so UI-logged sessions reach Session-Center /
+// episodes / goal-progress / claims. Fail-safe (never throws), so it can never break a
+// session write. See therapySessionProjection.js + DDD_VS_LEGACY_MODEL_SPLIT_2026-06-12.md.
+const { projectClinicalSession } = require('./therapySessionProjection');
 
 class SessionsService extends BaseService {
   constructor() {
@@ -55,6 +60,7 @@ class SessionsService extends BaseService {
       scheduledDate: session.scheduledDate,
     });
 
+    await projectClinicalSession(session, { logger: this.logger });
     return session;
   }
 
@@ -180,6 +186,7 @@ class SessionsService extends BaseService {
       throw err;
     }
     this.emit('session:updated', { sessionId: session._id, fields: Object.keys(data) });
+    await projectClinicalSession(session, { logger: this.logger });
     return session;
   }
 
@@ -230,6 +237,7 @@ class SessionsService extends BaseService {
       duration: duration || session.duration,
     });
 
+    await projectClinicalSession(session, { logger: this.logger });
     return session;
   }
 
@@ -265,6 +273,7 @@ class SessionsService extends BaseService {
       reason,
     });
 
+    await projectClinicalSession(session, { logger: this.logger });
     return session;
   }
 

--- a/backend/domains/sessions/services/therapySessionProjection.js
+++ b/backend/domains/sessions/services/therapySessionProjection.js
@@ -1,0 +1,147 @@
+'use strict';
+
+/**
+ * therapySessionProjection.js — W1240
+ *
+ * ROOT FIX for the ClinicalSession ↔ TherapySession write/read split documented in
+ * docs/DDD_VS_LEGACY_MODEL_SPLIT_2026-06-12.md. The web-admin UI writes sessions to
+ * `ClinicalSession` (domains/sessions); the entire analytics layer — Session-Center
+ * KPIs, episodes, goal-progress, NPHIES claims, ICF, pain (the 56 TherapySession
+ * consumers) — reads `TherapySession`. There was NO sync between them, so a session
+ * logged through the UI showed on the Beneficiary-360 but was INVISIBLE to all of
+ * those surfaces.
+ *
+ * This module projects each ClinicalSession write into a faithful TherapySession
+ * read-model record (CQRS read-model projection), keyed by `sourceClinicalSessionId`
+ * for idempotency (one TherapySession per source ClinicalSession; re-projecting an
+ * updated session updates the same record).
+ *
+ * Two invariants make this safe to run on the live (currently empty) session spine:
+ *   1. FAIL-SAFE — every error is swallowed and returned as `{ ok:false }`, never
+ *      thrown. A projection failure must NEVER break the UI session-create flow.
+ *      Incomplete analytics is acceptable; a broken session write is not.
+ *   2. FAITHFUL-OR-NULL — `ClinicalSession.therapistId` refs `User`, but
+ *      `TherapySession.therapist` refs `Employee`. We resolve via `Employee.user_id`;
+ *      when no Employee is linked we leave `therapist` null. The projection is never
+ *      WRONG (no fabricated therapist attribution feeding claims/KPIs) — only
+ *      incomplete, which a later backfill can fill.
+ */
+
+const mongoose = require('mongoose');
+
+// ClinicalSession.specialty (English) → TherapySession.sessionType (Arabic discipline enum)
+const SPECIALTY_TO_DISCIPLINE = Object.freeze({
+  physical_therapy: 'علاج طبيعي',
+  occupational_therapy: 'علاج وظيفي',
+  speech_therapy: 'نطق وتخاطب',
+  behavioral_therapy: 'علاج سلوكي',
+  psychological: 'علاج نفسي',
+  // educational | social_work | nursing | vocational | recreational |
+  // multidisciplinary | other | (unset) → 'أخرى'
+});
+
+// ClinicalSession.status (lowercase) → TherapySession.status (UPPERCASE enum)
+const STATUS_MAP = Object.freeze({
+  scheduled: 'SCHEDULED',
+  confirmed: 'CONFIRMED',
+  in_progress: 'IN_PROGRESS',
+  completed: 'COMPLETED',
+  cancelled: 'CANCELLED_BY_CENTER',
+  late_cancel: 'CANCELLED_BY_PATIENT',
+  no_show: 'NO_SHOW',
+  rescheduled: 'RESCHEDULED',
+});
+
+function mapSessionType(specialty) {
+  return SPECIALTY_TO_DISCIPLINE[specialty] || 'أخرى';
+}
+
+function mapStatus(status) {
+  return STATUS_MAP[status] || 'SCHEDULED';
+}
+
+/**
+ * Resolve a ClinicalSession.therapistId (ref User) to an Employee._id
+ * (TherapySession.therapist ref Employee). Faithful-or-null: returns null when no
+ * Employee is linked or on any error. Never throws.
+ * @param {mongoose.Types.ObjectId|string|null} userId
+ * @returns {Promise<mongoose.Types.ObjectId|null>}
+ */
+async function resolveTherapistEmployeeId(userId) {
+  if (!userId) return null;
+  try {
+    const Employee = mongoose.model('Employee');
+    const emp = await Employee.findOne({ user_id: userId }).select('_id').lean();
+    return emp ? emp._id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the TherapySession projection fields from a ClinicalSession document.
+ * One async lookup (therapist resolution); never throws.
+ * @param {Object} clinical - a ClinicalSession doc or lean object
+ * @returns {Promise<Object>} fields for a TherapySession upsert
+ */
+async function mapClinicalToTherapy(clinical) {
+  const therapist = await resolveTherapistEmployeeId(clinical.therapistId);
+  // `date` is the only required TherapySession field — always provide a valid Date.
+  const date =
+    clinical.scheduledDate || clinical.actualStartTime || clinical.createdAt || new Date(0);
+  const duration =
+    clinical.actualDurationMinutes != null
+      ? clinical.actualDurationMinutes
+      : clinical.scheduledDurationMinutes;
+
+  return {
+    sourceClinicalSessionId: clinical._id,
+    beneficiary: clinical.beneficiaryId || undefined,
+    episodeOfCare: clinical.episodeId || undefined,
+    carePlan: clinical.carePlanId || undefined,
+    therapist: therapist || undefined,
+    branchId: clinical.branchId || undefined,
+    sessionType: mapSessionType(clinical.specialty),
+    status: mapStatus(clinical.status),
+    date,
+    ...(duration != null ? { duration } : {}),
+    createdBy: clinical.therapistId || undefined,
+  };
+}
+
+/**
+ * Idempotently project a ClinicalSession into its TherapySession read-model record
+ * (upsert keyed by `sourceClinicalSessionId`). FAIL-SAFE — returns a result object,
+ * never throws.
+ * @param {Object} clinical - the ClinicalSession doc just written
+ * @param {{logger?: {warn?: Function}}} [opts]
+ * @returns {Promise<{ok: boolean, id?: any, error?: string}>}
+ */
+async function projectClinicalSession(clinical, { logger } = {}) {
+  try {
+    if (!clinical || !clinical._id) return { ok: false, error: 'no source doc' };
+    const TherapySession = mongoose.model('TherapySession');
+    const fields = await mapClinicalToTherapy(clinical);
+    const doc = await TherapySession.findOneAndUpdate(
+      { sourceClinicalSessionId: clinical._id },
+      { $set: fields },
+      { upsert: true, returnDocument: 'after', setDefaultsOnInsert: true, runValidators: true }
+    );
+    return { ok: true, id: doc ? doc._id : undefined };
+  } catch (err) {
+    if (logger && typeof logger.warn === 'function') {
+      logger.warn(`[therapySessionProjection] projection failed (non-fatal): ${err.message}`);
+    }
+    return { ok: false, error: err.message };
+  }
+}
+
+module.exports = {
+  SPECIALTY_TO_DISCIPLINE,
+  STATUS_MAP,
+  mapSessionType,
+  mapStatus,
+  resolveTherapistEmployeeId,
+  mapClinicalToTherapy,
+  projectClinicalSession,
+};

--- a/backend/models/TherapySession.js
+++ b/backend/models/TherapySession.js
@@ -31,6 +31,17 @@ const therapySessionSchema = new mongoose.Schema(
     plan: { type: mongoose.Schema.Types.ObjectId, ref: 'TherapeuticPlan' },
     episodeOfCare: { type: mongoose.Schema.Types.ObjectId, ref: 'EpisodeOfCare', index: true },
     carePlan: { type: mongoose.Schema.Types.ObjectId, ref: 'CarePlan', index: true },
+    // W1240 — CQRS read-model link back to the source ClinicalSession (the UI write
+    // model in domains/sessions). Populated by therapySessionProjection.js so this
+    // model's analytics consumers see UI-logged sessions. sparse + unique → one
+    // projection per source ClinicalSession; manually-created sessions stay null.
+    sourceClinicalSessionId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'ClinicalSession',
+      index: true,
+      sparse: true,
+      unique: true,
+    },
     beneficiary: { type: mongoose.Schema.Types.ObjectId, ref: 'Beneficiary', index: true },
     therapist: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee' },
     // W647 — branch tenancy denormalization (R4). beneficiary is optional, so

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1018,3 +1018,4 @@ __tests__/expense-anomaly-wave1218.test.js
 __tests__/seed-goal-bank-wave1223.test.js
 __tests__/cctv-reports-wave1230.test.js
 __tests__/cctv-reports-behavioral-wave1230.test.js
+__tests__/session-therapy-projection-wave1240.test.js


### PR DESCRIPTION
## The first real CODE fix of the systemic split (not another doc)
The UI writes sessions to `ClinicalSession` (`domains/sessions`); the analytics layer — Session-Center KPIs, episodes, goal-progress, **NPHIES claims**, ICF, pain (56 `TherapySession` consumers) — reads `TherapySession`, with **no sync**. UI-logged sessions showed on the 360 but were invisible to all of them (`DDD_VS_LEGACY_MODEL_SPLIT_2026-06-12.md`).

## Fix — a fail-safe, idempotent CQRS read-model projection
Every `ClinicalSession` write (schedule/update/complete/cancel via `SessionsService`) is faithfully projected into a `TherapySession` record, keyed by a new `sourceClinicalSessionId` (sparse+unique) for idempotency.

**Two safety invariants (both tested):**
- **FAIL-SAFE** — `projectClinicalSession()` never throws; a failure is logged + swallowed so it can **never break the UI session-create flow**.
- **FAITHFUL-OR-NULL** — `therapistId`(User) → `therapist`(Employee) via `Employee.user_id`; **null when unlinked** — never fabricates therapist attribution into KPIs/claims (incomplete > wrong).

Mappings: specialty→Arabic discipline enum · status lowercase→UPPERCASE · beneficiaryId→beneficiary · episodeId→episodeOfCare · scheduledDate→date · duration · branchId.

## Why safe to ship now
Prod `clinical_sessions`=0 → the projection only ever acts on **new** UI data; the `TherapySession` field is additive+sparse so the 1 demo row is untouched.

## Tests
- **8 behavioral tests** (MongoMemoryServer): pure mappers · faithful projection · therapist resolve · faithful-or-null · idempotency · fail-safe. ✅
- Existing `session-branch-tenancy` (W647) + `session-goal-linkage` (W1149) still green — no regression. ✅
- Added to `sprint-tests.txt` (+ yml synced).

## Scope note
Care-plans (`UnifiedCarePlan`↔`CarePlanVersion`) is the same class but heavier (W41-51 invariants + the prod-ON workers) — **staged next** per the blueprint; the care-plan version may belong in `feat/w928-core-linkage`'s event layer. This PR touches only the session model-twins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)