### PR TITLE
W1242: professional bilingual email-template system (registry + RTL renderer + preview API)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1701,6 +1701,8 @@ on:
       - 'backend/__tests__/cctv-reports-behavioral-wave1230.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/session-therapy-projection-wave1240.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/email-templates-wave1242.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3385,6 +3387,8 @@ on:
       - 'backend/__tests__/cctv-reports-behavioral-wave1230.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/session-therapy-projection-wave1240.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/email-templates-wave1242.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/email-templates-wave1242.test.js
+++ b/backend/__tests__/email-templates-wave1242.test.js
@@ -1,0 +1,190 @@
+'use strict';
+
+/**
+ * W1242 — professional email-template system (registry + renderer + routes).
+ *
+ * Layers:
+ *  1. REGISTRY — every template structurally complete (bilingual subjects,
+ *     valid category/block types/panel tones, variable specs with samples,
+ *     every {{var}} used in subject/blocks is DECLARED in the contract and
+ *     vice-versa for required vars).
+ *  2. RENDERER — contract enforcement (missing required → 422-coded throw),
+ *     HTML-escaping of interpolated values (injection-safe), RTL layout
+ *     markers, hidden preheader, plain-text alternative, CTA omitted when
+ *     its url variable is absent.
+ *  3. STATIC WIRING — routes mounted via dualMountAuth; admin-only test-send.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const registry = require('../intelligence/email-templates.registry');
+const renderer = require('../services/email/templateRenderer.service');
+
+const BACKEND = path.join(__dirname, '..');
+const read = (rel) => fs.readFileSync(path.join(BACKEND, rel), 'utf8');
+
+const VAR_RE = /\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g;
+function varsIn(str) {
+  const out = new Set();
+  let m;
+  while ((m = VAR_RE.exec(String(str))) !== null) out.add(m[1]);
+  return out;
+}
+
+describe('W1242 registry — catalogue integrity', () => {
+  const all = registry.listTemplates();
+
+  test('catalogue is substantial and frozen', () => {
+    expect(all.length).toBeGreaterThanOrEqual(12);
+    expect(Object.isFrozen(registry.EMAIL_TEMPLATES)).toBe(true);
+    expect(Object.isFrozen(all[0])).toBe(true);
+    expect(Object.isFrozen(all[0].blocks)).toBe(true);
+  });
+
+  test('every template: key match, valid category, bilingual subject, Arabic title', () => {
+    for (const t of all) {
+      expect(registry.EMAIL_TEMPLATES[t.key]).toBe(t);
+      expect(registry.CATEGORIES).toContain(t.category);
+      expect(t.subjectAr.length).toBeGreaterThan(5);
+      expect(typeof t.subjectEn).toBe('string');
+      expect(/[؀-ۿ]/.test(t.titleAr)).toBe(true);
+    }
+  });
+
+  test('every block has a valid type; panels have valid tones; kv rows are labelled', () => {
+    for (const t of all) {
+      expect(t.blocks.length).toBeGreaterThanOrEqual(2);
+      for (const b of t.blocks) {
+        expect(registry.BLOCK_TYPES).toContain(b.type);
+        if (b.type === 'panel' && b.tone) expect(registry.PANEL_TONES).toContain(b.tone);
+        if (b.type === 'kv')
+          for (const r of b.rows) {
+            expect(typeof r.labelAr).toBe('string');
+            expect(typeof r.value).toBe('string');
+          }
+        if (b.type === 'cta') expect(typeof b.urlVar).toBe('string');
+      }
+    }
+  });
+
+  test('variable contract is CLOSED both ways (no undeclared use, no dead required vars)', () => {
+    for (const t of all) {
+      const declared = new Set(Object.keys(t.variables || {}));
+      const used = new Set();
+      for (const v of varsIn(t.subjectAr)) used.add(v);
+      for (const v of varsIn(t.subjectEn || '')) used.add(v);
+      for (const v of varsIn(t.preheaderAr || '')) used.add(v);
+      for (const b of t.blocks) {
+        if (b.ar) for (const v of varsIn(b.ar)) used.add(v);
+        if (b.rows) for (const r of b.rows) for (const v of varsIn(r.value)) used.add(v);
+        if (b.urlVar) used.add(b.urlVar);
+      }
+      for (const v of used) expect(declared.has(v) ? v : `UNDECLARED:${v}@${t.key}`).toBe(v);
+      for (const [name, spec] of Object.entries(t.variables)) {
+        if (spec.required)
+          expect(used.has(name) ? name : `DEAD-REQUIRED:${name}@${t.key}`).toBe(name);
+        expect(spec.sample !== undefined && spec.sample !== '').toBe(true);
+        expect(typeof spec.labelAr).toBe('string');
+      }
+    }
+  });
+
+  test('every template renders from its own samples (catalogue is self-previewable)', () => {
+    for (const t of all) {
+      const out = renderer.renderSample(t.key);
+      expect(out.subject.length).toBeGreaterThan(3);
+      expect(out.html).toContain('dir="rtl"');
+      expect(out.text.length).toBeGreaterThan(10);
+      expect(out.html).not.toMatch(/\{\{\s*[A-Za-z_]/); // no unresolved vars leak
+    }
+  });
+});
+
+describe('W1242 renderer — safety + layout', () => {
+  test('missing required variables → coded 422 throw listing the gaps', () => {
+    expect(() => renderer.renderTemplate('PASSWORD_RESET', { name: 'x' })).toThrow(
+      /TEMPLATE_VARS_MISSING/
+    );
+    try {
+      renderer.renderTemplate('PASSWORD_RESET', { name: 'x' });
+    } catch (err) {
+      expect(err.code).toBe('TEMPLATE_VARS_MISSING');
+      expect(err.statusCode).toBe(422);
+      expect(err.missing).toEqual(expect.arrayContaining(['otp', 'expiryMinutes']));
+    }
+  });
+
+  test('unknown template key → coded 404 throw', () => {
+    expect(() => renderer.renderTemplate('NOPE', {})).toThrow(/TEMPLATE_NOT_FOUND/);
+  });
+
+  test('interpolated values are HTML-escaped (injection cannot smuggle markup)', () => {
+    const out = renderer.renderTemplate('PASSWORD_RESET', {
+      name: '<script>alert(1)</script>',
+      otp: '12"34',
+      expiryMinutes: '15',
+    });
+    expect(out.html).not.toContain('<script>alert(1)</script>');
+    expect(out.html).toContain('&lt;script&gt;');
+    expect(out.html).toContain('12&quot;34');
+    // plain text keeps the raw value (no HTML context)
+    expect(out.text).toContain('<script>alert(1)</script>');
+  });
+
+  test('layout: RTL+lang, hidden preheader, brand header, footer, 600px table', () => {
+    const out = renderer.renderSample('APPOINTMENT_REMINDER');
+    expect(out.html).toContain('dir="rtl" lang="ar"');
+    expect(out.html).toContain('display:none!important'); // preheader
+    expect(out.html).toContain('مراكز الأوائل للتأهيل'); // brand
+    expect(out.html).toContain('width="600"');
+    expect(out.html).toContain('جميع الحقوق محفوظة'); // footer
+  });
+
+  test('CTA renders as a link when url provided and is OMITTED when absent', () => {
+    const withUrl = renderer.renderTemplate('GOAL_ACHIEVED', {
+      beneficiaryName: 'محمد',
+      goalTitle: 'هدف',
+      progressUrl: 'https://example.org/p?a=1&b=2',
+    });
+    expect(withUrl.html).toContain('href="https://example.org/p?a=1&amp;b=2"');
+    const withoutUrl = renderer.renderTemplate('GOAL_ACHIEVED', {
+      beneficiaryName: 'محمد',
+      goalTitle: 'هدف',
+    });
+    expect(withoutUrl.html).not.toContain('<a href');
+  });
+
+  test('plain-text alternative carries the substance (kv rows + cta url)', () => {
+    const out = renderer.renderSample('INVOICE_ISSUED');
+    expect(out.text).toContain('رقم الفاتورة: INV-2026-0451');
+    expect(out.text).toContain('https://alaweal.org/portal/invoices');
+  });
+
+  test('subject interpolates without escaping artifacts', () => {
+    const out = renderer.renderTemplate('WELCOME_USER', {
+      name: 'سارة & فريقها',
+      email: 'a@b.c',
+      loginUrl: 'https://x.y',
+    });
+    expect(out.subject).toContain('سارة & فريقها'); // raw & in subject (header, not HTML)
+    expect(out.subject).not.toContain('&amp;');
+  });
+});
+
+describe('W1242 static wiring', () => {
+  test('routes file: auth + read roles + admin-only test-send + no raw body spread', () => {
+    const src = read('routes/email-templates.routes.js');
+    expect(src).toMatch(/authenticateToken/);
+    expect(src).toMatch(/requireRole\(READ_ROLES\)/);
+    expect(src).toMatch(/requireRole\(SEND_ROLES\)/);
+    expect(src).toMatch(/'admin', 'superadmin', 'super_admin'\]/); // SEND_ROLES tight
+    expect(src).not.toMatch(/\.\.\.req\.body/);
+  });
+
+  test('mounted via dualMountAuth in features.registry', () => {
+    const src = read('routes/registries/features.registry.js');
+    expect(src).toMatch(/safeRequire\('\.\.\/routes\/email-templates\.routes'\)/);
+    expect(src).toMatch(/dualMountAuth\(app, 'email-templates', emailTemplatesRoutes, authenticate\)/);
+  });
+});

--- a/backend/intelligence/email-templates.registry.js
+++ b/backend/intelligence/email-templates.registry.js
@@ -1,0 +1,424 @@
+'use strict';
+
+/**
+ * email-templates.registry.js — W1242 (نظام القوالب البريدية الاحترافي)
+ *
+ * Single source of truth for the platform's transactional email catalogue.
+ * Today the codebase sends email through 55+ INLINE `dir="rtl"` HTML strings
+ * scattered across utils/emailService.js, communication/email-service.js and
+ * channel services — no shared layout, no variable contracts, no preview.
+ * This registry centralizes them house-style (frozen, bilingual, pure data):
+ *
+ *   key            stable identifier (callers + EmailLog.template.slug)
+ *   category       maps to EmailPreference categories (auth|appointments|
+ *                  clinical|finance|hr|system|reports)
+ *   subjectAr/En   subject lines with {{var}} placeholders
+ *   preheaderAr    hidden inbox-preview line (professional clients show it)
+ *   blocks         STRUCTURED body — the renderer owns ALL HTML, so every
+ *                  template inherits the same polished RTL layout:
+ *                    {type:'paragraph', ar}             plain text (escaped)
+ *                    {type:'greeting', ar}              «مرحباً {{name}}،»
+ *                    {type:'panel',  ar, tone}          highlighted box
+ *                                                       tone: info|success|warning|danger
+ *                    {type:'kv',     rows:[{labelAr, value:'{{var}}'}]}
+ *                    {type:'cta',    labelAr, urlVar}   button (url from variable)
+ *                    {type:'divider'}
+ *   variables      CONTRACT — {name: {required, labelAr, sample}}; the
+ *                  renderer REJECTS a render with missing required vars
+ *                  (refuse-to-fabricate: no email goes out half-filled) and
+ *                  previews use `sample` values.
+ *
+ * Rendering (layout, escaping, plain-text fallback) lives in
+ * services/email/templateRenderer.service.js. Drift guard:
+ * __tests__/email-templates-wave1242.test.js.
+ */
+
+const CATEGORIES = Object.freeze([
+  'auth',
+  'appointments',
+  'clinical',
+  'finance',
+  'hr',
+  'system',
+  'reports',
+]);
+
+const BLOCK_TYPES = Object.freeze(['greeting', 'paragraph', 'panel', 'kv', 'cta', 'divider']);
+const PANEL_TONES = Object.freeze(['info', 'success', 'warning', 'danger']);
+
+const T = (def) => Object.freeze(def);
+
+const EMAIL_TEMPLATES = Object.freeze({
+  // ── الحساب والدخول ────────────────────────────────────────────────────────
+  WELCOME_USER: T({
+    key: 'WELCOME_USER',
+    category: 'auth',
+    titleAr: 'ترحيب بمستخدم جديد',
+    subjectAr: 'مرحباً بك في منصة الأوائل، {{name}}',
+    subjectEn: 'Welcome to Al-Awael, {{name}}',
+    preheaderAr: 'تم إنشاء حسابك بنجاح — ابدأ رحلتك معنا',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'مرحباً {{name}}،' }),
+      T({ type: 'paragraph', ar: 'يسعدنا انضمامك إلى منصة مراكز الأوائل للتأهيل. تم إنشاء حسابك بنجاح ويمكنك الدخول مباشرة باستخدام بريدك الإلكتروني.' }),
+      T({ type: 'kv', rows: Object.freeze([T({ labelAr: 'البريد الإلكتروني', value: '{{email}}' }), T({ labelAr: 'الدور', value: '{{role}}' })]) }),
+      T({ type: 'cta', labelAr: 'الدخول إلى المنصة', urlVar: 'loginUrl' }),
+      T({ type: 'paragraph', ar: 'إن لم تكن أنت من أنشأ هذا الحساب فتجاهل هذه الرسالة أو تواصل مع الدعم.' }),
+    ]),
+    variables: Object.freeze({
+      name: T({ required: true, labelAr: 'اسم المستخدم', sample: 'أ. سارة القحطاني' }),
+      email: T({ required: true, labelAr: 'البريد', sample: 'sara@example.com' }),
+      role: T({ required: false, labelAr: 'الدور', sample: 'أخصائية نطق' }),
+      loginUrl: T({ required: true, labelAr: 'رابط الدخول', sample: 'https://alaweal.org/login' }),
+    }),
+  }),
+
+  PASSWORD_RESET: T({
+    key: 'PASSWORD_RESET',
+    category: 'auth',
+    titleAr: 'إعادة تعيين كلمة المرور',
+    subjectAr: 'رمز إعادة تعيين كلمة المرور — صالح لمدة {{expiryMinutes}} دقيقة',
+    subjectEn: 'Your password reset code',
+    preheaderAr: 'استخدم الرمز أدناه لإعادة تعيين كلمة المرور',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'مرحباً {{name}}،' }),
+      T({ type: 'paragraph', ar: 'تلقّينا طلباً لإعادة تعيين كلمة المرور لحسابك. استخدم الرمز التالي خلال {{expiryMinutes}} دقيقة:' }),
+      T({ type: 'panel', tone: 'info', ar: 'رمز التحقق: {{otp}}' }),
+      T({ type: 'paragraph', ar: 'إن لم تطلب ذلك فتجاهل هذه الرسالة — حسابك آمن ولن يتغير شيء.' }),
+    ]),
+    variables: Object.freeze({
+      name: T({ required: true, labelAr: 'الاسم', sample: 'أ. محمد' }),
+      otp: T({ required: true, labelAr: 'رمز التحقق', sample: '482913' }),
+      expiryMinutes: T({ required: true, labelAr: 'مدة الصلاحية', sample: '15' }),
+    }),
+  }),
+
+  // ── المواعيد ──────────────────────────────────────────────────────────────
+  APPOINTMENT_REMINDER: T({
+    key: 'APPOINTMENT_REMINDER',
+    category: 'appointments',
+    titleAr: 'تذكير بموعد',
+    subjectAr: 'تذكير: موعد {{beneficiaryName}} يوم {{date}} الساعة {{time}}',
+    subjectEn: 'Appointment reminder — {{date}} {{time}}',
+    preheaderAr: 'موعد {{serviceType}} مع {{therapistName}}',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'عزيزي ولي الأمر،' }),
+      T({ type: 'paragraph', ar: 'نذكّركم بموعد {{beneficiaryName}} القادم في مركز الأوائل:' }),
+      T({ type: 'kv', rows: Object.freeze([
+        T({ labelAr: 'الخدمة', value: '{{serviceType}}' }),
+        T({ labelAr: 'الأخصائي', value: '{{therapistName}}' }),
+        T({ labelAr: 'التاريخ', value: '{{date}}' }),
+        T({ labelAr: 'الوقت', value: '{{time}}' }),
+        T({ labelAr: 'الفرع', value: '{{branchName}}' }),
+      ]) }),
+      T({ type: 'panel', tone: 'warning', ar: 'نرجو الحضور قبل الموعد بعشر دقائق. وفي حال تعذّر الحضور يرجى إبلاغنا قبل 24 ساعة لإعادة الجدولة.' }),
+    ]),
+    variables: Object.freeze({
+      beneficiaryName: T({ required: true, labelAr: 'اسم المستفيد', sample: 'محمد العتيبي' }),
+      serviceType: T({ required: true, labelAr: 'الخدمة', sample: 'جلسة علاج نطق' }),
+      therapistName: T({ required: true, labelAr: 'الأخصائي', sample: 'أ. نورة الشمري' }),
+      date: T({ required: true, labelAr: 'التاريخ', sample: 'الأحد 15 يونيو 2026' }),
+      time: T({ required: true, labelAr: 'الوقت', sample: '10:30 صباحاً' }),
+      branchName: T({ required: false, labelAr: 'الفرع', sample: 'فرع الرياض — النرجس' }),
+    }),
+  }),
+
+  APPOINTMENT_CANCELLED: T({
+    key: 'APPOINTMENT_CANCELLED',
+    category: 'appointments',
+    titleAr: 'إلغاء/تأجيل موعد',
+    subjectAr: 'تنبيه: تم إلغاء موعد {{beneficiaryName}} ليوم {{date}}',
+    subjectEn: 'Appointment cancelled — {{date}}',
+    preheaderAr: 'سنتواصل معكم لإعادة الجدولة في أقرب وقت',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'عزيزي ولي الأمر،' }),
+      T({ type: 'panel', tone: 'danger', ar: 'نأسف لإبلاغكم بإلغاء موعد {{beneficiaryName}} ({{serviceType}}) المقرر يوم {{date}} الساعة {{time}}.' }),
+      T({ type: 'paragraph', ar: 'السبب: {{reason}}' }),
+      T({ type: 'paragraph', ar: 'سيتواصل معكم فريق المواعيد خلال يوم عمل لإعادة الجدولة بما يناسبكم. نعتذر عن أي إزعاج.' }),
+    ]),
+    variables: Object.freeze({
+      beneficiaryName: T({ required: true, labelAr: 'اسم المستفيد', sample: 'سارة القحطاني' }),
+      serviceType: T({ required: true, labelAr: 'الخدمة', sample: 'جلسة علاج وظيفي' }),
+      date: T({ required: true, labelAr: 'التاريخ', sample: 'الثلاثاء 17 يونيو 2026' }),
+      time: T({ required: true, labelAr: 'الوقت', sample: '12:00 ظهراً' }),
+      reason: T({ required: false, labelAr: 'السبب', sample: 'ظرف طارئ لدى الأخصائي' }),
+    }),
+  }),
+
+  // ── سريري (الخيط الذهبي) ─────────────────────────────────────────────────
+  SESSION_SUMMARY_GUARDIAN: T({
+    key: 'SESSION_SUMMARY_GUARDIAN',
+    category: 'clinical',
+    titleAr: 'ملخص جلسة لولي الأمر',
+    subjectAr: 'ملخص جلسة {{beneficiaryName}} اليوم — {{serviceType}}',
+    subjectEn: 'Session summary — {{beneficiaryName}}',
+    preheaderAr: 'ما تم العمل عليه اليوم وواجب المنزل',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'عزيزي ولي أمر {{beneficiaryName}}،' }),
+      T({ type: 'paragraph', ar: 'أُنجزت اليوم جلسة {{serviceType}} مع {{therapistName}}. ملخص ما تم:' }),
+      T({ type: 'panel', tone: 'info', ar: '{{summary}}' }),
+      T({ type: 'kv', rows: Object.freeze([
+        T({ labelAr: 'الأهداف المعمول عليها', value: '{{goalsWorked}}' }),
+        T({ labelAr: 'الواجب المنزلي', value: '{{homework}}' }),
+      ]) }),
+      T({ type: 'paragraph', ar: 'مشاركتكم في تطبيق الواجب المنزلي تضاعف أثر الجلسات. لأي استفسار تواصلوا معنا عبر بوابة الأهل.' }),
+    ]),
+    variables: Object.freeze({
+      beneficiaryName: T({ required: true, labelAr: 'المستفيد', sample: 'محمد' }),
+      serviceType: T({ required: true, labelAr: 'الخدمة', sample: 'علاج نطق' }),
+      therapistName: T({ required: true, labelAr: 'الأخصائي', sample: 'أ. ريم الحربي' }),
+      summary: T({ required: true, labelAr: 'الملخص', sample: 'عمل ممتاز على أصوات /س/ في بداية الكلمة بدقة 80%' }),
+      goalsWorked: T({ required: false, labelAr: 'الأهداف', sample: 'النطق — المفردات' }),
+      homework: T({ required: false, labelAr: 'الواجب', sample: 'تمرين بطاقات الصور 10 دقائق يومياً' }),
+    }),
+  }),
+
+  GOAL_ACHIEVED: T({
+    key: 'GOAL_ACHIEVED',
+    category: 'clinical',
+    titleAr: 'تهنئة بتحقيق هدف',
+    subjectAr: '🎉 إنجاز جديد: {{beneficiaryName}} حقق هدف «{{goalTitle}}»',
+    subjectEn: 'Goal achieved — {{beneficiaryName}}',
+    preheaderAr: 'خطوة جديدة في رحلة التقدم — نبارك لكم',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'عزيزي ولي أمر {{beneficiaryName}}،' }),
+      T({ type: 'panel', tone: 'success', ar: 'نبارك لكم! حقق {{beneficiaryName}} الهدف العلاجي: «{{goalTitle}}» 🎉' }),
+      T({ type: 'paragraph', ar: 'هذا الإنجاز ثمرة المواظبة على الجلسات وتطبيق التوصيات في المنزل. سيناقش الفريق الهدف التالي في المراجعة القادمة.' }),
+      T({ type: 'cta', labelAr: 'عرض تقرير التقدم', urlVar: 'progressUrl' }),
+    ]),
+    variables: Object.freeze({
+      beneficiaryName: T({ required: true, labelAr: 'المستفيد', sample: 'محمد العتيبي' }),
+      goalTitle: T({ required: true, labelAr: 'الهدف', sample: 'تكوين جملة من 3-4 كلمات' }),
+      progressUrl: T({ required: false, labelAr: 'رابط التقرير', sample: 'https://alaweal.org/portal/progress' }),
+    }),
+  }),
+
+  BASELINE_DUE: T({
+    key: 'BASELINE_DUE',
+    category: 'clinical',
+    titleAr: 'تنبيه خط أساس مستحق (NBA)',
+    subjectAr: 'مطلوب: تسجيل خط الأساس لـ{{beneficiaryName}} — {{goalCount}} هدف بانتظار القياس',
+    subjectEn: 'Baseline due — {{beneficiaryName}}',
+    preheaderAr: 'أهداف موصولة بمقاييس دون قياس أول — من طابور الإجراء الأفضل التالي',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'مرحباً {{therapistName}}،' }),
+      T({ type: 'paragraph', ar: 'رصد محرّك «الإجراء الأفضل التالي» أهدافاً نشطة لـ{{beneficiaryName}} موصولة بمقاييس لكن دون خط أساس مسجّل:' }),
+      T({ type: 'panel', tone: 'warning', ar: '{{goalsList}}' }),
+      T({ type: 'paragraph', ar: 'تسجيل خط الأساس يجعل قياس التقدم لاحقاً صادقاً وقابلاً للدفاع أمام الأسرة والجهات.' }),
+      T({ type: 'cta', labelAr: 'فتح طابور الإجراءات', urlVar: 'nbaUrl' }),
+    ]),
+    variables: Object.freeze({
+      therapistName: T({ required: true, labelAr: 'الأخصائي', sample: 'أ. فيصل' }),
+      beneficiaryName: T({ required: true, labelAr: 'المستفيد', sample: 'محمد العتيبي' }),
+      goalCount: T({ required: true, labelAr: 'عدد الأهداف', sample: '3' }),
+      goalsList: T({ required: true, labelAr: 'قائمة الأهداف', sample: 'المفردات — النطق — تكوين الجمل' }),
+      nbaUrl: T({ required: false, labelAr: 'رابط الطابور', sample: 'https://alaweal.org/next-best-action' }),
+    }),
+  }),
+
+  OVERDUE_REVIEW_SUPERVISOR: T({
+    key: 'OVERDUE_REVIEW_SUPERVISOR',
+    category: 'clinical',
+    titleAr: 'مراجعات خطط متأخرة (مشرف)',
+    subjectAr: 'تنبيه إشرافي: {{count}} خطة رعاية تجاوزت موعد المراجعة في {{branchName}}',
+    subjectEn: 'Overdue care-plan reviews — {{branchName}}',
+    preheaderAr: 'الأكثر تأخراً أولاً — مطلوب جدولة مراجعات',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'مرحباً {{supervisorName}}،' }),
+      T({ type: 'panel', tone: 'danger', ar: 'يوجد {{count}} خطة رعاية تجاوزت موعد مراجعتها الدورية، أقدمها متأخر {{maxOverdueDays}} يوماً.' }),
+      T({ type: 'paragraph', ar: '{{plansList}}' }),
+      T({ type: 'cta', labelAr: 'فتح لوحة عمليات الإشراف', urlVar: 'opsUrl' }),
+    ]),
+    variables: Object.freeze({
+      supervisorName: T({ required: true, labelAr: 'المشرف', sample: 'د. عبدالله' }),
+      count: T({ required: true, labelAr: 'العدد', sample: '4' }),
+      branchName: T({ required: true, labelAr: 'الفرع', sample: 'فرع الرياض' }),
+      maxOverdueDays: T({ required: true, labelAr: 'أقصى تأخير', sample: '21' }),
+      plansList: T({ required: false, labelAr: 'القائمة', sample: 'محمد (21 يوماً) — سارة (14 يوماً) — فيصل (9 أيام)' }),
+      opsUrl: T({ required: false, labelAr: 'الرابط', sample: 'https://alaweal.org/supervisor-ops' }),
+    }),
+  }),
+
+  // ── مالية ─────────────────────────────────────────────────────────────────
+  INVOICE_ISSUED: T({
+    key: 'INVOICE_ISSUED',
+    category: 'finance',
+    titleAr: 'إصدار فاتورة',
+    subjectAr: 'فاتورة رقم {{invoiceNumber}} — {{amount}} ريال',
+    subjectEn: 'Invoice {{invoiceNumber}}',
+    preheaderAr: 'تفاصيل الفاتورة وطرق السداد',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'عزيزي {{guardianName}}،' }),
+      T({ type: 'paragraph', ar: 'صدرت فاتورة جديدة لخدمات {{beneficiaryName}}:' }),
+      T({ type: 'kv', rows: Object.freeze([
+        T({ labelAr: 'رقم الفاتورة', value: '{{invoiceNumber}}' }),
+        T({ labelAr: 'الفترة', value: '{{period}}' }),
+        T({ labelAr: 'المبلغ', value: '{{amount}} ريال' }),
+        T({ labelAr: 'تاريخ الاستحقاق', value: '{{dueDate}}' }),
+      ]) }),
+      T({ type: 'cta', labelAr: 'عرض الفاتورة والسداد', urlVar: 'invoiceUrl' }),
+      T({ type: 'paragraph', ar: 'لأي استفسار عن الفاتورة يسعد فريق الحسابات بخدمتكم.' }),
+    ]),
+    variables: Object.freeze({
+      guardianName: T({ required: true, labelAr: 'ولي الأمر', sample: 'أ. سعود العتيبي' }),
+      beneficiaryName: T({ required: true, labelAr: 'المستفيد', sample: 'محمد' }),
+      invoiceNumber: T({ required: true, labelAr: 'رقم الفاتورة', sample: 'INV-2026-0451' }),
+      period: T({ required: false, labelAr: 'الفترة', sample: 'يونيو 2026' }),
+      amount: T({ required: true, labelAr: 'المبلغ', sample: '2,400' }),
+      dueDate: T({ required: true, labelAr: 'الاستحقاق', sample: '25 يونيو 2026' }),
+      invoiceUrl: T({ required: false, labelAr: 'الرابط', sample: 'https://alaweal.org/portal/invoices' }),
+    }),
+  }),
+
+  PAYMENT_RECEIPT: T({
+    key: 'PAYMENT_RECEIPT',
+    category: 'finance',
+    titleAr: 'إيصال سداد',
+    subjectAr: 'شكراً لسدادكم — إيصال رقم {{receiptNumber}}',
+    subjectEn: 'Payment receipt {{receiptNumber}}',
+    preheaderAr: 'تم استلام دفعتكم بنجاح',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'عزيزي {{guardianName}}،' }),
+      T({ type: 'panel', tone: 'success', ar: 'تم استلام دفعتكم بمبلغ {{amount}} ريال بنجاح. شكراً لكم.' }),
+      T({ type: 'kv', rows: Object.freeze([
+        T({ labelAr: 'رقم الإيصال', value: '{{receiptNumber}}' }),
+        T({ labelAr: 'الفاتورة', value: '{{invoiceNumber}}' }),
+        T({ labelAr: 'طريقة السداد', value: '{{method}}' }),
+        T({ labelAr: 'التاريخ', value: '{{paidAt}}' }),
+      ]) }),
+    ]),
+    variables: Object.freeze({
+      guardianName: T({ required: true, labelAr: 'ولي الأمر', sample: 'أ. سعود' }),
+      amount: T({ required: true, labelAr: 'المبلغ', sample: '2,400' }),
+      receiptNumber: T({ required: true, labelAr: 'رقم الإيصال', sample: 'RC-2026-0789' }),
+      invoiceNumber: T({ required: false, labelAr: 'الفاتورة', sample: 'INV-2026-0451' }),
+      method: T({ required: false, labelAr: 'الطريقة', sample: 'مدى' }),
+      paidAt: T({ required: true, labelAr: 'التاريخ', sample: '12 يونيو 2026' }),
+    }),
+  }),
+
+  // ── تقارير ────────────────────────────────────────────────────────────────
+  MONTHLY_PROGRESS_REPORT: T({
+    key: 'MONTHLY_PROGRESS_REPORT',
+    category: 'reports',
+    titleAr: 'تقرير التقدم الشهري',
+    subjectAr: 'تقرير {{month}} — تقدم {{beneficiaryName}}',
+    subjectEn: 'Monthly progress — {{beneficiaryName}}',
+    preheaderAr: 'نظرة شهرية موجزة: الجلسات، الأهداف، والتوصيات',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'عزيزي ولي أمر {{beneficiaryName}}،' }),
+      T({ type: 'paragraph', ar: 'إليكم خلاصة شهر {{month}}:' }),
+      T({ type: 'kv', rows: Object.freeze([
+        T({ labelAr: 'جلسات منفذة', value: '{{sessionsCount}}' }),
+        T({ labelAr: 'نسبة الحضور', value: '{{attendancePct}}%' }),
+        T({ labelAr: 'أهداف نشطة', value: '{{activeGoals}}' }),
+        T({ labelAr: 'أهداف تحققت هذا الشهر', value: '{{achievedGoals}}' }),
+      ]) }),
+      T({ type: 'panel', tone: 'info', ar: 'أبرز الملاحظات: {{highlights}}' }),
+      T({ type: 'cta', labelAr: 'عرض التقرير الكامل', urlVar: 'reportUrl' }),
+    ]),
+    variables: Object.freeze({
+      beneficiaryName: T({ required: true, labelAr: 'المستفيد', sample: 'محمد العتيبي' }),
+      month: T({ required: true, labelAr: 'الشهر', sample: 'يونيو 2026' }),
+      sessionsCount: T({ required: true, labelAr: 'الجلسات', sample: '12' }),
+      attendancePct: T({ required: true, labelAr: 'الحضور', sample: '92' }),
+      activeGoals: T({ required: true, labelAr: 'أهداف نشطة', sample: '3' }),
+      achievedGoals: T({ required: true, labelAr: 'أهداف محققة', sample: '1' }),
+      highlights: T({ required: false, labelAr: 'الملاحظات', sample: 'تحسن ملحوظ في المبادرة بالتواصل' }),
+      reportUrl: T({ required: false, labelAr: 'الرابط', sample: 'https://alaweal.org/portal/reports' }),
+    }),
+  }),
+
+  // ── نظام/تشغيل ────────────────────────────────────────────────────────────
+  INCIDENT_NOTIFICATION: T({
+    key: 'INCIDENT_NOTIFICATION',
+    category: 'system',
+    titleAr: 'إشعار حادثة (جودة/سلامة)',
+    subjectAr: '⚠️ حادثة {{severity}}: {{incidentType}} — {{branchName}}',
+    subjectEn: 'Incident: {{incidentType}}',
+    preheaderAr: 'تفاصيل الحادثة والإجراء المطلوب',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'مرحباً {{recipientName}}،' }),
+      T({ type: 'panel', tone: 'danger', ar: 'سُجّلت حادثة من نوع «{{incidentType}}» بدرجة {{severity}} في {{branchName}} بتاريخ {{occurredAt}}.' }),
+      T({ type: 'paragraph', ar: 'الوصف: {{description}}' }),
+      T({ type: 'paragraph', ar: 'الإجراء المطلوب: {{requiredAction}}' }),
+      T({ type: 'cta', labelAr: 'فتح سجل الحادثة', urlVar: 'incidentUrl' }),
+    ]),
+    variables: Object.freeze({
+      recipientName: T({ required: true, labelAr: 'المستلم', sample: 'مسؤول الجودة' }),
+      incidentType: T({ required: true, labelAr: 'النوع', sample: 'سقوط' }),
+      severity: T({ required: true, labelAr: 'الدرجة', sample: 'متوسطة' }),
+      branchName: T({ required: true, labelAr: 'الفرع', sample: 'فرع الرياض' }),
+      occurredAt: T({ required: true, labelAr: 'التاريخ', sample: '12 يونيو 2026 — 10:20' }),
+      description: T({ required: true, labelAr: 'الوصف', sample: 'انزلاق أثناء النشاط الحركي دون إصابة' }),
+      requiredAction: T({ required: false, labelAr: 'الإجراء', sample: 'مراجعة وتوقيع خلال 24 ساعة' }),
+      incidentUrl: T({ required: false, labelAr: 'الرابط', sample: 'https://alaweal.org/quality/incidents' }),
+    }),
+  }),
+
+  STAFF_ANNOUNCEMENT: T({
+    key: 'STAFF_ANNOUNCEMENT',
+    category: 'hr',
+    titleAr: 'تعميم إداري للموظفين',
+    subjectAr: 'تعميم: {{title}}',
+    subjectEn: 'Announcement: {{title}}',
+    preheaderAr: '{{title}}',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'الزملاء الأعزاء،' }),
+      T({ type: 'paragraph', ar: '{{body}}' }),
+      T({ type: 'kv', rows: Object.freeze([T({ labelAr: 'الجهة المصدرة', value: '{{issuer}}' }), T({ labelAr: 'تاريخ السريان', value: '{{effectiveDate}}' })]) }),
+    ]),
+    variables: Object.freeze({
+      title: T({ required: true, labelAr: 'العنوان', sample: 'تحديث سياسة الإجازات' }),
+      body: T({ required: true, labelAr: 'النص', sample: 'اعتباراً من الشهر القادم تُقدَّم طلبات الإجازة عبر المنصة فقط…' }),
+      issuer: T({ required: false, labelAr: 'الجهة', sample: 'الموارد البشرية' }),
+      effectiveDate: T({ required: false, labelAr: 'السريان', sample: '1 يوليو 2026' }),
+    }),
+  }),
+
+  WEEKLY_SUPERVISOR_DIGEST: T({
+    key: 'WEEKLY_SUPERVISOR_DIGEST',
+    category: 'reports',
+    titleAr: 'الملخص الأسبوعي للمشرف',
+    subjectAr: 'ملخص الأسبوع — {{branchName}}: {{sessionsCount}} جلسة، {{alertsCount}} تنبيه',
+    subjectEn: 'Weekly digest — {{branchName}}',
+    preheaderAr: 'صحة العمليات، الإنتاجية، وما يحتاج انتباهك',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'مرحباً {{supervisorName}}،' }),
+      T({ type: 'kv', rows: Object.freeze([
+        T({ labelAr: 'جلسات منفذة', value: '{{sessionsCount}}' }),
+        T({ labelAr: 'نسبة التوثيق', value: '{{docPct}}%' }),
+        T({ labelAr: 'تنبيهات مفتوحة', value: '{{alertsCount}}' }),
+        T({ labelAr: 'درجة صحة العمليات', value: '{{healthGrade}}' }),
+      ]) }),
+      T({ type: 'panel', tone: 'info', ar: 'الأكثر إلحاحاً: {{topAttention}}' }),
+      T({ type: 'cta', labelAr: 'فتح لوحة العمليات', urlVar: 'opsUrl' }),
+    ]),
+    variables: Object.freeze({
+      supervisorName: T({ required: true, labelAr: 'المشرف', sample: 'د. عبدالله' }),
+      branchName: T({ required: true, labelAr: 'الفرع', sample: 'فرع الرياض' }),
+      sessionsCount: T({ required: true, labelAr: 'الجلسات', sample: '84' }),
+      docPct: T({ required: true, labelAr: 'التوثيق', sample: '91' }),
+      alertsCount: T({ required: true, labelAr: 'التنبيهات', sample: '5' }),
+      healthGrade: T({ required: true, labelAr: 'الصحة', sample: 'HEALTHY' }),
+      topAttention: T({ required: false, labelAr: 'الانتباه', sample: '3 أهداف بلا خط أساس لدى محمد' }),
+      opsUrl: T({ required: false, labelAr: 'الرابط', sample: 'https://alaweal.org/supervisor-ops' }),
+    }),
+  }),
+});
+
+function getTemplate(key) {
+  return EMAIL_TEMPLATES[String(key || '').trim()] || null;
+}
+
+function listTemplates() {
+  return Object.values(EMAIL_TEMPLATES);
+}
+
+module.exports = {
+  CATEGORIES,
+  BLOCK_TYPES,
+  PANEL_TONES,
+  EMAIL_TEMPLATES,
+  getTemplate,
+  listTemplates,
+};

