### PR TITLE
fix(behavior): W1242 — ROOT FIX BehaviorRecord↔BehaviorIncident split (CQRS projection)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1701,6 +1701,8 @@ on:
       - 'backend/__tests__/cctv-reports-behavioral-wave1230.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/session-therapy-projection-wave1240.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/behavior-incident-projection-wave1242.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3385,6 +3387,8 @@ on:
       - 'backend/__tests__/cctv-reports-behavioral-wave1230.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/session-therapy-projection-wave1240.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/behavior-incident-projection-wave1242.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/behavior-incident-projection-wave1242.test.js
+++ b/backend/__tests__/behavior-incident-projection-wave1242.test.js
@@ -1,0 +1,134 @@
+/**
+ * W1242 — behavioral test for the BehaviorRecord → BehaviorIncident CQRS projection
+ * (behaviorIncidentProjection.js). Verifies the root fix for the behavior write/read
+ * split: a behavior logged through the UI model (BehaviorRecord, domains/behavior) is
+ * faithfully projected into the legacy BehaviorIncident that the risk/escalation engine
+ * reads — so UI-logged aggression reaches the `behavioral.aggression.frequency.spike_200`
+ * detector instead of being silently missed (patient-safety relevant).
+ *
+ * Asserts: faithful topography→type roll-up (incl. hitting/kicking/biting → aggression)
+ * · severity mapping · idempotent upsert · FAIL-SAFE (never throws).
+ */
+
+jest.unmock('mongoose');
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const {
+  mapBehaviorType,
+  mapSeverity,
+  mapRecordToIncident,
+  projectBehaviorRecord,
+} = require('../domains/behavior/services/behaviorIncidentProjection');
+
+let mongod;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  require('../models/BehaviorIncident'); // real analytics/risk model + the new field
+}, 60000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+});
+
+afterEach(async () => {
+  await mongoose.model('BehaviorIncident').deleteMany({});
+});
+
+function recordStub(overrides = {}) {
+  const { behavior, ...rest } = overrides;
+  return {
+    _id: new mongoose.Types.ObjectId(),
+    beneficiaryId: new mongoose.Types.ObjectId(),
+    occurredAt: new Date('2026-06-12T09:00:00Z'),
+    antecedent: { description: 'demand placed' },
+    consequence: { description: 'redirected' },
+    behavior: { topography: 'aggression', severity: 'severe', description: 'hit peer', ...behavior },
+    ...rest,
+  };
+}
+
+describe('W1242 — pure mappers (faithful clinical roll-up)', () => {
+  test('topography → BehaviorIncident.behaviorType taxonomy', () => {
+    expect(mapBehaviorType('aggression')).toBe('aggression');
+    // safety-critical: physical aggression sub-types roll up to aggression
+    expect(mapBehaviorType('hitting')).toBe('aggression');
+    expect(mapBehaviorType('kicking')).toBe('aggression');
+    expect(mapBehaviorType('biting')).toBe('aggression');
+    expect(mapBehaviorType('self_injury')).toBe('self_injury');
+    expect(mapBehaviorType('elopement')).toBe('elopement');
+    expect(mapBehaviorType('throwing')).toBe('property_destruction');
+    expect(mapBehaviorType('tantrums')).toBe('disruption');
+    // conservative: ambiguous/internalizing → other (don't inflate aggression count)
+    expect(mapBehaviorType('stereotypy')).toBe('other');
+    expect(mapBehaviorType('withdrawal')).toBe('other');
+    expect(mapBehaviorType(undefined)).toBe('other');
+  });
+
+  test('severity mild/moderate/severe/crisis → minor/moderate/major', () => {
+    expect(mapSeverity('mild')).toBe('minor');
+    expect(mapSeverity('moderate')).toBe('moderate');
+    expect(mapSeverity('severe')).toBe('major');
+    expect(mapSeverity('crisis')).toBe('major');
+    expect(mapSeverity('weird')).toBeUndefined();
+  });
+});
+
+describe('W1242 — projection (faithful, escalation-visible)', () => {
+  test('UI-logged hitting becomes an aggression BehaviorIncident the predictor can see', async () => {
+    const record = recordStub({ behavior: { topography: 'hitting', severity: 'crisis' } });
+    const res = await projectBehaviorRecord(record);
+    expect(res.ok).toBe(true);
+
+    const BehaviorIncident = mongoose.model('BehaviorIncident');
+    // the exact query the escalation source runs: by beneficiary + recent + type
+    const found = await BehaviorIncident.findOne({
+      beneficiaryId: record.beneficiaryId,
+      behaviorType: 'aggression',
+    }).lean();
+    expect(found).toBeTruthy();
+    expect(found.severity).toBe('major');
+    expect(new Date(found.observedAt).toISOString()).toBe(record.occurredAt.toISOString());
+    expect(found.antecedent).toBe('demand placed');
+    expect(String(found.sourceBehaviorRecordId)).toBe(String(record._id));
+  });
+
+  test('mapRecordToIncident always yields a valid observedAt', () => {
+    const fields = mapRecordToIncident(recordStub({ occurredAt: undefined }));
+    expect(fields.observedAt instanceof Date).toBe(true);
+    expect(fields.behaviorType).toBe('aggression');
+  });
+});
+
+describe('W1242 — idempotency', () => {
+  test('re-projecting updates the SAME incident, no duplicate', async () => {
+    const record = recordStub();
+    const r1 = await projectBehaviorRecord(record);
+    const r2 = await projectBehaviorRecord({
+      ...record,
+      behavior: { ...record.behavior, severity: 'mild' },
+    });
+    expect(String(r1.id)).toBe(String(r2.id));
+    const count = await mongoose
+      .model('BehaviorIncident')
+      .countDocuments({ sourceBehaviorRecordId: record._id });
+    expect(count).toBe(1);
+    const doc = await mongoose.model('BehaviorIncident').findById(r1.id).lean();
+    expect(doc.severity).toBe('minor'); // updated in place
+  });
+});
+
+describe('W1242 — FAIL-SAFE', () => {
+  test('returns {ok:false} for null / id-less / beneficiary-less source, never throws', async () => {
+    await expect(projectBehaviorRecord(null)).resolves.toEqual(
+      expect.objectContaining({ ok: false })
+    );
+    await expect(projectBehaviorRecord({ _id: new mongoose.Types.ObjectId() })).resolves.toEqual(
+      expect.objectContaining({ ok: false })
+    );
+  });
+});

