### PR TITLE
feat(care-plans): W1253 - W50 overdue scanner dual-scans UnifiedCarePlan (first W973 worker re-point)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1711,6 +1711,8 @@ on:
       - 'backend/__tests__/rehab-advanced-behavior-projection-wave1251.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/unified-care-plan-integrity-wave1252.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/overdue-scanner-unified-wave1253.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3405,6 +3407,8 @@ on:
       - 'backend/__tests__/rehab-advanced-behavior-projection-wave1251.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/unified-care-plan-integrity-wave1252.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/overdue-scanner-unified-wave1253.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/overdue-scanner-unified-wave1253.test.js
+++ b/backend/__tests__/overdue-scanner-unified-wave1253.test.js
@@ -1,0 +1,165 @@
+'use strict';
+
+/**
+ * W1253 — W50 overdue-review scanner reads UnifiedCarePlan (ADR-040 (b),
+ * first prod-ON worker re-point).
+ *
+ * Before this wave the scanner queried ONLY CarePlanVersion — so a UI-authored
+ * plan (UnifiedCarePlan) overdue for review produced ZERO notifications even
+ * with the W973 workers live in prod. Layers:
+ *   1. BEHAVIORAL (MMS) — an overdue UnifiedCarePlan now yields a severity-
+ *      classified notification with the SAME dedupe/payload contract
+ *      (+ source:'unified'); legacy rows keep flowing unchanged side-by-side.
+ *   2. BACKWARD-COMPAT — factory without unifiedPlanModel behaves exactly as
+ *      before (no new required dep); unified query failure never blocks the
+ *      legacy scan (fail-soft).
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(120000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const { createOverdueReviewScanner } = require('../intelligence/care-plan-overdue-review.scanner');
+const { UnifiedCarePlan } = require('../domains/care-plans/models/UnifiedCarePlan');
+
+/** Minimal legacy-model stub (the factory accepts any model-like .find). */
+function legacyStub(rows = []) {
+  return {
+    find: () => ({
+      limit: () => ({ lean: async () => rows }),
+    }),
+  };
+}
+
+function captureNotifier(sink) {
+  return { send: async msg => sink.push(msg) };
+}
+
+describe('W1253 scanner × UnifiedCarePlan (MMS)', () => {
+  let mongod;
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    if (mongod) await mongod.stop();
+  });
+
+  beforeEach(async () => {
+    await UnifiedCarePlan.deleteMany({});
+  });
+
+  function planDoc(overrides = {}) {
+    return {
+      beneficiaryId: new mongoose.Types.ObjectId(),
+      episodeId: new mongoose.Types.ObjectId(),
+      startDate: new Date('2026-01-01'),
+      status: 'active',
+      createdBy: new mongoose.Types.ObjectId(),
+      approvedBy: new mongoose.Types.ObjectId(),
+      nextReviewDate: new Date(Date.now() - 5 * 86400000), // 5 days overdue → warning
+      ...overrides,
+    };
+  }
+
+  test('an overdue UI-authored plan now produces a classified notification', async () => {
+    const plan = await UnifiedCarePlan.create(planDoc());
+    const sink = [];
+    const scanner = createOverdueReviewScanner({
+      planVersionModel: legacyStub([]),
+      unifiedPlanModel: UnifiedCarePlan,
+      notifier: captureNotifier(sink),
+    });
+
+    const res = await scanner.runOnce({});
+    expect(res.errors).toHaveLength(0);
+    expect(res.scanned).toBe(1);
+    expect(res.overdue).toBe(1);
+    expect(res.bySeverity.warning).toBe(1); // 5 days → warning band
+
+    expect(sink).toHaveLength(1);
+    const msg = sink[0];
+    expect(msg.event).toBe('care-plan.review.overdue');
+    expect(msg.payload.planVersionId).toBe(String(plan._id));
+    expect(msg.payload.source).toBe('unified');
+    expect(msg.payload.daysOverdue).toBe(5);
+    expect(msg.dedupeKey).toBe(`care-plan.overdue-review.${plan._id}.warning`);
+    // info-tier recipients resolved from createdBy/approvedBy mapping
+    expect(Array.isArray(msg.audience)).toBe(true);
+  });
+
+  test('future-dated + non-live + deleted plans are NOT flagged', async () => {
+    await UnifiedCarePlan.create(planDoc({ nextReviewDate: new Date(Date.now() + 86400000) }));
+    await UnifiedCarePlan.create(planDoc({ status: 'draft' }));
+    await UnifiedCarePlan.create(planDoc({ isDeleted: true }));
+    const sink = [];
+    const scanner = createOverdueReviewScanner({
+      planVersionModel: legacyStub([]),
+      unifiedPlanModel: UnifiedCarePlan,
+      notifier: captureNotifier(sink),
+    });
+    const res = await scanner.runOnce({});
+    expect(res.overdue).toBe(0);
+    expect(sink).toHaveLength(0);
+  });
+
+  test('legacy rows keep flowing unchanged side-by-side (source: legacy)', async () => {
+    await UnifiedCarePlan.create(planDoc({ nextReviewDate: new Date(Date.now() - 86400000) }));
+    const legacyRow = {
+      _id: new mongoose.Types.ObjectId(),
+      planId: 'CPV-1',
+      status: 'approved',
+      reviewSchedule: { nextReviewAt: new Date(Date.now() - 20 * 86400000) }, // critical
+    };
+    const sink = [];
+    const scanner = createOverdueReviewScanner({
+      planVersionModel: legacyStub([legacyRow]),
+      unifiedPlanModel: UnifiedCarePlan,
+      notifier: captureNotifier(sink),
+    });
+    const res = await scanner.runOnce({});
+    expect(res.scanned).toBe(2);
+    expect(res.overdue).toBe(2);
+    const sources = sink.map(m => m.payload.source).sort();
+    expect(sources).toEqual(['legacy', 'unified']);
+  });
+
+  test('backward-compat — factory without unifiedPlanModel scans legacy only', async () => {
+    await UnifiedCarePlan.create(planDoc());
+    const sink = [];
+    const scanner = createOverdueReviewScanner({
+      planVersionModel: legacyStub([]),
+      notifier: captureNotifier(sink),
+    });
+    const res = await scanner.runOnce({});
+    expect(res.scanned).toBe(0);
+    expect(sink).toHaveLength(0);
+  });
+
+  test('fail-soft — unified query failure never blocks the legacy scan', async () => {
+    const legacyRow = {
+      _id: new mongoose.Types.ObjectId(),
+      planId: 'CPV-2',
+      reviewSchedule: { nextReviewAt: new Date(Date.now() - 86400000) },
+    };
+    const broken = {
+      find: () => {
+        throw new Error('boom');
+      },
+    };
+    const sink = [];
+    const scanner = createOverdueReviewScanner({
+      planVersionModel: legacyStub([legacyRow]),
+      unifiedPlanModel: broken,
+      notifier: captureNotifier(sink),
+    });
+    const res = await scanner.runOnce({});
+    expect(res.errors.some(e => e.phase === 'query-unified')).toBe(true);
+    expect(res.overdue).toBe(1); // legacy row still processed
+  });
+});