--- a/backend/routes/email-templates.routes.js
+++ b/backend/routes/email-templates.routes.js
@@ -1,0 +1,125 @@
+'use strict';
+
+/**
+ * email-templates.routes.js — W1242 (واجهة كتالوج القوالب البريدية)
+ *
+ *   GET  /                     — catalogue (key/title/category/variable contract)
+ *   GET  /:key                 — template detail + variable contract + samples
+ *   GET  /:key/preview         — rendered SAMPLE (html|text|json via ?format=)
+ *   POST /:key/preview         — rendered with caller-supplied variables
+ *                                (422 TEMPLATE_VARS_MISSING on contract gaps)
+ *   POST /:key/test-send       — ADMIN: render + send to ONE explicit address
+ *                                through the existing email facade (mock-mode
+ *                                returns skipped:true — safe everywhere)
+ *
+ * READ-mostly; the only side effect is the explicit admin test-send.
+ * Mounted via features.registry dualMountAuth at /api(/v1)/email-templates.
+ */
+
+const express = require('express');
+const { authenticateToken, requireRole } = require('../middleware/auth');
+const renderer = require('../services/email/templateRenderer.service');
+const { listTemplates, getTemplate } = require('../intelligence/email-templates.registry');
+
+const router = express.Router();
+
+const READ_ROLES = [
+  'admin',
+  'superadmin',
+  'super_admin',
+  'manager',
+  'clinical_supervisor',
+  'coordinator',
+  'hr',
+  'quality',
+];
+const SEND_ROLES = ['admin', 'superadmin', 'super_admin'];
+
+router.use(authenticateToken);
+
+function catalogueRow(t) {
+  return {
+    key: t.key,
+    titleAr: t.titleAr,
+    category: t.category,
+    subjectAr: t.subjectAr,
+    variables: Object.entries(t.variables || {}).map(([name, spec]) => ({
+      name,
+      required: !!spec.required,
+      labelAr: spec.labelAr,
+      sample: spec.sample,
+    })),
+  };
+}
+
+// ── GET / — catalogue ────────────────────────────────────────────────────────
+router.get('/', requireRole(READ_ROLES), (_req, res) => {
+  res.json({ success: true, data: listTemplates().map(catalogueRow) });
+});
+
+// ── GET /:key — detail ───────────────────────────────────────────────────────
+router.get('/:key', requireRole(READ_ROLES), (req, res) => {
+  const t = getTemplate(req.params.key);
+  if (!t) return res.status(404).json({ success: false, message: 'قالب غير موجود' });
+  res.json({ success: true, data: catalogueRow(t) });
+});
+
+// ── GET /:key/preview — sample render ───────────────────────────────────────
+router.get('/:key/preview', requireRole(READ_ROLES), (req, res) => {
+  try {
+    const rendered = renderer.renderSample(req.params.key);
+    const format = String(req.query.format || 'html').toLowerCase();
+    if (format === 'json') return res.json({ success: true, data: rendered });
+    if (format === 'text') return res.type('text/plain; charset=utf-8').send(rendered.text);
+    return res.type('text/html; charset=utf-8').send(rendered.html);
+  } catch (err) {
+    return res
+      .status(err.statusCode || 500)
+      .json({ success: false, code: err.code, message: err.message });
+  }
+});
+
+// ── POST /:key/preview — render with caller variables ───────────────────────
+router.post('/:key/preview', requireRole(READ_ROLES), (req, res) => {
+  try {
+    const variables = req.body && typeof req.body.variables === 'object' ? req.body.variables : {};
+    const rendered = renderer.renderTemplate(req.params.key, variables);
+    return res.json({ success: true, data: rendered });
+  } catch (err) {
+    return res
+      .status(err.statusCode || 500)
+      .json({ success: false, code: err.code, missing: err.missing, message: err.message });
+  }
+});
+
+// ── POST /:key/test-send — admin smoke (one explicit recipient) ─────────────
+router.post('/:key/test-send', requireRole(SEND_ROLES), async (req, res) => {
+  try {
+    const to = req.body && req.body.to;
+    if (!to || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(String(to)))
+      return res.status(400).json({ success: false, message: 'حقل to بريد صالح مطلوب' });
+
+    const variables =
+      req.body && typeof req.body.variables === 'object' && req.body.variables !== null
+        ? req.body.variables
+        : null;
+    const rendered = variables
+      ? renderer.renderTemplate(req.params.key, variables)
+      : renderer.renderSample(req.params.key);
+
+    const { sendEmail } = require('../services/emailService');
+    const result = await sendEmail({
+      to,
+      subject: `[تجربة] ${rendered.subject}`,
+      html: rendered.html,
+      text: rendered.text,
+    });
+    return res.json({ success: true, data: { template: rendered.key, to, result } });
+  } catch (err) {
+    return res
+      .status(err.statusCode || 500)
+      .json({ success: false, code: err.code, missing: err.missing, message: err.message });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/registries/features.registry.js
+++ b/backend/routes/registries/features.registry.js
@@ -33,6 +33,7 @@ module.exports = function registerFeatureRoutes(
   const pathwayBundlesRoutes = safeRequire('../routes/pathway-bundles.routes');
   const nextBestActionRoutes = safeRequire('../routes/next-best-action.routes');
   const outcomesRollupRoutes = safeRequire('../routes/outcomes-rollup.routes');
+  const emailTemplatesRoutes = safeRequire('../routes/email-templates.routes');
   const beneficiaryTransfersRoutes = safeRequire('../routes/beneficiary-transfers.routes');
   const beneficiaryDayAttendanceRoutes = safeRequire('../routes/beneficiary-day-attendance.routes');
   const beneficiarySectionsRoutes = safeRequire('../routes/beneficiary-sections.routes');
@@ -151,6 +152,10 @@ module.exports = function registerFeatureRoutes(
   // aggregation goal → beneficiary → program(domain) → branch → center.
   // Center tier is cross-branch-roles-only (restricted callers get 403).
   dualMountAuth(app, 'outcomes-rollup', outcomesRollupRoutes, authenticate);
+  // Wave 1242: professional bilingual email-template catalogue — registry-driven
+  // RTL layout renderer + preview + admin test-send (converges the 55 scattered
+  // inline-HTML email call sites onto one contract-validated formatting layer).
+  dualMountAuth(app, 'email-templates', emailTemplatesRoutes, authenticate);
   dualMount(app, 'beneficiary-transfers', beneficiaryTransfersRoutes);
   // Wave 174: Daily rollcall (مركز تأهيل نهاري) — distinct from session attendance
   dualMountAuth(app, 'beneficiary-day-attendance', beneficiaryDayAttendanceRoutes, authenticate);

--- a/backend/services/email/templateRenderer.service.js
+++ b/backend/services/email/templateRenderer.service.js
@@ -1,0 +1,296 @@
+'use strict';
+
+/**
+ * templateRenderer.service.js — W1242 (محرّك عرض القوالب البريدية)
+ *
+ * Renders intelligence/email-templates.registry.js entries into production
+ * email payloads: { subject, html, text }. Owns 100% of the HTML so every
+ * template shares ONE polished, email-client-safe layout:
+ *
+ *  - RTL/Arabic first: dir="rtl" lang="ar", system Arabic font stack.
+ *  - Table-based 600px layout (Gmail/Outlook-safe), bulletproof CTA button,
+ *    hidden preheader, brand header + compliance footer.
+ *  - SMART + SAFE:
+ *      • variable CONTRACT enforcement — a render with missing required
+ *        variables THROWS (code TEMPLATE_VARS_MISSING) so no half-filled
+ *        email ever leaves the system (refuse-to-fabricate);
+ *      • every interpolated value is HTML-escaped (user-content injection
+ *        can't break layout or smuggle markup);
+ *      • automatic plain-text alternative generated from the same blocks
+ *        (deliverability + accessibility).
+ *
+ * Pure module: no transport, no DB. EmailManager/callers pass the rendered
+ * payload to their existing send() — this is the formatting layer the 55
+ * scattered inline-HTML call sites can converge on.
+ */
+
+const {
+  getTemplate,
+  listTemplates,
+  BLOCK_TYPES,
+  PANEL_TONES,
+} = require('../../intelligence/email-templates.registry');
+
+const BRAND = Object.freeze({
+  nameAr: 'مراكز الأوائل للتأهيل',
+  primary: '#1B4A8A',
+  primaryDark: '#143A6E',
+  paper: '#F6F4EF',
+  ink: '#2E2A26',
+  inkSoft: '#6B5F55',
+  line: '#E7DFD2',
+  success: '#2F7D4F',
+  successBg: '#EAF6EE',
+  info: '#1B4A8A',
+  infoBg: '#EEF4FB',
+  warning: '#9A6B15',
+  warningBg: '#FBF3E0',
+  danger: '#A6453B',
+  dangerBg: '#FBEAEA',
+});
+
+const VAR_RE = /\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g;
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Interpolate {{vars}} into a string. html=true escapes each value. */
+function interpolate(str, variables, { html }) {
+  return String(str).replace(VAR_RE, (_m, name) => {
+    const v = variables[name];
+    if (v === undefined || v === null) return '';
+    return html ? escapeHtml(v) : String(v);
+  });
+}
+
+/**
+ * Enforce the template's variable contract.
+ * @returns {{ok:true}|never} throws Error(code=TEMPLATE_VARS_MISSING) listing gaps.
+ */
+function validateVariables(template, variables = {}) {
+  const missing = [];
+  for (const [name, spec] of Object.entries(template.variables || {})) {
+    if (!spec.required) continue;
+    const v = variables[name];
+    if (v === undefined || v === null || String(v).trim() === '') missing.push(name);
+  }
+  if (missing.length) {
+    const err = new Error(
+      `TEMPLATE_VARS_MISSING: قالب ${template.key} ينقصه متغيرات إلزامية: ${missing.join(', ')}`
+    );
+    err.code = 'TEMPLATE_VARS_MISSING';
+    err.missing = missing;
+    err.statusCode = 422;
+    throw err;
+  }
+  return { ok: true };
+}
+
+/* ─────────────────────────── block renderers (HTML) ─────────────────────── */
+
+function toneColors(tone) {
+  switch (tone) {
+    case 'success':
+      return { fg: BRAND.success, bg: BRAND.successBg };
+    case 'warning':
+      return { fg: BRAND.warning, bg: BRAND.warningBg };
+    case 'danger':
+      return { fg: BRAND.danger, bg: BRAND.dangerBg };
+    default:
+      return { fg: BRAND.info, bg: BRAND.infoBg };
+  }
+}
+
+function renderBlockHtml(block, vars) {
+  const P = (s) => interpolate(s, vars, { html: true });
+  switch (block.type) {
+    case 'greeting':
+      return `<p style="margin:0 0 14px;font-size:16px;font-weight:700;color:${BRAND.ink};">${P(block.ar)}</p>`;
+    case 'paragraph':
+      return `<p style="margin:0 0 14px;font-size:14px;line-height:1.9;color:${BRAND.ink};">${P(block.ar)}</p>`;
+    case 'panel': {
+      const { fg, bg } = toneColors(block.tone);
+      return (
+        `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 16px;">` +
+        `<tr><td style="background:${bg};border-right:4px solid ${fg};border-radius:8px;padding:14px 16px;` +
+        `font-size:14px;line-height:1.9;color:${BRAND.ink};">${P(block.ar)}</td></tr></table>`
+      );
+    }
+    case 'kv': {
+      const rows = (block.rows || [])
+        .map((r) => {
+          const value = P(r.value);
+          if (!value) return '';
+          return (
+            `<tr>` +
+            `<td style="padding:8px 12px;background:${BRAND.paper};border-bottom:1px solid ${BRAND.line};` +
+            `font-size:13px;color:${BRAND.inkSoft};white-space:nowrap;">${escapeHtml(r.labelAr)}</td>` +
+            `<td style="padding:8px 12px;border-bottom:1px solid ${BRAND.line};font-size:13px;` +
+            `font-weight:600;color:${BRAND.ink};">${value}</td></tr>`
+          );
+        })
+        .join('');
+      if (!rows) return '';
+      return (
+        `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" ` +
+        `style="margin:0 0 16px;border:1px solid ${BRAND.line};border-radius:8px;border-collapse:separate;overflow:hidden;">` +
+        rows +
+        `</table>`
+      );
+    }
+    case 'cta': {
+      const url = vars[block.urlVar];
+      if (!url) return '';
+      const safeUrl = escapeHtml(url);
+      return (
+        `<table role="presentation" cellpadding="0" cellspacing="0" style="margin:6px auto 18px;">` +
+        `<tr><td style="background:${BRAND.primary};border-radius:8px;">` +
+        `<a href="${safeUrl}" target="_blank" ` +
+        `style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:700;color:#ffffff;` +
+        `text-decoration:none;border-radius:8px;">${escapeHtml(block.labelAr)}</a>` +
+        `</td></tr></table>`
+      );
+    }
+    case 'divider':
+      return `<hr style="border:none;border-top:1px solid ${BRAND.line};margin:18px 0;" />`;
+    default:
+      return '';
+  }
+}
+
+/* ─────────────────────────── block renderers (text) ─────────────────────── */
+
+function renderBlockText(block, vars) {
+  const P = (s) => interpolate(s, vars, { html: false });
+  switch (block.type) {
+    case 'greeting':
+    case 'paragraph':
+      return P(block.ar);
+    case 'panel':
+      return `» ${P(block.ar)}`;
+    case 'kv':
+      return (block.rows || [])
+        .map((r) => {
+          const v = P(r.value);
+          return v ? `- ${r.labelAr}: ${v}` : '';
+        })
+        .filter(Boolean)
+        .join('\n');
+    case 'cta': {
+      const url = vars[block.urlVar];
+      return url ? `${block.labelAr}: ${url}` : '';
+    }
+    case 'divider':
+      return '----------------------------------------';
+    default:
+      return '';
+  }
+}
+
+/* ─────────────────────────── the shared layout ───────────────────────────── */
+
+function wrapLayout({ bodyHtml, preheader, titleAr }) {
+  const year = new Date().getFullYear();
+  return `<!DOCTYPE html>
+<html dir="rtl" lang="ar">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<title>${escapeHtml(titleAr)}</title>
+</head>
+<body style="margin:0;padding:0;background:${BRAND.paper};">
+<span style="display:none!important;visibility:hidden;opacity:0;height:0;width:0;overflow:hidden;mso-hide:all;">${escapeHtml(preheader || '')}</span>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:${BRAND.paper};">
+<tr><td align="center" style="padding:24px 12px;">
+  <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;">
+    <tr><td style="background:linear-gradient(135deg,${BRAND.primary},${BRAND.primaryDark});background-color:${BRAND.primary};border-radius:12px 12px 0 0;padding:22px 28px;text-align:right;">
+      <div style="font-family:'Segoe UI',Tahoma,Arial,sans-serif;font-size:20px;font-weight:800;color:#ffffff;">${escapeHtml(BRAND.nameAr)}</div>
+      <div style="font-family:'Segoe UI',Tahoma,Arial,sans-serif;font-size:12px;color:#D7E3F4;margin-top:2px;">${escapeHtml(titleAr)}</div>
+    </td></tr>
+    <tr><td style="background:#ffffff;padding:28px;border:1px solid ${BRAND.line};border-top:none;font-family:'Segoe UI',Tahoma,Arial,sans-serif;text-align:right;">
+      ${bodyHtml}
+    </td></tr>
+    <tr><td style="background:#ffffff;border:1px solid ${BRAND.line};border-top:1px dashed ${BRAND.line};border-radius:0 0 12px 12px;padding:16px 28px;font-family:'Segoe UI',Tahoma,Arial,sans-serif;text-align:center;">
+      <div style="font-size:11px;color:${BRAND.inkSoft};line-height:1.8;">
+        هذه رسالة آلية من منصة ${escapeHtml(BRAND.nameAr)} — يرجى عدم الرد عليها مباشرة.<br/>
+        © ${year} ${escapeHtml(BRAND.nameAr)}. جميع الحقوق محفوظة.
+      </div>
+    </td></tr>
+  </table>
+</td></tr>
+</table>
+</body>
+</html>`;
+}
+
+/* ─────────────────────────── public API ──────────────────────────────────── */
+
+/**
+ * Render a registry template with real variables.
+ * @returns {{key, category, subject, subjectEn, html, text}}
+ * @throws Error(code=TEMPLATE_NOT_FOUND|TEMPLATE_VARS_MISSING)
+ */
+function renderTemplate(key, variables = {}) {
+  const template = getTemplate(key);
+  if (!template) {
+    const err = new Error(`TEMPLATE_NOT_FOUND: لا يوجد قالب بالمفتاح ${key}`);
+    err.code = 'TEMPLATE_NOT_FOUND';
+    err.statusCode = 404;
+    throw err;
+  }
+  validateVariables(template, variables);
+
+  const subject = interpolate(template.subjectAr, variables, { html: false });
+  const subjectEn = template.subjectEn
+    ? interpolate(template.subjectEn, variables, { html: false })
+    : null;
+  const preheader = template.preheaderAr
+    ? interpolate(template.preheaderAr, variables, { html: false })
+    : '';
+
+  const bodyHtml = template.blocks.map((b) => renderBlockHtml(b, variables)).join('\n');
+  const html = wrapLayout({ bodyHtml, preheader, titleAr: template.titleAr });
+
+  const text =
+    template.blocks
+      .map((b) => renderBlockText(b, variables))
+      .filter(Boolean)
+      .join('\n\n') + `\n\n—\n${BRAND.nameAr}`;
+
+  return { key: template.key, category: template.category, subject, subjectEn, html, text };
+}
+
+/** Render using the registry's sample values (for previews/catalogue). */
+function renderSample(key) {
+  const template = getTemplate(key);
+  if (!template) {
+    const err = new Error(`TEMPLATE_NOT_FOUND: ${key}`);
+    err.code = 'TEMPLATE_NOT_FOUND';
+    err.statusCode = 404;
+    throw err;
+  }
+  const samples = {};
+  for (const [name, spec] of Object.entries(template.variables || {})) {
+    samples[name] = spec.sample;
+  }
+  return renderTemplate(key, samples);
+}
+
+module.exports = {
+  BRAND,
+  escapeHtml,
+  interpolate,
+  validateVariables,
+  renderTemplate,
+  renderSample,
+  listTemplates,
+  BLOCK_TYPES,
+  PANEL_TONES,
+};

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1019,3 +1019,4 @@ __tests__/seed-goal-bank-wave1223.test.js
 __tests__/cctv-reports-wave1230.test.js
 __tests__/cctv-reports-behavioral-wave1230.test.js
 __tests__/session-therapy-projection-wave1240.test.js
+__tests__/email-templates-wave1242.test.js


### PR DESCRIPTION
## Why
Email content today = **55+ scattered inline `dir=rtl` HTML strings** across 3 email services — no shared layout, no variable contracts, no preview surface.

## What
| piece | highlights |
|---|---|
| `intelligence/email-templates.registry.js` | **14 curated bilingual templates** (auth/appointments/clinical/finance/reports/system/hr — incl. NBA baseline-due + supervisor digest tied to this week's golden-thread surfaces). Structured blocks + variable contracts with Arabic labels & samples |
| `services/email/templateRenderer.service.js` | ONE polished Gmail/Outlook-safe RTL layout (600px table, brand header, hidden preheader, bulletproof CTA, footer). Missing required vars → 422-coded throw; all values HTML-escaped; auto plain-text alternative; CTA omitted when url absent |
| `routes/email-templates.routes.js` | catalogue / detail / preview (GET sample + POST with vars; html\|text\|json) / **admin-only** test-send via existing facade (mock-mode safe) |

14-test guard: closed-both-ways contract check, self-previewable catalogue, injection-escaping, layout markers, text-alt substance.

Send path untouched — this is the formatting layer existing callers converge on (EmailManager/sendEmail keep working as-is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)