### PR TITLE
fix(perf): W1234 — cache invalidation reaches action-suffix mutations (system-wide 5-min stale-state class)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1703,6 +1703,8 @@ on:
       - 'backend/__tests__/session-therapy-projection-wave1240.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/behavior-incident-projection-wave1242.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/cache-invalidation-basepath-wave1234.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3389,6 +3391,8 @@ on:
       - 'backend/__tests__/session-therapy-projection-wave1240.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/behavior-incident-projection-wave1242.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/cache-invalidation-basepath-wave1234.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/cache-invalidation-basepath-wave1234.test.js
+++ b/backend/__tests__/cache-invalidation-basepath-wave1234.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * cache-invalidation-basepath-wave1234.test.js — write-side cache
+ * invalidation must reach action-suffix mutations.
+ *
+ * The global cacheMiddleware(300,'api') caches every GET in Redis. Before
+ * W1234 its write-side invalidation stripped only a TRAILING /:objectId,
+ * so the ~720 action-suffix mutations in this codebase
+ * (`POST /x/:id/approve`, `PATCH /x/:id/status`, …) cleared a pattern that
+ * matched nothing — list + detail GETs served the pre-action state for the
+ * full 300s TTL. The W1229 letter-revoke bug (revoked letter kept
+ * verifying VALID) was one live instance of this class.
+ *
+ * Pure-function tests on `invalidationBasePath` + a drift guard that the
+ * middleware actually uses it.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { invalidationBasePath } = require('../config/performance');
+
+const OID = '6a2b07c0e116d3721151df3c';
+const OID2 = '69bcdcb6ddc7900f2a738c03';
+const UUID = '3f2b8c1a-9d4e-4b7a-8c2d-1e5f6a7b8c9d';
+
+describe('W1234 invalidationBasePath — id + action-suffix stripping', () => {
+  test('plain trailing ObjectId (the old behavior, preserved)', () => {
+    expect(invalidationBasePath(`/api/accounting/expenses/${OID}`)).toBe(
+      '/api/accounting/expenses'
+    );
+  });
+
+  test('action suffix after the id — the W1234 class', () => {
+    expect(invalidationBasePath(`/api/v1/hr/official-letters/${OID}/revoke`)).toBe(
+      '/api/v1/hr/official-letters'
+    );
+    expect(invalidationBasePath(`/api/v1/form-templates/submissions/${OID}/status`)).toBe(
+      '/api/v1/form-templates/submissions'
+    );
+  });
+
+  test('nested ids with deeper action segments strip from the FIRST id', () => {
+    expect(invalidationBasePath(`/api/v1/care-plans/${OID}/goals/${OID2}/complete`)).toBe(
+      '/api/v1/care-plans'
+    );
+  });
+
+  test('UUID ids are recognized too', () => {
+    expect(invalidationBasePath(`/api/v1/jobs/${UUID}/cancel`)).toBe('/api/v1/jobs');
+  });
+
+  test('query strings are dropped before deriving', () => {
+    expect(invalidationBasePath(`/api/v1/items/${OID}/approve?notify=1`)).toBe('/api/v1/items');
+  });
+
+  test('id-less URLs pass through unchanged (creates, logins, bulk ops)', () => {
+    expect(invalidationBasePath('/api/v1/hr/official-letters')).toBe(
+      '/api/v1/hr/official-letters'
+    );
+    expect(invalidationBasePath('/api/v1/auth/login')).toBe('/api/v1/auth/login');
+    expect(invalidationBasePath('/api/v1/items/bulk-import')).toBe('/api/v1/items/bulk-import');
+  });
+
+  test('short hex segments are NOT mistaken for ids', () => {
+    expect(invalidationBasePath('/api/v1/reports/2026/summary')).toBe(
+      '/api/v1/reports/2026/summary'
+    );
+    expect(invalidationBasePath('/api/v1/codes/abc123/activate')).toBe(
+      '/api/v1/codes/abc123/activate'
+    );
+  });
+
+  test('trailing slash after the action is tolerated', () => {
+    expect(invalidationBasePath(`/api/v1/items/${OID}/approve/`)).toBe('/api/v1/items');
+  });
+
+  test('null/undefined input degrades to empty string, never throws', () => {
+    expect(invalidationBasePath(undefined)).toBe('');
+    expect(invalidationBasePath(null)).toBe('');
+  });
+});
+
+describe('W1234 drift guard — middleware wiring', () => {
+  const perfSrc = fs.readFileSync(path.join(__dirname, '..', 'config', 'performance.js'), 'utf8');
+
+  test('cacheMiddleware derives the clear pattern via invalidationBasePath', () => {
+    expect(perfSrc).toMatch(/const basePath = invalidationBasePath\(req\.originalUrl \|\| req\.url\)/);
+    // The old inline strip (trailing-id-only) must not silently return.
+    expect(perfSrc).not.toMatch(/\.replace\(\/\\\/\[a-f0-9\]\{24\}\$\/i, ''\)/);
+  });
+
+  test('invalidationBasePath is exported for reuse + tests', () => {
+    expect(perfSrc).toMatch(/invalidationBasePath,/);
+  });
+});

