### PR TITLE
feat(linkage): W1240 — beneficiary letters surface on the unified CareTimeline

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1707,6 +1707,8 @@ on:
       - 'backend/__tests__/cache-invalidation-basepath-wave1234.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/email-templates-wave1242.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/official-letter-timeline-linkage-wave1240.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3397,6 +3399,8 @@ on:
       - 'backend/__tests__/cache-invalidation-basepath-wave1234.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/email-templates-wave1242.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/official-letter-timeline-linkage-wave1240.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/official-letter-timeline-linkage-wave1240.test.js
+++ b/backend/__tests__/official-letter-timeline-linkage-wave1240.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+/**
+ * W1240 — OfficialLetter → unified core timeline linkage.
+ *
+ * Beneficiary letters are part of the beneficiary's story (golden-thread
+ * doctrine): issuing a registry letter for a beneficiary materialises one
+ * CareTimeline row (administrative/success), and revoking it materialises
+ * a second (administrative/warning). Employee letters never touch the
+ * timeline. Producer = native pre-compile post('save') hooks on
+ * OfficialLetter (W933 lesson); delivery = integrationBus → DDD
+ * cross-module subscriber.
+ *
+ * Async assertions use the W1227 poll-until pattern — never a fixed sleep.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const { CareTimeline } = require('../domains/timeline/models/CareTimeline');
+const { integrationBus } = require('../integration/systemIntegrationBus');
+const { initializeDDDSubscribers } = require('../integration/dddCrossModuleSubscribers');
+
+let OfficialLetter;
+let mongo;
+
+function issuer() {
+  return { userId: new mongoose.Types.ObjectId(), name: 'HR Tester' };
+}
+
+function beneficiarySubject(refId) {
+  return {
+    kind: 'beneficiary',
+    refId,
+    nameAr: 'مستفيد اختبار',
+    number: 'MRN-2026-0001',
+  };
+}
+
+/** Poll until `expected` rows exist (or timeout) — W1227 deflake pattern. */
+async function waitForRows(filter, expected, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  let rows = [];
+  for (;;) {
+    rows = await CareTimeline.find(filter).sort({ createdAt: 1 });
+    if (rows.length >= expected || Date.now() > deadline) return rows;
+    await new Promise(r => setTimeout(r, 25));
+  }
+}
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  OfficialLetter = require('../models/OfficialLetter');
+  await OfficialLetter.init();
+  await CareTimeline.init();
+  initializeDDDSubscribers(integrationBus);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+});
+
+afterEach(async () => {
+  await CareTimeline.deleteMany({});
+  await OfficialLetter.deleteMany({});
+  await OfficialLetter.OfficialLetterCounter.deleteMany({});
+});
+
+describe('W1240 OfficialLetter → CareTimeline', () => {
+  it('issuing a beneficiary letter records one administrative/success row', async () => {
+    const beneficiaryId = new mongoose.Types.ObjectId();
+    const letter = await OfficialLetter.issue({
+      letterType: 'beneficiary_certificate',
+      subject: beneficiarySubject(beneficiaryId),
+      issuer: issuer(),
+      branchId: new mongoose.Types.ObjectId(),
+    });
+
+    const rows = await waitForRows({ beneficiaryId }, 1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].eventType).toBe('official_letter_issued');
+    expect(rows[0].category).toBe('administrative');
+    expect(rows[0].severity).toBe('success');
+    expect(rows[0].title).toContain(letter.refNumber);
+    expect(rows[0].metadata.letterId).toBe(String(letter._id));
+  });
+
+  it('revoking the letter records a second warning row', async () => {
+    const beneficiaryId = new mongoose.Types.ObjectId();
+    const letter = await OfficialLetter.issue({
+      letterType: 'beneficiary_certificate',
+      subject: beneficiarySubject(beneficiaryId),
+      issuer: issuer(),
+    });
+    await waitForRows({ beneficiaryId }, 1);
+
+    letter.status = 'revoked';
+    letter.revokedAt = new Date();
+    letter.revokedBy = new mongoose.Types.ObjectId();
+    letter.revokeReason = 'خطاب تجريبي';
+    await letter.save();
+
+    const rows = await waitForRows({ beneficiaryId }, 2);
+    expect(rows).toHaveLength(2);
+    expect(rows[1].eventType).toBe('official_letter_revoked');
+    expect(rows[1].severity).toBe('warning');
+    expect(rows[1].metadata.revokeReason).toBe('خطاب تجريبي');
+  });
+
+  it('employee letters never touch the timeline', async () => {
+    const refId = new mongoose.Types.ObjectId();
+    await OfficialLetter.issue({
+      letterType: 'employment_certificate',
+      subject: {
+        kind: 'employee',
+        refId,
+        nameAr: 'موظف اختبار',
+        number: 'EMP-2026-0001',
+        jobTitle: 'أخصائي',
+      },
+      issuer: issuer(),
+    });
+    await new Promise(r => setTimeout(r, 150));
+
+    const rows = await CareTimeline.find({});
+    expect(rows).toHaveLength(0);
+  });
+
+  it('an unrelated later save of an issued letter does not duplicate the row', async () => {
+    const beneficiaryId = new mongoose.Types.ObjectId();
+    const letter = await OfficialLetter.issue({
+      letterType: 'beneficiary_certificate',
+      subject: beneficiarySubject(beneficiaryId),
+      issuer: issuer(),
+    });
+    await waitForRows({ beneficiaryId }, 1);
+
+    letter.addressee = 'جهة أخرى';
+    await letter.save();
+    await new Promise(r => setTimeout(r, 150));
+
+    const rows = await CareTimeline.find({ beneficiaryId });
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/backend/domains/timeline/models/CareTimeline.js
+++ b/backend/domains/timeline/models/CareTimeline.js
@@ -202,6 +202,8 @@ const careTimelineSchema = new mongoose.Schema(
         'clinical_risk_score_escalated',
         'corrective_action_opened',
         'complaint_resolved', // W1136 — beneficiary-linked complaint resolved → unified core
+        'official_letter_issued', // W1240 — registry letter issued for a beneficiary
+        'official_letter_revoked', // W1240 — registry letter revoked
         // Family
         'family_contact',
         'family_meeting',

--- a/backend/integration/dddCrossModuleSubscribers.js
+++ b/backend/integration/dddCrossModuleSubscribers.js
@@ -3337,6 +3337,56 @@ function initializeDDDSubscribers(integrationBus, _moduleConnector) {
   });
 
   subscribers.push({
+    name: 'official-letter:issued → timeline:record',
+    pattern: 'official-letter.official_letter.issued',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'official_letter_issued',
+            category: 'administrative',
+            severity: 'success',
+            title: `Official letter issued — ${event.payload.refNumber}`,
+            title_ar: `صدر خطاب رسمي للمستفيد (${event.payload.refNumber})`,
+            ...(event.payload.branchId ? { branchId: event.payload.branchId } : {}),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] OfficialLetter issued timeline failed: ${err.message}`);
+      }
+    },
+  });
+
+  subscribers.push({
+    name: 'official-letter:revoked → timeline:record',
+    pattern: 'official-letter.official_letter.revoked',
+    handler: async event => {
+      try {
+        const mongoose = require('mongoose');
+        const CareTimeline = mongoose.models.CareTimeline;
+        if (CareTimeline && event.payload.beneficiaryId) {
+          await CareTimeline.create({
+            beneficiaryId: event.payload.beneficiaryId,
+            eventType: 'official_letter_revoked',
+            category: 'administrative',
+            severity: 'warning',
+            title: `Official letter revoked — ${event.payload.refNumber}`,
+            title_ar: `أُبطل خطاب رسمي للمستفيد (${event.payload.refNumber})`,
+            ...(event.payload.branchId ? { branchId: event.payload.branchId } : {}),
+            metadata: event.payload,
+          });
+        }
+      } catch (err) {
+        logger.error(`[DDD-CrossModule] OfficialLetter revoked timeline failed: ${err.message}`);
+      }
+    },
+  });
+
+  subscribers.push({
     name: 'insurance-policy:activated → timeline:record',
     pattern: 'insurance-policy.insurance_policy.activated',
     handler: async event => {

--- a/backend/models/OfficialLetter.js
+++ b/backend/models/OfficialLetter.js
@@ -118,6 +118,46 @@ officialLetterSchema.pre('validate', async function () {
   }
 });
 
+// ── W1240 core-linkage: beneficiary letters surface on the unified
+// CareTimeline (golden-thread doctrine — every beneficiary milestone is
+// linked to the beneficiary + the timeline + time). Native pre-compile
+// hooks (W933 lesson: hooks added after mongoose.model() never fire);
+// publish is best-effort and never blocks the save.
+officialLetterSchema.pre('save', function flagLetterEvents() {
+  this.$__letterIssued = this.isNew;
+  this.$__letterRevoked =
+    !this.isNew && this.isModified('status') && this.status === 'revoked';
+});
+
+officialLetterSchema.post('save', function emitLetterEvents(doc) {
+  if (doc.subject?.kind !== 'beneficiary') return;
+  const issued = doc.$__letterIssued;
+  const revoked = doc.$__letterRevoked;
+  if (!issued && !revoked) return;
+  try {
+    const { integrationBus } = require('../integration/systemIntegrationBus');
+    const payload = {
+      letterId: String(doc._id),
+      refNumber: doc.refNumber,
+      letterType: doc.letterType,
+      beneficiaryId: String(doc.subject.refId),
+      subjectNameAr: doc.subject.nameAr,
+      ...(doc.branchId ? { branchId: String(doc.branchId) } : {}),
+    };
+    if (issued) {
+      integrationBus.publish('official-letter', 'official_letter.issued', payload);
+    }
+    if (revoked) {
+      integrationBus.publish('official-letter', 'official_letter.revoked', {
+        ...payload,
+        revokeReason: doc.revokeReason ?? null,
+      });
+    }
+  } catch (_err) {
+    /* best-effort: never block the save on bus failure */
+  }
+});
+
 /**
  * Atomically issue a letter: claim the next sequence for (type, year),
  * format the official reference number, and persist the snapshot.

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1022,3 +1022,4 @@ __tests__/session-therapy-projection-wave1240.test.js
 __tests__/behavior-incident-projection-wave1242.test.js
 __tests__/cache-invalidation-basepath-wave1234.test.js
 __tests__/email-templates-wave1242.test.js
+__tests__/official-letter-timeline-linkage-wave1240.test.js


### PR DESCRIPTION
Golden-thread doctrine: a registry letter issued **for a beneficiary** is part of their story (visible in /care/360).

- Native pre-compile `post('save')` hooks on `OfficialLetter` (W933 lesson) publish `official_letter.issued` / `.revoked` — **beneficiary-kind subjects only**, best-effort (never blocks the save).
- Two DDD cross-module subscribers materialise CareTimeline rows (administrative/success on issue, administrative/warning on revoke; ref number in title).
- `eventType` enum extended with both values.

Behavioral suite (real bus + subscriber, **W1227 poll-until — no fixed sleeps** on positive paths): issue→row, revoke→second row, employee letters never touch the timeline, unrelated saves don't duplicate. 4 tests + the 29 existing letters tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)