### PR TITLE
fix(care-gap): W1243 — read canonical TherapeuticGoal for stalled-goal detection (goals split)

### DIFF
--- a/backend/__tests__/care-gap-loader-wave29.test.js
+++ b/backend/__tests__/care-gap-loader-wave29.test.js
@@ -87,11 +87,18 @@ describe('care-gap.loader — ctx assembly', () => {
   const benId2 = new mongoose.Types.ObjectId();
   const branchId = new mongoose.Types.ObjectId();
 
-  function buildLoader({ beneficiaries, carePlans = [], smartGoals = [], vaccinations = [] } = {}) {
+  function buildLoader({
+    beneficiaries,
+    carePlans = [],
+    smartGoals = [],
+    therapeuticGoals = [],
+    vaccinations = [],
+  } = {}) {
     return createCareGapLoader({
       Beneficiary: modelFromRows(beneficiaries),
       CarePlan: modelFromRows(carePlans),
       SmartGoal: modelFromRows(smartGoals),
+      TherapeuticGoal: modelFromRows(therapeuticGoals),
       Vaccination: modelFromRows(vaccinations),
       now: () => fixedNow,
     });
@@ -164,6 +171,54 @@ describe('care-gap.loader — ctx assembly', () => {
     expect(b.activeCarePlan).toBeNull();
     expect(b.activeGoals).toHaveLength(1);
     expect(b.dueVaccinations).toHaveLength(0);
+  });
+
+  // W1243 — care-gap stalled detection now reads the canonical TherapeuticGoal
+  // (the model the UI writes), not only the deprecated/empty SmartGoal.
+  test('attaches TherapeuticGoal (in_progress) into activeGoals, merged with SmartGoals', async () => {
+    const loader = buildLoader({
+      beneficiaries: [{ _id: benId1, branchId }],
+      smartGoals: [
+        { _id: 'sg-1', beneficiary: benId1, status: 'active', updatedAt: new Date('2026-03-01') },
+      ],
+      therapeuticGoals: [
+        {
+          _id: 'tg-1',
+          beneficiaryId: benId1,
+          status: 'in_progress',
+          updatedAt: new Date('2026-02-01'),
+        },
+        {
+          _id: 'tg-2',
+          beneficiaryId: benId1,
+          status: 'in_progress',
+          updatedAt: new Date('2026-05-10'),
+        },
+      ],
+    });
+    const ctx = await loader();
+    const a = ctx.beneficiaries.find(x => String(x._id) === String(benId1));
+    // 1 SmartGoal + 2 TherapeuticGoals all merged into activeGoals
+    expect(a.activeGoals).toHaveLength(3);
+    const tg1 = a.activeGoals.find(g => String(g._id) === 'tg-1');
+    expect(tg1).toBeTruthy();
+    expect(tg1.status).toBe('in-progress'); // normalized for the stalled generator
+    expect(tg1.lastProgressAt).toEqual(new Date('2026-02-01')); // updatedAt proxy
+  });
+
+  test('TherapeuticGoal query failure is non-fatal (SmartGoals still attach)', async () => {
+    const loader = createCareGapLoader({
+      Beneficiary: modelFromRows([{ _id: benId1, branchId }]),
+      SmartGoal: modelFromRows([
+        { _id: 'sg-1', beneficiary: benId1, status: 'active', updatedAt: new Date('2026-03-01') },
+      ]),
+      TherapeuticGoal: modelThatThrows('tg boom'),
+      now: () => fixedNow,
+      logger: { warn: () => {} },
+    });
+    const ctx = await loader();
+    const a = ctx.beneficiaries.find(x => String(x._id) === String(benId1));
+    expect(a.activeGoals).toHaveLength(1); // SmartGoal still there, TG failure swallowed
   });
 
   test('maps SmartGoal.status=active to in-progress (generator expects that name)', async () => {

--- a/backend/intelligence/loaders/care-gap.loader.js
+++ b/backend/intelligence/loaders/care-gap.loader.js
@@ -50,6 +50,11 @@ function createCareGapLoader({
   Beneficiary,
   CarePlan = null,
   SmartGoal = null,
+  // W1243 — TherapeuticGoal is the canonical goal model the UI writes (domains/goals).
+  // care-gap stalled-goal detection previously read only the deprecated/empty SmartGoal,
+  // so UI-entered goals never produced a stalled-goal care gap (DDD↔legacy split, goals
+  // row). Read both: SmartGoal (legacy/portal) + TherapeuticGoal (canonical), merged.
+  TherapeuticGoal = null,
   Vaccination = null,
   maxBeneficiaries = DEFAULT_MAX_BENEFICIARIES,
   stalledDays = DEFAULT_STALLED_DAYS,
@@ -133,6 +138,35 @@ function createCareGapLoader({
         }
       } catch (err) {
         logger.warn && logger.warn(`[care-gap.loader] smartgoal query failed: ${err.message}`);
+      }
+    }
+
+    // 3b. Pull open TherapeuticGoals (the canonical goal the UI writes) — W1243.
+    // Same stalled-detection shape as the SmartGoal block above, merged into the
+    // same per-beneficiary map. `status:'in_progress'` ≙ open; `updatedAt` proxies
+    // `lastProgressAt` (a progress log bumps the goal). Additive: a beneficiary's
+    // stalled goals are now detected across BOTH models.
+    if (TherapeuticGoal) {
+      try {
+        const tgoals = await TherapeuticGoal.find({
+          beneficiaryId: { $in: beneficiaryIds },
+          status: 'in_progress',
+          isDeleted: { $ne: true },
+        })
+          .select('_id beneficiaryId status updatedAt')
+          .lean();
+        for (const g of tgoals) {
+          const key = String(g.beneficiaryId);
+          if (!goalsByBen.has(key)) goalsByBen.set(key, []);
+          goalsByBen.get(key).push({
+            _id: g._id,
+            status: 'in-progress',
+            lastProgressAt: g.updatedAt,
+          });
+        }
+      } catch (err) {
+        logger.warn &&
+          logger.warn(`[care-gap.loader] therapeuticgoal query failed: ${err.message}`);
       }
     }
 

--- a/backend/intelligence/orchestrator-loaders.registry.js
+++ b/backend/intelligence/orchestrator-loaders.registry.js
@@ -42,6 +42,7 @@ function careGapLoader({ models = {}, logger = console } = {}) {
     Beneficiary: models.Beneficiary,
     CarePlan: models.CarePlan || null,
     SmartGoal: models.SmartGoal || null,
+    TherapeuticGoal: models.TherapeuticGoal || null, // W1243 — canonical goal (UI write)
     Vaccination: models.Vaccination || null,
     logger,
   });


### PR DESCRIPTION
## Closes the one real split in the goals row
`care-gap.loader`'s stalled-goal detection read **only `SmartGoal`** — the qualitative-suggestion tier that is **deprecated + empty** in prod (ADR-040). The UI writes goals to `TherapeuticGoal`, so **UI-entered goals never produced a stalled-goal care gap** — the care-gap engine was blind to them.

## Fix (additive, bounded)
The loader now **also** queries `TherapeuticGoal` (`status:'in_progress'`) and merges it into the same per-beneficiary map with the identical stalled shape (`status→'in-progress'`, `updatedAt→lastProgressAt`). SmartGoal path unchanged (harmless on empty data) → stalled goals detected across **both** models. Injected via the orchestrator registry; query failure is non-fatal.

## Classification of the other 4 SmartGoal readers — all LEGITIMATE, not splits
- `assessmentRecommendationEngine` — uses SmartGoal as the suggestion taxonomy ✅
- `therapistPortal` — dedicated SmartGoal read+write surface (consistent) ✅
- `assessmentReassessmentSweeper` — SmartGoal-specific sweeper ✅
- `orchestrator-loaders` — infrastructure ✅

Only `care-gap` needed the canonical goal.

## Tests
20 pass (18 existing + 2 new: TherapeuticGoal merges into `activeGoals`; TG query failure non-fatal). No regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)