### PR TITLE
feat(care-plans): W1254 - W45 family-retry serves UnifiedCarePlan + lean-persistence root-fix

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1713,6 +1713,8 @@ on:
       - 'backend/__tests__/unified-care-plan-integrity-wave1252.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/overdue-scanner-unified-wave1253.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/family-retry-unified-wave1254.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3409,6 +3411,8 @@ on:
       - 'backend/__tests__/unified-care-plan-integrity-wave1252.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/overdue-scanner-unified-wave1253.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/family-retry-unified-wave1254.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/family-retry-unified-wave1254.test.js
+++ b/backend/__tests__/family-retry-unified-wave1254.test.js
@@ -1,0 +1,194 @@
+'use strict';
+
+/**
+ * W1254 — W45 family-retry worker serves UnifiedCarePlan (second prod-ON
+ * worker re-point, ADR-040 (b)) + the .lean() persistence root-fix.
+ *
+ * Layers:
+ *   1. BEHAVIORAL (MMS) — a UI-authored plan with a failed family-notification
+ *      attempt gets retried through the W45 handler; success/failure mutations
+ *      (retries, status, failureReason) NOW PERSIST (pre-W1254 the real-model
+ *      path fetched .lean() rows whose missing .save() silently dropped every
+ *      mutation — backoff/exhaustion state reset on every cron run).
+ *   2. EXHAUSTION — a 3rd-retry attempt flips to manual_override and persists.
+ *   3. BACKWARD-COMPAT — legacy mock paths (plain arrays) work unchanged;
+ *      factory without unifiedPlanModel ignores UnifiedCarePlan rows;
+ *      unified query failure never blocks the legacy scan.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(120000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const { createFamilyRetryWorker } = require('../intelligence/care-plan-family-retry.worker');
+const { HANDLER_NAMES } = require('../intelligence/care-plan-side-effects.service');
+const { UnifiedCarePlan } = require('../domains/care-plans/models/UnifiedCarePlan');
+
+function legacyStub(rows = []) {
+  return { find: () => rows };
+}
+
+function handlers(result) {
+  const calls = [];
+  return {
+    calls,
+    map: {
+      [HANDLER_NAMES.NOTIFY_FAMILY]: async args => {
+        calls.push(args);
+        return typeof result === 'function' ? result(args) : result;
+      },
+    },
+  };
+}
+
+describe('W1254 family-retry × UnifiedCarePlan (MMS)', () => {
+  let mongod;
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    if (mongod) await mongod.stop();
+  });
+
+  beforeEach(async () => {
+    await UnifiedCarePlan.deleteMany({});
+  });
+
+  function uiPlan(attempt = {}) {
+    return {
+      beneficiaryId: new mongoose.Types.ObjectId(),
+      episodeId: new mongoose.Types.ObjectId(),
+      startDate: new Date('2026-01-01'),
+      status: 'active',
+      familyNotifications: [
+        {
+          attemptId: 'AT-1',
+          channel: 'sms',
+          attemptedAt: new Date(Date.now() - 6 * 3600000), // old enough for any backoff slot
+          status: 'failed',
+          retries: 0,
+          failureReason: 'sms gateway timeout',
+          ...attempt,
+        },
+      ],
+    };
+  }
+
+  test('failed attempt on a UI plan is retried; success mutation PERSISTS', async () => {
+    const plan = await UnifiedCarePlan.create(uiPlan());
+    const h = handlers({ ok: true });
+    const worker = createFamilyRetryWorker({
+      planVersionModel: legacyStub([]),
+      unifiedPlanModel: UnifiedCarePlan,
+      sideEffectHandlers: h.map,
+    });
+
+    const res = await worker.runOnce({});
+    expect(res.scanned).toBe(1);
+    expect(res.retried).toBe(1);
+    expect(res.succeeded).toBe(1);
+    expect(res.details[0].source).toBe('unified');
+    expect(h.calls).toHaveLength(1);
+    expect(h.calls[0].metadata.isRetry).toBe(true);
+
+    // The root-fix proof: mutations persisted to the DB (pre-W1254 they were lost)
+    const after = await UnifiedCarePlan.findById(plan._id).lean();
+    expect(after.familyNotifications[0].status).toBe('sent');
+    expect(after.familyNotifications[0].retries).toBe(1);
+    expect(after.familyNotifications[0].failureReason).toBeNull();
+  });
+
+  test('failed retry persists incremented counter + reason (backoff state survives)', async () => {
+    const plan = await UnifiedCarePlan.create(uiPlan());
+    const h = handlers({ ok: false, reason: 'still down' });
+    const worker = createFamilyRetryWorker({
+      planVersionModel: legacyStub([]),
+      unifiedPlanModel: UnifiedCarePlan,
+      sideEffectHandlers: h.map,
+    });
+
+    await worker.runOnce({});
+    const after = await UnifiedCarePlan.findById(plan._id).lean();
+    expect(after.familyNotifications[0].status).toBe('failed');
+    expect(after.familyNotifications[0].retries).toBe(1);
+    expect(after.familyNotifications[0].failureReason).toBe('still down');
+  });
+
+  test('exhausted attempt (3 retries) flips to manual_override and persists', async () => {
+    const plan = await UnifiedCarePlan.create(uiPlan({ retries: 3 }));
+    const h = handlers({ ok: true });
+    const worker = createFamilyRetryWorker({
+      planVersionModel: legacyStub([]),
+      unifiedPlanModel: UnifiedCarePlan,
+      sideEffectHandlers: h.map,
+    });
+
+    const res = await worker.runOnce({});
+    expect(res.exhausted).toBe(1);
+    expect(res.manualOverrideMarked).toBe(1);
+    expect(h.calls).toHaveLength(0); // never re-sent
+    const after = await UnifiedCarePlan.findById(plan._id).lean();
+    expect(after.familyNotifications[0].status).toBe('manual_override');
+  });
+
+  test('backward-compat — without unifiedPlanModel, UI plans are ignored; legacy array path unchanged', async () => {
+    await UnifiedCarePlan.create(uiPlan());
+    const legacyRow = {
+      _id: new mongoose.Types.ObjectId(),
+      status: 'family_notification_sent',
+      familyNotifications: [
+        {
+          attemptId: 'L-1',
+          channel: 'email',
+          attemptedAt: new Date(Date.now() - 6 * 3600000),
+          status: 'failed',
+          retries: 0,
+        },
+      ],
+    };
+    const h = handlers({ ok: true });
+    const worker = createFamilyRetryWorker({
+      planVersionModel: legacyStub([legacyRow]),
+      sideEffectHandlers: h.map,
+    });
+    const res = await worker.runOnce({});
+    expect(res.scanned).toBe(1); // legacy only
+    expect(res.succeeded).toBe(1);
+    expect(res.details[0].source).toBe('legacy');
+  });
+
+  test('fail-soft — unified query failure never blocks the legacy scan', async () => {
+    const broken = {
+      find: () => {
+        throw new Error('boom');
+      },
+    };
+    const legacyRow = {
+      _id: new mongoose.Types.ObjectId(),
+      status: 'saved_to_record',
+      familyNotifications: [
+        {
+          attemptId: 'L-2',
+          channel: 'portal',
+          attemptedAt: new Date(Date.now() - 6 * 3600000),
+          status: 'failed',
+          retries: 0,
+        },
+      ],
+    };
+    const h = handlers({ ok: true });
+    const worker = createFamilyRetryWorker({
+      planVersionModel: legacyStub([legacyRow]),
+      unifiedPlanModel: broken,
+      sideEffectHandlers: h.map,
+    });
+    const res = await worker.runOnce({});
+    expect(res.succeeded).toBe(1);
+  });
+});

--- a/backend/domains/care-plans/models/UnifiedCarePlan.js
+++ b/backend/domains/care-plans/models/UnifiedCarePlan.js
@@ -30,6 +30,29 @@ const SignatureSchema = new mongoose.Schema(
   { _id: false }
 );
 
+// W1254 — same shape as CarePlanVersion.FamilyNotificationSchema (field-for-
+// field) so the W45 retry worker's attempt logic is shared verbatim.
+const FamilyNotificationSchema = new mongoose.Schema(
+  {
+    attemptId: { type: String, required: true, maxlength: 100 },
+    channel: {
+      type: String,
+      enum: ['email', 'sms', 'whatsapp', 'portal', 'manual'],
+      required: true,
+    },
+    attemptedAt: { type: Date, required: true, default: Date.now },
+    status: {
+      type: String,
+      enum: ['queued', 'sent', 'delivered', 'read', 'failed', 'manual_override'],
+      required: true,
+    },
+    retries: { type: Number, default: 0, min: 0, max: 5 },
+    failureReason: { type: String, default: null, maxlength: 500 },
+    acknowledgedAt: { type: Date, default: null },
+  },
+  { _id: false }
+);
+
 const goalRefSchema = new mongoose.Schema(
   {
     goalId: { type: mongoose.Schema.Types.ObjectId, ref: 'TherapeuticGoal' },
@@ -255,6 +278,10 @@ const unifiedCarePlanSchema = new mongoose.Schema(
     // ── Integrity layer (W1252 — lifted from CarePlanVersion) ────────
     signatureChain: { type: [SignatureSchema], default: () => [] },
     evidenceHash: { type: String, default: null, maxlength: 128 },
+
+    // ── Family notifications (W1254 — lifted from CarePlanVersion so the
+    // W45 family-retry worker can serve UI-authored plans) ───────────
+    familyNotifications: { type: [FamilyNotificationSchema], default: () => [] },
 
     // ── Version Control ─────────────────────────────────────────────
     version: { type: Number, default: 1 },

--- a/backend/intelligence/care-plan-bootstrap.js
+++ b/backend/intelligence/care-plan-bootstrap.js
@@ -188,6 +188,7 @@ function bootstrapCarePlanning(opts = {}) {
   // 6. Background workers (caller is responsible for scheduling)
   const familyRetryWorker = createFamilyRetryWorker({
     planVersionModel: CarePlanVersion,
+    unifiedPlanModel: UnifiedCarePlan, // W1254 — UI-authored plans now served too
     sideEffectHandlers,
     logger,
     now,

--- a/backend/intelligence/care-plan-family-retry.worker.js
+++ b/backend/intelligence/care-plan-family-retry.worker.js
@@ -79,6 +79,7 @@ function _evaluateAttempt(attempt, now) {
  */
 function createFamilyRetryWorker({
   planVersionModel = null,
+  unifiedPlanModel = null, // W1254 — ADR-040 (b): also serve UnifiedCarePlan (the model the UI writes)
   sideEffectHandlers = {},
   logger = console,
   now = () => new Date(),
@@ -87,6 +88,11 @@ function createFamilyRetryWorker({
   if (!planVersionModel) {
     throw new Error('family-retry.worker: planVersionModel is required');
   }
+
+  // W1254 — UnifiedCarePlan's post-approval (live) statuses. familyNotifications
+  // was lifted field-for-field onto UnifiedCarePlan, so the per-attempt logic
+  // below is shared verbatim; only the status eligibility differs per model.
+  const UNIFIED_RETRYABLE_STATUSES = ['active', 'under_review'];
   // Handler is optional at construction time — gracefully skipped at
   // runtime if the bootstrap didn't wire family notifications.
   const handler = sideEffectHandlers[HANDLER_NAMES.NOTIFY_FAMILY];
@@ -124,31 +130,74 @@ function createFamilyRetryWorker({
     // We rely on application-level invariants (status + familyNotifications)
     // rather than a query-side $elemMatch so this works against both the
     // real Mongoose model and the lightweight test mock.
+    //
+    // W1254 — fetched HYDRATED (no .lean()): pre-W1254 the real-model path
+    // used .lean(), so the retry mutations below (retries++, status flips,
+    // manual_override) hit `typeof pv.save === 'function'` === false and were
+    // NEVER persisted — meaning backoff/exhaustion state silently reset every
+    // run against real data. Hydrated docs restore persistence; the mock
+    // paths (array / thenable / exec) are unchanged.
+    async function _fetch(model, query) {
+      const cursor = model.find(query);
+      if (cursor && typeof cursor.limit === 'function') {
+        const limited = cursor.limit(limit * 4);
+        // Real mongoose Query is thenable → await yields HYDRATED docs
+        // (the W1254 persistence fix). Legacy test mocks return a plain
+        // { lean } object instead — honor that shape unchanged.
+        if (limited && typeof limited.then === 'function') return await limited;
+        if (limited && typeof limited.lean === 'function') return await limited.lean();
+        return Array.isArray(limited) ? limited : [];
+      } else if (cursor && typeof cursor.exec === 'function') {
+        return await cursor.exec();
+      } else if (Array.isArray(cursor)) {
+        return cursor;
+      } else if (cursor && typeof cursor.then === 'function') {
+        return await cursor;
+      }
+      return [];
+    }
+
     let candidates = [];
     try {
-      const cursor = planVersionModel.find({
+      const legacyRows = await _fetch(planVersionModel, {
         status: { $in: ['saved_to_record', 'family_notification_sent'] },
       });
-      if (cursor && typeof cursor.limit === 'function') {
-        candidates = await cursor.limit(limit * 4).lean();
-      } else if (cursor && typeof cursor.exec === 'function') {
-        candidates = await cursor.exec();
-      } else if (Array.isArray(cursor)) {
-        candidates = cursor;
-      } else if (cursor && typeof cursor.then === 'function') {
-        candidates = await cursor;
-      }
+      candidates = (Array.isArray(legacyRows) ? legacyRows : []).map(pv => ({
+        pv,
+        source: 'legacy',
+      }));
     } catch (err) {
       logger.warn && logger.warn(`[family-retry] scan failed: ${err.message}`);
       return { ...summary, scanError: err.message };
     }
 
-    candidates = Array.isArray(candidates) ? candidates : [];
+    // W1254 — second source: UnifiedCarePlan (UI-authored). Optional +
+    // fail-soft: an error here never blocks the legacy scan.
+    if (unifiedPlanModel) {
+      try {
+        const uRows = await _fetch(unifiedPlanModel, {
+          isDeleted: { $ne: true },
+          status: { $in: UNIFIED_RETRYABLE_STATUSES },
+          'familyNotifications.status': 'failed',
+        });
+        candidates = candidates.concat(
+          (Array.isArray(uRows) ? uRows : []).map(pv => ({ pv, source: 'unified' }))
+        );
+      } catch (err) {
+        logger.warn &&
+          logger.warn(`[family-retry] unified scan failed (non-fatal): ${err.message}`);
+      }
+    }
+
     summary.scanned = candidates.length;
 
-    for (const pv of candidates) {
+    for (const { pv, source } of candidates) {
       if (summary.retried >= limit) break;
-      if (!_isRetryableStatus(pv.status)) continue;
+      const statusOk =
+        source === 'unified'
+          ? UNIFIED_RETRYABLE_STATUSES.includes(pv.status)
+          : _isRetryableStatus(pv.status);
+      if (!statusOk) continue;
       const notifications = Array.isArray(pv.familyNotifications) ? pv.familyNotifications : [];
       // Pick the most-recent failed attempt only (don't pile retries
       // on multiple historical attempts in the same run).
@@ -208,6 +257,7 @@ function createFamilyRetryWorker({
           attemptId: target.attemptId,
           action: 'retried_ok',
           newAttempt: verdict.nextAttempt,
+          source, // W1254
         });
       } else {
         summary.failed += 1;
@@ -221,6 +271,7 @@ function createFamilyRetryWorker({
           action: 'retried_failed',
           newAttempt: verdict.nextAttempt,
           reason: target.failureReason,
+          source, // W1254
         });
       }
 

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1025,3 +1025,4 @@ __tests__/email-templates-wave1242.test.js
 __tests__/rehab-advanced-behavior-projection-wave1251.test.js
 __tests__/unified-care-plan-integrity-wave1252.test.js
 __tests__/overdue-scanner-unified-wave1253.test.js
+__tests__/family-retry-unified-wave1254.test.js

--- a/docs/DDD_VS_LEGACY_MODEL_SPLIT_2026-06-12.md
+++ b/docs/DDD_VS_LEGACY_MODEL_SPLIT_2026-06-12.md
@@ -150,6 +150,20 @@ approve the direction; the per-file re-point work is then mechanical and testabl
 > degrades to legacy-only). 5 new MMS tests + the original W50 suite green.
 > **Remaining re-points: family-retry worker (W45), plateau detector,
 > side-effects/audit-trail/hash-chain consumers, plan-recommendation.**
+>
+> ✅ **W1254 (2026-06-12): second prod-ON worker re-pointed + a latent
+> persistence bug root-fixed.** `familyNotifications[]` lifted field-for-field
+> onto `UnifiedCarePlan`; the W45 family-retry worker dual-scans (legacy
+> statuses unchanged; unified = active/under_review with a failed attempt),
+> `details[].source` tagging, fail-soft. **Root-fix:** the worker's real-model
+> path fetched candidates `.lean()`, so every retry mutation (retries++,
+> status flips, manual_override) hit a missing `.save()` and was silently
+> dropped — backoff/exhaustion state reset on every cron run (potential
+> notification spam). Candidates are now hydrated against real models while
+> legacy mock shapes are honored unchanged. 5 MMS tests (incl. persistence
+> proofs) + the original W50 suite green (38/38 across the worker suites).
+> **Remaining: plateau detector, side-effects/audit-trail/hash-chain
+> consumers, plan-recommendation.**
 
 ### 2c. CORRECTION (W1245) — the behavior row was mis-analysed; W1242 fixed an unused path
 


### PR DESCRIPTION
## W1254 - second prod-ON worker re-point (ADR-040 (b))

**Stacked on #442** (← #441 ← #440). Merge in chain order.

### What
- \amilyNotifications[]\ lifted **field-for-field** onto \UnifiedCarePlan\ (same enums/limits as CarePlanVersion) so the W45 retry logic is shared verbatim
- Worker: optional \unifiedPlanModel\ dep; dual scan — legacy statuses unchanged, unified = \ctive\/\under_review\ with a failed attempt; \details[].source\ tagging; fail-soft (unified errors never block the legacy scan)
- Lazy bootstrap wire-through (degrades to legacy-only)

### 🔴 Root-fix found during the re-point
The worker's **real-model path fetched candidates \.lean()\** — so every retry mutation (\etries++\, status flips, \manual_override\) hit \	ypeof pv.save === 'function'\ === false and was **silently dropped**. Against real data, backoff/exhaustion state reset on every 15-min cron run (notification-spam class). Candidates now hydrate against real models (mongoose Query thenable); the legacy test-mock shape (\{limit→lean}\) is honored unchanged.

### Tests — 38/38 across the worker suites
5 new MMS tests incl. **persistence proofs** (success/failure/exhaustion mutations survive a DB round-trip), backward-compat without the new dep, fail-soft. Original W50 suite + W1253 suite green.

### Remaining re-points
plateau detector → side-effects/audit-trail/hash-chain consumers → plan-recommendation.

Pushed with \CHECK_WAVE_SKIP=1\ (known historical merge-pair false positives).