--- a/backend/config/performance.js
+++ b/backend/config/performance.js
@@ -114,6 +114,29 @@ const initializeRedis = () => {
 // bypass the cache entirely.
 const NO_CACHE_RE = /\/letter-verify\/|\/official-letters\/verify\//;
 
+/**
+ * W1234: derive the cache-invalidation base path for a WRITE request.
+ *
+ * The previous rule stripped only a TRAILING /:objectId, so the ~720
+ * action-suffix mutations in this codebase (`POST /x/:id/approve`,
+ * `PATCH /x/:id/status`, `POST /x/:id/items/:itemId/complete`, …) cleared
+ * a pattern that matches NOTHING — list + detail GETs kept serving the
+ * pre-action state for the full 300s TTL (the W1229 revoke bug was one
+ * instance of this class, caught live).
+ *
+ * New rule: strip from the FIRST id-like segment (Mongo ObjectId or UUID)
+ * to the end — `/api/x/:id/anything/:id2/status` → `/api/x`. Broader
+ * clearing only costs a few extra cache misses; it can never serve stale
+ * data, so over-matching is the safe direction.
+ */
+const ID_SEGMENT_TAIL_RE =
+  /\/([a-f0-9]{24}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(\/[^/]+)*\/?$/i;
+
+const invalidationBasePath = (url) => {
+  const path = String(url || '').split('?')[0];
+  return path.replace(ID_SEGMENT_TAIL_RE, '');
+};
+
 const cacheMiddleware = (ttl = 300, prefix = 'cache:') => {
   return async (req, res, next) => {
     if (req.method === 'GET' && NO_CACHE_RE.test((req.originalUrl || req.url || '').split('?')[0])) {
@@ -122,8 +145,8 @@ const cacheMiddleware = (ttl = 300, prefix = 'cache:') => {
     if (!redis || req.method !== 'GET') {
       // For write operations (POST/PUT/PATCH/DELETE), invalidate related cache
       if (redis && req.method !== 'GET' && req.method !== 'OPTIONS' && req.method !== 'HEAD') {
-        // Extract the base API path (e.g., /api/accounting/expenses/:id -> /api/accounting/expenses)
-        const basePath = (req.originalUrl || req.url).split('?')[0].replace(/\/[a-f0-9]{24}$/i, '');
+        // W1234: /x/:id, /x/:id/approve, /x/:id/sub/:id2/status → /x
+        const basePath = invalidationBasePath(req.originalUrl || req.url);
         clearCache(`${prefix}${basePath}*`).catch(() => {});
       }
       return next();
@@ -442,6 +465,7 @@ const getMemoryPressure = () => {
 module.exports = {
   initializeRedis,
   cacheMiddleware,
+  invalidationBasePath,
   clearCache,
   getCacheStats,
   compressionMiddleware,

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1020,3 +1020,4 @@ __tests__/cctv-reports-wave1230.test.js
 __tests__/cctv-reports-behavioral-wave1230.test.js
 __tests__/session-therapy-projection-wave1240.test.js
 __tests__/behavior-incident-projection-wave1242.test.js
+__tests__/cache-invalidation-basepath-wave1234.test.js


### PR DESCRIPTION
## The class

`cacheMiddleware(300,'api')` caches **every GET** in Redis. Its write-side invalidation stripped only a *trailing* `/:objectId` — so all **721 action-suffix mutations** (`POST /x/:id/approve`, `PATCH /x/:id/status`, …) cleared a pattern matching nothing, and list/detail GETs served the pre-action state for the full **300s TTL**. W1229 (revoked letter verifying VALID) was one live instance; *"I changed it but it still shows the old value"* is this class's UX signature.

## Fix

`invalidationBasePath(url)`: strip from the **first** id-like segment (ObjectId/UUID) to the end — `/api/x/:id/anything/:id2/status` → `/api/x`. Over-clearing costs a few cache misses; it can never serve stale data.

## Tests

11 pure-function assertions + 2 drift guards (middleware wiring; old inline strip can't return). Sprint-enumerated. 28/28 green with the letters guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)