### PR TITLE
feat(care-plans): W1260 - CarePlanVersion deprecation ratchet + ADR-041

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1730,6 +1730,8 @@ on:
       - 'backend/__tests__/email-migration-digests-wave1246.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/family-version-unified-wave1259.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/careplanversion-deprecation-ratchet-wave1260.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3443,6 +3445,8 @@ on:
       - 'backend/__tests__/email-migration-digests-wave1246.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/family-version-unified-wave1259.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/careplanversion-deprecation-ratchet-wave1260.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/careplanversion-deprecation-ratchet-wave1260.test.js
+++ b/backend/__tests__/careplanversion-deprecation-ratchet-wave1260.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+/**
+ * W1260 — CarePlanVersion deprecation ratchet (ADR-041).
+ *
+ * The owner approved UnifiedCarePlan as the canonical care plan (ADR-040
+ * option (b), 2026-06-12) and every consumer was re-pointed/dual-read in
+ * W1252-W1259. This guard makes the direction PERMANENT via the proven
+ * W325c/W340 ratchet pattern:
+ *
+ *   1. Any NEW functional consumer of CarePlanVersion (require of the model
+ *      file / mongoose model lookup) fails CI — new care-plan work must
+ *      target UnifiedCarePlan.
+ *   2. Any STALE baseline entry (consumer removed) fails CI — forcing the
+ *      baseline to ratchet DOWN in the same commit, until only the model
+ *      file remains and retirement (ADR-041 phase 3) can execute.
+ *
+ * Scope: FUNCTIONAL consumption only. `ref: 'CarePlanVersion'` cross-links
+ * (e.g. TransitionPlan's deliberate dual-link) and comments are NOT counted —
+ * they don't read/write the collection.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const BACKEND = path.join(__dirname, '..');
+
+const SCAN_ROOTS = [
+  'models',
+  'services',
+  'intelligence',
+  'routes',
+  'domains',
+  'startup',
+  'scheduler',
+  'controllers',
+  'middleware',
+  'workflow',
+  'events',
+  'integration',
+];
+
+const CONSUMER_RE =
+  /(require\(['"][^'"]*CarePlanVersion['"]\)|mongoose\.models?\.CarePlanVersion|model\(\s*['"]CarePlanVersion['"]\s*\))/;
+
+// ── Baseline (2026-06-12, W1260) — ratchet DOWN only ─────────────────
+// • models/CarePlanVersion.js        — the model itself (last to go)
+// • intelligence/care-plan-bootstrap.js — legacy W41-51 engine factory
+// • startup/carePlanningBootstrap.js — wires the engine (passes the model)
+// • startup/parentChatbotBootstrap.js — chatbot reads legacy plans
+const KNOWN_CONSUMERS_BASELINE = new Set([
+  'models/CarePlanVersion.js',
+  'intelligence/care-plan-bootstrap.js',
+  'startup/carePlanningBootstrap.js',
+  'startup/parentChatbotBootstrap.js',
+]);
+
+function scanConsumers() {
+  const hits = [];
+  function walk(dir) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (_e) {
+      return;
+    }
+    for (const e of entries) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (/node_modules|__tests__|archived|\.git/.test(e.name)) continue;
+        walk(p);
+      } else if (e.name.endsWith('.js')) {
+        const src = fs.readFileSync(p, 'utf8');
+        if (CONSUMER_RE.test(src)) {
+          hits.push(path.relative(BACKEND, p).split(path.sep).join('/'));
+        }
+      }
+    }
+  }
+  for (const r of SCAN_ROOTS) walk(path.join(BACKEND, r));
+  return hits;
+}
+
+describe('W1260 CarePlanVersion deprecation ratchet (ADR-041)', () => {
+  const found = scanConsumers();
+
+  test('no NEW functional consumers of the deprecated CarePlanVersion', () => {
+    const newcomers = found.filter(f => !KNOWN_CONSUMERS_BASELINE.has(f));
+    expect({
+      hint: 'CarePlanVersion is deprecated (ADR-041). New care-plan work targets UnifiedCarePlan. If this consumer is part of an approved retirement step, update the baseline in the SAME commit.',
+      newcomers,
+    }).toEqual({ hint: expect.any(String), newcomers: [] });
+  });
+
+  test('stale baseline entries must be pruned (ratchet DOWN)', () => {
+    const foundSet = new Set(found);
+    const stale = [...KNOWN_CONSUMERS_BASELINE].filter(f => !foundSet.has(f));
+    expect({
+      hint: 'A baseline consumer no longer references CarePlanVersion — remove it from KNOWN_CONSUMERS_BASELINE in this same commit (the whole point of the ratchet).',
+      stale,
+    }).toEqual({ hint: expect.any(String), stale: [] });
+  });
+
+  test('sanity — the scan sees the model file itself', () => {
+    expect(found).toContain('models/CarePlanVersion.js');
+  });
+
+  test('ADR-041 exists and records the deprecation', () => {
+    const adr = fs.readFileSync(
+      path.join(
+        BACKEND,
+        '..',
+        'docs',
+        'architecture',
+        'decisions',
+        '041-careplanversion-deprecation.md'
+      ),
+      'utf8'
+    );
+    expect(adr).toContain('UnifiedCarePlan');
+    expect(adr).toContain('W1260');
+  });
+});

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1034,3 +1034,4 @@ __tests__/audit-trail-unified-wave1257.test.js
 __tests__/side-effects-entity-type-wave1258.test.js
 __tests__/email-migration-digests-wave1246.test.js
 __tests__/family-version-unified-wave1259.test.js
+__tests__/careplanversion-deprecation-ratchet-wave1260.test.js

--- a/docs/architecture/decisions/041-careplanversion-deprecation.md
+++ b/docs/architecture/decisions/041-careplanversion-deprecation.md
@@ -1,0 +1,61 @@
+# ADR-041 — CarePlanVersion deprecation (UnifiedCarePlan canonical)
+
+**Status:** ✅ Accepted (owner-approved 2026-06-12) · **Wave:** W1260 ·
+**Supersedes context:** ADR-040 (goal consolidation), the W1238-W1244
+DDD-vs-legacy split audit, and the W1252-W1259 re-point series.
+
+## Decision
+
+`UnifiedCarePlan` (`domains/care-plans`) is the **single canonical care-plan
+model**. `CarePlanVersion` (W41-51) is **deprecated**: no new functional
+consumers may be added. Enforced by the W1260 ratchet guard
+(`__tests__/careplanversion-deprecation-ratchet-wave1260.test.js`).
+
+## Why option (b) won (recorded from W1244, owner-approved)
+
+1. **ADR-040 alignment** — `TherapeuticGoal` is the canonical goal;
+   `UnifiedCarePlan` references it, while `CarePlanVersion` embeds a second
+   copy of goal detail (the duplication ADR-040 removed).
+2. **Zero data cost** — both collections were empty in prod (W1235).
+3. **The UI + 360 already author/read `UnifiedCarePlan`** — no rework of the
+   live data-entry spine.
+
+## What was lifted/re-pointed (all merged to main 2026-06-12)
+
+| Wave  | What                                                                                                                                |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| W1252 | Integrity layer: hash-chained `signatureChain` + `evidenceHash` (immutable once set); `activatePlan` records the activate signature |
+| W1253 | W50 overdue-review scanner dual-scans (legacy + unified, source-tagged, fail-soft)                                                  |
+| W1254 | W45 family-retry worker dual-scans + `familyNotifications[]` lifted + the `.lean()` persistence root-fix                            |
+| W1255 | Plateau detector dual-reviews; `lastPlateauReviewAt` cadence stamp                                                                  |
+| W1257 | Audit trail: `buildUnifiedAuditTrail` + `GET /care-plans/:id/audit-trail` (PDPL Art.13, role redaction)                             |
+| W1258 | Side-effects audit label source-faithful (`entityTypeOf`); plan-recommendation audited PURE → reclassified, not a split             |
+| W1259 | W43 family-version generator: unified adapter + `familyVersion` storage at activation behind the deterministic safety floor         |
+
+## Functional-consumer baseline at deprecation (W1260)
+
+`models/CarePlanVersion.js` (the model itself) ·
+`intelligence/care-plan-bootstrap.js` ·
+`startup/carePlanningBootstrap.js` ·
+`startup/parentChatbotBootstrap.js`
+
+`ref: 'CarePlanVersion'` cross-links (e.g. `TransitionPlan`'s deliberate
+dual-link) are populate-only and out of ratchet scope.
+
+## Retirement plan (phases — each is its own wave, ratchet enforces order)
+
+1. **DONE** — dual-read everywhere the prod-ON intelligence consumes plans.
+2. **Freeze** (this ADR) — no new consumers; baseline ratchets DOWN only.
+3. **Retire the legacy authoring engine** — once confirmed the legacy
+   `/api/care-plan` W42 surface has no callers in prod telemetry, unwire
+   `care-plan-bootstrap` (the workers already read unified) and prune the
+   two startup consumers from the baseline.
+4. **Drop the model** — verify `care_plan_versions` is empty in prod, archive
+   the collection, delete `models/CarePlanVersion.js`, prune the final
+   baseline entry, and delete this guard's baseline (guard then asserts
+   zero consumers forever).
+
+## Rollback
+
+Phases 2-3 are reversible (re-add baseline entries with a justifying commit).
+Phase 4 requires the archived collection dump.


### PR DESCRIPTION
## W1260 - making the migration direction permanent

With the W1252-W1259 chain merged, this freezes \CarePlanVersion\ via the proven W325c/W340 ratchet pattern:

- Guard scans **functional consumers only** (require / model lookup; \ef:\ cross-links and comments out of scope) — exactly **4** at freeze: the model file, the legacy engine factory, and two startup wirings
- Any NEW consumer fails CI (new care-plan work must target \UnifiedCarePlan\); any STALE baseline entry forces ratchet-DOWN in the same commit
- **ADR-041** records the owner-approved decision, the full lift map, the baseline, and the 4-phase retirement plan (freeze → unwire legacy engine → drop model)

4/4 tests. Sprint-enumerated.