--- a/backend/domains/behavior/services/BehaviorService.js
+++ b/backend/domains/behavior/services/BehaviorService.js
@@ -7,6 +7,11 @@
 
 const mongoose = require('mongoose');
 const { BaseService } = require('../../_base/BaseService');
+// W1242 — CQRS projection: mirror every BehaviorRecord write into the legacy
+// BehaviorIncident the risk/escalation engine reads, so UI-logged behavior (esp.
+// aggression) reaches the spike detector. Fail-safe (never throws). See
+// behaviorIncidentProjection.js + DDD_VS_LEGACY_MODEL_SPLIT_2026-06-12.md.
+const { projectBehaviorRecord } = require('./behaviorIncidentProjection');
 
 class BehaviorService extends BaseService {
   constructor() {
@@ -36,6 +41,7 @@ class BehaviorService extends BaseService {
         severity: data.behavior.severity,
       });
     }
+    await projectBehaviorRecord(record, { logger: this.logger });
     return record;
   }
 

--- a/backend/domains/behavior/services/behaviorIncidentProjection.js
+++ b/backend/domains/behavior/services/behaviorIncidentProjection.js
@@ -1,0 +1,122 @@
+'use strict';
+
+/**
+ * behaviorIncidentProjection.js — W1242
+ *
+ * ROOT FIX for the BehaviorRecord ↔ BehaviorIncident write/read split
+ * (docs/DDD_VS_LEGACY_MODEL_SPLIT_2026-06-12.md §2a-class). The web-admin UI writes
+ * behavioral observations to `BehaviorRecord` (domains/behavior); the risk/escalation
+ * engine — `intelligence/risk/sources/behavioral-escalation.source.js` →
+ * `escalation-predictor.lib` powering the `behavioral.aggression.frequency.spike_200`
+ * rule — reads the legacy `BehaviorIncident`. Both are ABC (Antecedent-Behavior-
+ * Consequence) event logs of the SAME concept, with NO sync. So a behavior logged
+ * through the UI was INVISIBLE to the escalation predictor — meaning a real aggression
+ * spike entered via the UI could be MISSED. This is patient-safety relevant.
+ *
+ * Same template + safety invariants as W1240 (therapySessionProjection):
+ *   1. FAIL-SAFE — never throws; returns `{ ok:false }`. A projection failure must
+ *      NEVER break the UI behavior-record write.
+ *   2. FAITHFUL — `BehaviorIncident` is a plain ABC log (no hash-chain, no required
+ *      fields BehaviorRecord lacks), so every field maps faithfully. The only
+ *      transform is a clinical roll-up of the fine-grained `behavior.topography` into
+ *      `BehaviorIncident`'s coarser `behaviorType` taxonomy — a standard clinical
+ *      classification, not fabrication. Conservative: only unambiguous physical
+ *      aggression (hitting/kicking/biting) rolls up to `aggression`; ambiguous
+ *      topographies fall through to `other` rather than inflate the aggression count.
+ */
+
+const mongoose = require('mongoose');
+
+// BehaviorRecord.behavior.topography (fine-grained) → BehaviorIncident.behaviorType
+// (coarse taxonomy: aggression | self_injury | elopement | property_destruction |
+// disruption | other). Unmapped → 'other'.
+const TOPOGRAPHY_TO_TYPE = Object.freeze({
+  aggression: 'aggression',
+  hitting: 'aggression',
+  kicking: 'aggression',
+  biting: 'aggression',
+  self_injury: 'self_injury',
+  property_destruction: 'property_destruction',
+  throwing: 'property_destruction',
+  elopement: 'elopement',
+  tantrums: 'disruption',
+  verbal_outburst: 'disruption',
+  screaming: 'disruption',
+  non_compliance: 'disruption',
+  // stereotypy | withdrawal | crying | other | (unset) → 'other'
+});
+
+// BehaviorRecord.behavior.severity → BehaviorIncident.severity
+const SEVERITY_MAP = Object.freeze({
+  mild: 'minor',
+  moderate: 'moderate',
+  severe: 'major',
+  crisis: 'major',
+});
+
+function mapBehaviorType(topography) {
+  return TOPOGRAPHY_TO_TYPE[topography] || 'other';
+}
+
+function mapSeverity(severity) {
+  return SEVERITY_MAP[severity] || undefined; // severity is optional on BehaviorIncident
+}
+
+/**
+ * Build the BehaviorIncident projection fields from a BehaviorRecord document.
+ * Pure; never throws.
+ * @param {Object} record - a BehaviorRecord doc or lean object
+ * @returns {Object} fields for a BehaviorIncident upsert
+ */
+function mapRecordToIncident(record) {
+  const behavior = record.behavior || {};
+  const severity = mapSeverity(behavior.severity);
+  return {
+    sourceBehaviorRecordId: record._id,
+    beneficiaryId: record.beneficiaryId,
+    branchId: record.branchId || undefined,
+    behaviorType: mapBehaviorType(behavior.topography),
+    ...(severity ? { severity } : {}),
+    // observedAt is required on BehaviorIncident — always provide a valid Date.
+    observedAt: record.occurredAt || record.createdAt || new Date(0),
+    antecedent: (record.antecedent && record.antecedent.description) || null,
+    consequence: (record.consequence && record.consequence.description) || null,
+  };
+}
+
+/**
+ * Idempotently project a BehaviorRecord into its BehaviorIncident record (upsert
+ * keyed by `sourceBehaviorRecordId`). FAIL-SAFE — returns a result object, never
+ * throws.
+ * @param {Object} record - the BehaviorRecord just written
+ * @param {{logger?: {warn?: Function}}} [opts]
+ * @returns {Promise<{ok: boolean, id?: any, error?: string}>}
+ */
+async function projectBehaviorRecord(record, { logger } = {}) {
+  try {
+    if (!record || !record._id) return { ok: false, error: 'no source doc' };
+    if (!record.beneficiaryId) return { ok: false, error: 'no beneficiaryId' };
+    const BehaviorIncident = mongoose.model('BehaviorIncident');
+    const fields = mapRecordToIncident(record);
+    const doc = await BehaviorIncident.findOneAndUpdate(
+      { sourceBehaviorRecordId: record._id },
+      { $set: fields },
+      { upsert: true, returnDocument: 'after', setDefaultsOnInsert: true, runValidators: true }
+    );
+    return { ok: true, id: doc ? doc._id : undefined };
+  } catch (err) {
+    if (logger && typeof logger.warn === 'function') {
+      logger.warn(`[behaviorIncidentProjection] projection failed (non-fatal): ${err.message}`);
+    }
+    return { ok: false, error: err.message };
+  }
+}
+
+module.exports = {
+  TOPOGRAPHY_TO_TYPE,
+  SEVERITY_MAP,
+  mapBehaviorType,
+  mapSeverity,
+  mapRecordToIncident,
+  projectBehaviorRecord,
+};