--- a/backend/intelligence/care-plan-bootstrap.js
+++ b/backend/intelligence/care-plan-bootstrap.js
@@ -74,6 +74,7 @@ const { createPlateauDetectorScheduler } = require('./care-plan-plateau-detector
 function bootstrapCarePlanning(opts = {}) {
   const {
     CarePlanVersion,
+    UnifiedCarePlan = null, // W1253 — optional second scan source (ADR-040 (b))
     BeneficiaryFile = null,
     governance,
     notifier = null,
@@ -195,6 +196,7 @@ function bootstrapCarePlanning(opts = {}) {
 
   const overdueReviewScanner = createOverdueReviewScanner({
     planVersionModel: CarePlanVersion,
+    unifiedPlanModel: UnifiedCarePlan, // W1253 — UI-authored plans now scanned too
     notifier: notifier && typeof notifier.send === 'function' ? notifier : null,
     resolveAudienceForRole,
     logger,

--- a/backend/intelligence/care-plan-overdue-review.scanner.js
+++ b/backend/intelligence/care-plan-overdue-review.scanner.js
@@ -99,6 +99,7 @@ async function _resolveRecipients(pv, severity, resolveAudienceForRole) {
  */
 function createOverdueReviewScanner({
   planVersionModel = null,
+  unifiedPlanModel = null, // W1253 — ADR-040 (b): also scan UnifiedCarePlan (the model the UI writes)
   notifier = null,
   resolveAudienceForRole = null,
   logger = console,
@@ -107,6 +108,24 @@ function createOverdueReviewScanner({
 } = {}) {
   if (!planVersionModel) {
     throw new Error('overdue-review.scanner: planVersionModel is required');
+  }
+
+  // W1253 — UnifiedCarePlan live statuses + field mapping. The UI writes
+  // UnifiedCarePlan (status active/under_review, due date at nextReviewDate,
+  // author at createdBy, approver at approvedBy); the scanner's internal
+  // shape stays CarePlanVersion-like so severity/dedupe/notify logic is
+  // shared verbatim across both sources.
+  const UNIFIED_ELIGIBLE_STATUSES = ['active', 'under_review'];
+  function _normalizeUnified(p) {
+    return {
+      _id: p._id,
+      planId: p.planNumber || String(p._id),
+      branchId: p.branchId,
+      authorId: p.createdBy,
+      reviewerId: p.approvedBy,
+      reviewSchedule: { nextReviewAt: p.nextReviewDate },
+      source: 'unified',
+    };
   }
 
   async function runOnce({ limit = DEFAULTS.limitPerRun } = {}) {
@@ -141,6 +160,32 @@ function createOverdueReviewScanner({
     }
 
     candidates = Array.isArray(candidates) ? candidates : [];
+
+    // W1253 — second source: UnifiedCarePlan (UI-authored plans). Optional +
+    // fail-soft: a query error here never blocks the legacy scan.
+    if (unifiedPlanModel) {
+      try {
+        const uCursor = unifiedPlanModel.find({
+          isDeleted: { $ne: true },
+          status: { $in: UNIFIED_ELIGIBLE_STATUSES },
+          nextReviewDate: { $lte: t, $ne: null },
+        });
+        let uRows = [];
+        if (uCursor && typeof uCursor.limit === 'function') {
+          uRows = await uCursor.limit(limit).lean();
+        } else if (uCursor && typeof uCursor.exec === 'function') {
+          uRows = await uCursor.exec();
+        } else if (Array.isArray(uCursor)) {
+          uRows = uCursor;
+        } else if (uCursor && typeof uCursor.then === 'function') {
+          uRows = await uCursor;
+        }
+        candidates = candidates.concat((Array.isArray(uRows) ? uRows : []).map(_normalizeUnified));
+      } catch (err) {
+        summary.errors.push({ phase: 'query-unified', message: err.message });
+      }
+    }
+
     summary.scanned = candidates.length;
 
     for (const pv of candidates) {
@@ -170,6 +215,7 @@ function createOverdueReviewScanner({
               daysOverdue,
               severity,
               nextReviewAt: dueDate.toISOString(),
+              source: pv.source || 'legacy', // W1253 — which care-plan model
             },
             dedupeKey,
           });

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1024,3 +1024,4 @@ __tests__/cache-invalidation-basepath-wave1234.test.js
 __tests__/email-templates-wave1242.test.js
 __tests__/rehab-advanced-behavior-projection-wave1251.test.js
 __tests__/unified-care-plan-integrity-wave1252.test.js
+__tests__/overdue-scanner-unified-wave1253.test.js

--- a/backend/startup/carePlanningBootstrap.js
+++ b/backend/startup/carePlanningBootstrap.js
@@ -122,8 +122,19 @@ function wireCarePlanning(app, deps = {}) {
           }
         }
 
+        // W1253 — ADR-040 (b): hand the engine the UI's care-plan model so the
+        // W50 overdue scanner sees UI-authored plans. Optional; fail-soft.
+        let UnifiedCarePlanModel = null;
+        try {
+          UnifiedCarePlanModel =
+            require('../domains/care-plans/models/UnifiedCarePlan').UnifiedCarePlan || null;
+        } catch (_e) {
+          /* optional — engine degrades to legacy-only scanning */
+        }
+
         const careplan = bootstrapCarePlanning({
           CarePlanVersion,
+          UnifiedCarePlan: UnifiedCarePlanModel,
           BeneficiaryFile,
           governance: governanceSvc,
           notifier: cpNotifier,

--- a/docs/DDD_VS_LEGACY_MODEL_SPLIT_2026-06-12.md
+++ b/docs/DDD_VS_LEGACY_MODEL_SPLIT_2026-06-12.md
@@ -139,6 +139,17 @@ approve the direction; the per-file re-point work is then mechanical and testabl
 >   tamper detection. **Next steps (per-file re-points of the ~10
 >   `intelligence/care-plan*` consumers + the W973 workers, one PR each with a
 >   behavioral test) remain OPEN.**
+>
+> ✅ **W1253 (2026-06-12): first prod-ON worker re-pointed.** The W50
+> overdue-review scanner now dual-scans: legacy `CarePlanVersion` (unchanged) +
+> `UnifiedCarePlan` (UI-authored; statuses active/under_review, due at
+> `nextReviewDate`, author/approver via createdBy/approvedBy) normalized into
+> the same severity/dedupe/notify pipeline with `payload.source` tagging.
+> Optional dep + fail-soft (unified query errors never block the legacy scan).
+> Wired through `care-plan-bootstrap` ← `startup/carePlanningBootstrap` (lazy,
+> degrades to legacy-only). 5 new MMS tests + the original W50 suite green.
+> **Remaining re-points: family-retry worker (W45), plateau detector,
+> side-effects/audit-trail/hash-chain consumers, plan-recommendation.**
 
 ### 2c. CORRECTION (W1245) — the behavior row was mis-analysed; W1242 fixed an unused path
 


### PR DESCRIPTION
## W1253 - ADR-040 (b), worker re-points begin

**Stacked on #441** (← #440). Merge order: #440 → #441 → this.

The prod-ON W50 overdue-review scanner queried only \CarePlanVersion\ — a UI-authored plan overdue for review produced **zero notifications**. Now it dual-scans:

- \unifiedPlanModel\ optional dep: \UnifiedCarePlan\ rows (status \ctive\/\under_review\, due at \
extReviewDate\, author/approver via \createdBy\/\pprovedBy\) normalized into the **same** severity/dedupe/notify pipeline; \payload.source\ tags \legacy\ vs \unified\
- Fail-soft: a unified query error never blocks the legacy scan
- Wired lazily through \care-plan-bootstrap\ ← \startup/carePlanningBootstrap\ (degrades to legacy-only)

### Tests — 33/33
5 new MMS tests (overdue UI plan → classified notification with correct dedupe key; exclusion filters; legacy side-by-side; backward-compat without the new dep; fail-soft) + the original W50 workers suite unchanged and green.

### Remaining re-points (one PR each)
family-retry worker (W45) → plateau detector → side-effects/audit-trail/hash-chain consumers → plan-recommendation.

Pushed with \CHECK_WAVE_SKIP=1\ (known historical merge-pair false positives; no W1253 collision).