### PR TITLE
feat(care-plans): W1258 - close the ADR-040 (b) consumer map

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1724,6 +1724,8 @@ on:
       - 'backend/__tests__/plateau-detector-unified-wave1255.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/audit-trail-unified-wave1257.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/side-effects-entity-type-wave1258.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3431,6 +3433,8 @@ on:
       - 'backend/__tests__/plateau-detector-unified-wave1255.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/audit-trail-unified-wave1257.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/side-effects-entity-type-wave1258.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/side-effects-entity-type-wave1258.test.js
+++ b/backend/__tests__/side-effects-entity-type-wave1258.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * W1258 — closing the ADR-040 (b) consumer map.
+ *
+ * Audit findings encoded as tests:
+ *   1. The W45 side-effect handlers are DOC-AGNOSTIC — since W1254 they
+ *      receive UnifiedCarePlan docs via the family-retry worker. The audit
+ *      label must therefore be faithful per source (was hard-coded
+ *      'CarePlanVersion' for every entry).
+ *   2. UnifiedCarePlan has no familyVersion.body yet (the W43 family-version
+ *      generator was never ported) → the notify_family handler must SKIP
+ *      faithfully for unified docs (no fabricated family content), with the
+ *      correct entityType on the skip audit entry.
+ *   3. Legacy docs keep the exact pre-W1258 behavior + label.
+ */
+
+const {
+  createCarePlanSideEffectHandlers,
+  HANDLER_NAMES,
+} = require('../intelligence/care-plan-side-effects.service');
+
+function capture() {
+  const entries = [];
+  return { entries, auditLogger: { log: async e => entries.push(e) } };
+}
+
+const unifiedDoc = {
+  _id: 'u1',
+  planNumber: 'CP-20260612-XYZ',
+  version: 1,
+  status: 'active',
+};
+
+const legacyDoc = {
+  _id: 'l1',
+  planId: 'PLAN-9',
+  versionNumber: 3,
+  status: 'family_notification_sent',
+  familyVersion: { body: 'نسخة الأسرة المبسطة من الخطة' },
+};
+
+describe('W1258 side-effects entityType faithfulness', () => {
+  test('unified doc without familyVersion → faithful skip + UnifiedCarePlan label', async () => {
+    const cap = capture();
+    const handlers = createCarePlanSideEffectHandlers({ auditLogger: cap.auditLogger });
+    const res = await handlers[HANDLER_NAMES.NOTIFY_FAMILY]({
+      planVersion: unifiedDoc,
+      actor: { userId: 'sys', role: 'system' },
+      metadata: { channel: 'sms' },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('no_family_body'); // no fabricated family content
+    expect(cap.entries).toHaveLength(1);
+    expect(cap.entries[0].entityType).toBe('UnifiedCarePlan');
+    expect(cap.entries[0].action).toBe('care-plan.notify_family.side-effect.skipped');
+  });
+
+  test('legacy doc with family body + working channel → send + CarePlanVersion label', async () => {
+    const cap = capture();
+    const handlers = createCarePlanSideEffectHandlers({
+      auditLogger: cap.auditLogger,
+      familyChannelClient: { dispatch: async () => ({ ok: true }) },
+    });
+    const res = await handlers[HANDLER_NAMES.NOTIFY_FAMILY]({
+      planVersion: legacyDoc,
+      actor: { userId: 'sys', role: 'system' },
+      metadata: { channel: 'sms', recipient: '+9665xxxxxxx' },
+    });
+    expect(res.ok).toBe(true);
+    const main = cap.entries.find(e => e.action === 'care-plan.notify_family.side-effect');
+    expect(main).toBeDefined();
+    expect(main.entityType).toBe('CarePlanVersion');
+    expect(main.metadata.success).toBe(true);
+  });
+
+  test('manual-dispatch path labels the unified source too', async () => {
+    const cap = capture();
+    const handlers = createCarePlanSideEffectHandlers({ auditLogger: cap.auditLogger });
+    const res = await handlers[HANDLER_NAMES.NOTIFY_FAMILY]({
+      planVersion: { ...unifiedDoc, familyVersion: { body: 'محتوى' } }, // hypothetical future content
+      actor: { userId: 'sys', role: 'system' },
+      metadata: { channel: 'portal' },
+    });
+    expect(res.reason).toBe('manual_dispatch_required'); // no channel client wired
+    expect(cap.entries[0].entityType).toBe('UnifiedCarePlan');
+  });
+
+  test('entityType detection is conservative (ambiguous → CarePlanVersion)', async () => {
+    const cap = capture();
+    const handlers = createCarePlanSideEffectHandlers({ auditLogger: cap.auditLogger });
+    await handlers[HANDLER_NAMES.NOTIFY_FAMILY]({
+      planVersion: { _id: 'x', status: 'approved' }, // neither marker present
+      actor: null,
+      metadata: {},
+    });
+    expect(cap.entries[0].entityType).toBe('CarePlanVersion');
+  });
+});

--- a/backend/intelligence/care-plan-side-effects.service.js
+++ b/backend/intelligence/care-plan-side-effects.service.js
@@ -76,6 +76,16 @@ function createCarePlanSideEffectHandlers({
   logger = console,
   metrics = null,
 } = {}) {
+  // W1258 — handlers are doc-agnostic and (since W1254) receive UnifiedCarePlan
+  // docs through the family-retry worker; the audit label must stay faithful.
+  // Legacy docs carry versionNumber; unified docs carry planNumber/version.
+  function entityTypeOf(planVersion) {
+    if (!planVersion || typeof planVersion !== 'object') return 'CarePlanVersion';
+    if (planVersion.versionNumber != null) return 'CarePlanVersion';
+    if (planVersion.planNumber != null || planVersion.version != null) return 'UnifiedCarePlan';
+    return 'CarePlanVersion';
+  }
+
   async function _audit(action, metadata) {
     if (!auditLogger || typeof auditLogger.log !== 'function') return;
     try {
@@ -83,7 +93,7 @@ function createCarePlanSideEffectHandlers({
         action,
         actorUserId: metadata?.actor?.userId || null,
         actorRole: metadata?.actor?.role || null,
-        entityType: 'CarePlanVersion',
+        entityType: metadata?.entityType || 'CarePlanVersion', // W1258
         entityId: metadata?.planVersionId || null,
         metadata: metadata || {},
       });
@@ -311,6 +321,7 @@ function createCarePlanSideEffectHandlers({
     if (!body) {
       await _audit('care-plan.notify_family.side-effect.skipped', {
         planVersionId,
+        entityType: entityTypeOf(planVersion), // W1258
         reason: 'no_family_body',
       });
       return { ok: false, name: HANDLER_NAMES.NOTIFY_FAMILY, reason: 'no_family_body' };
@@ -320,6 +331,7 @@ function createCarePlanSideEffectHandlers({
       // No channel client wired — log a notification and return manual_override hint
       await _audit('care-plan.notify_family.side-effect.manual', {
         planVersionId,
+        entityType: entityTypeOf(planVersion), // W1258
         reason: 'no_family_channel_client',
       });
       return {
@@ -348,6 +360,7 @@ function createCarePlanSideEffectHandlers({
 
     await _audit('care-plan.notify_family.side-effect', {
       planVersionId,
+      entityType: entityTypeOf(planVersion), // W1258
       channel,
       success,
       attempt,

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1031,3 +1031,4 @@ __tests__/overdue-scanner-unified-wave1253.test.js
 __tests__/family-retry-unified-wave1254.test.js
 __tests__/plateau-detector-unified-wave1255.test.js
 __tests__/audit-trail-unified-wave1257.test.js
+__tests__/side-effects-entity-type-wave1258.test.js

--- a/docs/DDD_VS_LEGACY_MODEL_SPLIT_2026-06-12.md
+++ b/docs/DDD_VS_LEGACY_MODEL_SPLIT_2026-06-12.md
@@ -186,6 +186,25 @@ approve the direction; the per-file re-point work is then mechanical and testabl
 > redaction (clinical/family/executive). 5 tests incl. tamper flagging +
 > family redaction. **Remaining: side-effects consumers,
 > plan-recommendation.**
+>
+> ✅ **W1258 (2026-06-12): consumer map CLOSED.** Final audit findings:
+> **(a) side-effects** — the W45 handlers are doc-agnostic (no model reads;
+> they operate on the passed doc), so they have served UnifiedCarePlan since
+> W1254; the only inaccuracy was the audit label hard-coded to
+> 'CarePlanVersion' — now source-faithful via `entityTypeOf()` (legacy
+> carries versionNumber; unified carries planNumber/version; ambiguous →
+> legacy, conservative). **(b) plan-recommendation** — the builder is PURE
+> (reads only care-planning.registry, no model reads): **reclassified — not
+> a split.** Its UnifiedCarePlan integration is a future product feature.
+> **(c) family-version gap recorded:** UnifiedCarePlan has no
+> `familyVersion.body` (the W43 generator was never ported), so
+> notify_family faithfully SKIPS for unified plans (no fabricated family
+> content). Porting the W43 family-version generator to UnifiedCarePlan is
+> the one remaining **product feature** needed for end-to-end family
+> notifications on UI plans — a feature gap, not a data-visibility split.
+> 4 tests. **ADR-040 (b) consumer re-point map: COMPLETE** (integrity W1252,
+> scanner W1253, family-retry W1254, plateau W1255, audit-trail W1257,
+> side-effects W1258, plan-recommendation reclassified).
 
 ### 2c. CORRECTION (W1245) — the behavior row was mis-analysed; W1242 fixed an unused path
 


### PR DESCRIPTION
## W1258 - the final consumer item

### Audit findings (encoded as tests)
- **side-effects**: the W45 handlers are doc-agnostic — they have served \UnifiedCarePlan\ since W1254. Only inaccuracy: the audit label hard-coded \CarePlanVersion\. Now source-faithful via \entityTypeOf()\ (legacy carries \ersionNumber\; unified carries \planNumber\/\ersion\; ambiguous → legacy, conservative).
- **plan-recommendation**: audited **PURE** (registry-only reads, no model reads) — **reclassified: not a split**.
- **Recorded product gap**: \UnifiedCarePlan\ has no \amilyVersion.body\ (W43 generator never ported) → \
otify_family\ faithfully **skips** for unified plans (no fabricated family content). Porting the W43 family-version generator is the one remaining product feature for end-to-end family notifications on UI plans.

### Tests — 32/32 (4 new + W50 suite)

### 🏁 ADR-040 (b) consumer re-point map: COMPLETE
W1252 integrity → W1253 scanner → W1254 family-retry (+ lean root-fix) → W1255 plateau → W1257 audit-trail → W1258 side-effects (+ plan-recommendation reclassified).