--- a/backend/models/BehaviorIncident.js
+++ b/backend/models/BehaviorIncident.js
@@ -59,6 +59,17 @@ const behaviorIncidentSchema = new mongoose.Schema(
       required: true,
       index: true,
     },
+    // W1242 — link back to the source BehaviorRecord (the UI write model in
+    // domains/behavior). Populated by behaviorIncidentProjection.js so the
+    // risk/escalation engine sees UI-logged behavior. sparse + unique → one
+    // projection per source; manually-created incidents stay null.
+    sourceBehaviorRecordId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'BehaviorRecord',
+      index: true,
+      sparse: true,
+      unique: true,
+    },
     behaviorType: {
       type: String,
       enum: BEHAVIOR_TYPES,

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1019,3 +1019,4 @@ __tests__/seed-goal-bank-wave1223.test.js
 __tests__/cctv-reports-wave1230.test.js
 __tests__/cctv-reports-behavioral-wave1230.test.js
 __tests__/session-therapy-projection-wave1240.test.js
+__tests__/behavior-incident-projection-wave1242.test.js


### PR DESCRIPTION
## Second code fix of the systemic split — and patient-safety relevant
The UI writes behavior observations to `BehaviorRecord` (`domains/behavior`); the **risk/escalation engine** (`behavioral-escalation.source` → `escalation-predictor.lib`, the `behavioral.aggression.frequency.spike_200` rule) reads legacy `BehaviorIncident`. Both are ABC logs of the **same concept**, with **no sync** → a behavior logged via the UI was **invisible to the escalation predictor**, so a real **aggression spike could be missed**.

## Fix — same proven template as W1240, and projectable (unlike care-plans)
`BehaviorIncident` is a **plain ABC log** (no hash-chain, no fields BehaviorRecord lacks), so — unlike `CarePlanVersion` (W1241) — it projects **without fabrication**.

Fail-safe, idempotent CQRS projection on every `BehaviorRecord` write, keyed by new `sourceBehaviorRecordId` (sparse+unique). Faithful clinical roll-up:
- **hitting / kicking / biting → aggression** (UI-logged physical aggression now reaches the spike detector ✅)
- tantrums / screaming → disruption · ambiguous → other (conservative — never inflates the aggression count)
- severity mild/moderate/severe/crisis → minor/moderate/major

**FAIL-SAFE** (never throws → can't break the UI write). Safe on the empty spine; field is additive+sparse.

## Tests
- **6 behavioral tests** incl. the exact escalation-source query (`{beneficiaryId, behaviorType:'aggression'}`) finding a projected incident. ✅
- Existing `behavior-record-logged` (W1114) + `behavior-plan` (W1032) still green. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)