### PR TITLE
feat(hr): W1235 — experience certificate (شهادة خبرة) as the 4th letter type

### DIFF
--- a/backend/__tests__/official-letters-behavioral-wave1224.test.js
+++ b/backend/__tests__/official-letters-behavioral-wave1224.test.js
@@ -120,6 +120,17 @@ describe('W1224 OfficialLetter.issue — sequencing + format', () => {
     expect(letter.payload.nationalId).toBe('1234567890');
   });
 
+  test('W1235: experience_certificate issues with XC prefix and end-of-service payload', async () => {
+    const letter = await OfficialLetter.issue({
+      letterType: 'experience_certificate',
+      subject: subject(),
+      issuer: issuer(),
+      payload: { endDate: new Date('2026-05-31'), terminationType: 'resignation' },
+    });
+    expect(letter.refNumber).toBe(`XC-${YEAR}-0001`);
+    expect(letter.payload.terminationType).toBe('resignation');
+  });
+
   test('verifyTokens are unique across letters', async () => {
     const a = await OfficialLetter.issue({
       letterType: 'employment_certificate',

--- a/backend/__tests__/official-letters-routes-wave1224.test.js
+++ b/backend/__tests__/official-letters-routes-wave1224.test.js
@@ -56,6 +56,12 @@ describe('W1224 official-letters route — source contract', () => {
     expect(routeSrc).not.toMatch(/Object\.assign\([^)]*req\.body/);
   });
 
+  test('W1235: experience certificates ride the employee branch with end-of-service snapshot', () => {
+    expect(routeSrc).toMatch(/letterType === 'experience_certificate'/);
+    expect(routeSrc).toMatch(/termination_date termination_type/);
+    expect(routeSrc).toMatch(/terminationType: emp\.termination_type/);
+  });
+
   test('W1231: beneficiary letters snapshot server-side from the canonical Beneficiary model', () => {
     expect(routeSrc).toMatch(/mongoose\.model\('Beneficiary'\)/);
     expect(routeSrc).toMatch(/fullNameArabic fullNameEnglish mrn/);

--- a/backend/models/OfficialLetter.js
+++ b/backend/models/OfficialLetter.js
@@ -25,6 +25,7 @@ const LETTER_TYPES = Object.freeze({
   employment_certificate: { prefix: 'EC', labelAr: 'خطاب تعريف بالعمل' },
   salary_certificate: { prefix: 'SC', labelAr: 'خطاب تعريف بالراتب' },
   beneficiary_certificate: { prefix: 'BC', labelAr: 'خطاب تعريف بمستفيد' },
+  experience_certificate: { prefix: 'XC', labelAr: 'شهادة خبرة' },
 });
 
 // ─── Atomic sequence counter (one doc per letterType+year) ────────────────

--- a/backend/routes/hr/official-letters.routes.js
+++ b/backend/routes/hr/official-letters.routes.js
@@ -100,7 +100,11 @@ router.post('/', requireRole(WRITE_ROLES), async (req, res) => {
     let subject = null;
     let branchId = null;
     let payloadExtras = null;
-    if (letterType === 'employment_certificate' || letterType === 'salary_certificate') {
+    if (
+      letterType === 'employment_certificate' ||
+      letterType === 'salary_certificate' ||
+      letterType === 'experience_certificate'
+    ) {
       const employeeId = String(req.body.employeeId || '');
       if (!mongoose.isValidObjectId(employeeId)) {
         return res.status(400).json({ success: false, message: 'employeeId is required' });
@@ -112,7 +116,9 @@ router.post('/', requireRole(WRITE_ROLES), async (req, res) => {
         return res.status(503).json({ success: false, message: 'Employee model unavailable' });
       }
       const emp = await Employee.findById(employeeId)
-        .select('name_ar name_en employee_number job_title_ar job_title_en hire_date branch_id')
+        .select(
+          'name_ar name_en employee_number job_title_ar job_title_en hire_date branch_id termination_date termination_type'
+        )
         .lean();
       if (!emp) {
         return res.status(404).json({ success: false, message: 'Employee not found' });
@@ -130,6 +136,20 @@ router.post('/', requireRole(WRITE_ROLES), async (req, res) => {
         hireDate: emp.hire_date ?? null,
       };
       branchId = emp.branch_id ?? null;
+      if (letterType === 'experience_certificate') {
+        // End of service: prefer the system of record; fall back to an
+        // HR-entered last working day; null = still employed (the letter
+        // wording adapts).
+        let endDate = emp.termination_date ?? null;
+        if (!endDate && req.body.endDate) {
+          const d = new Date(String(req.body.endDate));
+          if (!Number.isNaN(d.getTime())) endDate = d;
+        }
+        payloadExtras = {
+          endDate,
+          terminationType: emp.termination_type ?? null,
+        };
+      }
     } else if (letterType === 'beneficiary_certificate') {
       const beneficiaryId = String(req.body.beneficiaryId || '');
       if (!mongoose.isValidObjectId(beneficiaryId)) {


### PR DESCRIPTION
XC-2026-NNNN sequence on the issuance registry. Employee branch + W269 enforcement; end-of-service snapshot prefers `termination_date`/`termination_type` from the record, falls back to HR-entered last working day, null = still employed. +2 tests, 29/29 green.

Frontend page (hub card 11) follows in alawael-rehab-platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)