### PR TITLE
fix(parent-portal): W1272 - parents see canonical plans + the family version

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1740,6 +1740,8 @@ on:
       - 'backend/__tests__/care-plan-from-proposal-wave1266.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/center-ops-wave1269.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/portal-plan-mapper-wave1272.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3463,6 +3465,8 @@ on:
       - 'backend/__tests__/care-plan-from-proposal-wave1266.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/center-ops-wave1269.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/portal-plan-mapper-wave1272.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/portal-plan-mapper-wave1272.test.js
+++ b/backend/__tests__/portal-plan-mapper-wave1272.test.js
@@ -1,0 +1,116 @@
+'use strict';
+
+/**
+ * W1272 — parents see canonical plans + the family version in their portal.
+ *
+ *   1. PURE MAPPER — UnifiedCarePlan → the portal's public payload: goals
+ *      flattened across all section groups + globalGoals, lowercase statuses
+ *      mapped to the portal vocabulary, family-only fields exposed and
+ *      clinician-internal fields NEVER leaked.
+ *   2. ROUTE GUARD — the portal endpoint reads UnifiedCarePlan FIRST
+ *      (fail-soft) and keeps the legacy branch as fallback.
+ */
+
+const {
+  mapUnifiedPlanToPortalPayload,
+  GOAL_STATUS_PUBLIC,
+} = require('../intelligence/portal-plan-mapper.lib');
+
+const fs = require('fs');
+const path = require('path');
+const routeSrc = fs.readFileSync(
+  path.join(__dirname, '..', 'routes', 'parent-portal-v1.routes.js'),
+  'utf8'
+);
+
+function fixturePlan() {
+  return {
+    _id: 'p1',
+    planNumber: 'CP-20260612-AB',
+    title_ar: 'خطة محمد الشاملة',
+    status: 'active',
+    startDate: new Date('2026-06-01'),
+    nextReviewDate: new Date('2026-07-15'),
+    therapeutic: {
+      domains: {
+        speech: {
+          goals: [
+            {
+              _id: 'g1',
+              title: 'ينطق الأصوات الأولى',
+              status: 'in_progress',
+              notes: 'ملاحظة سريرية داخلية',
+            },
+          ],
+        },
+      },
+    },
+    lifeSkills: {
+      domains: {
+        selfCare: { goals: [{ _id: 'g2', title: 'يغسل يديه', status: 'achieved' }] },
+      },
+    },
+    globalGoals: [{ _id: 'g3', title: 'يطلب حاجته', status: 'pending' }],
+    familyVersion: {
+      body: '‫# خطة محمد\\n\\nمرحبًا بكم…',
+      readabilityGrade: 6,
+      generatedAt: new Date(),
+    },
+  };
+}
+
+describe('W1272 pure mapper', () => {
+  const out = mapUnifiedPlanToPortalPayload(fixturePlan());
+
+  test('goals flattened across sections + globals with public statuses', () => {
+    expect(out.goals).toHaveLength(3);
+    const byId = Object.fromEntries(out.goals.map(g => [g.id, g]));
+    expect(byId.g1.status).toBe('IN_PROGRESS');
+    expect(byId.g1.priority).toBe('HIGH'); // speech section
+    expect(byId.g2.status).toBe('ACHIEVED'); // lifeSkills now visible to parents
+    expect(byId.g3.status).toBe('NOT_STARTED');
+  });
+
+  test('family version rides along; payload shape matches the legacy branch', () => {
+    expect(out.familyVersion).toContain('خطة محمد');
+    expect(out.summary).toBe('خطة محمد الشاملة');
+    expect(out.status).toBe('ACTIVE');
+    expect(out.startDate).toBe('2026-06-01');
+    expect(out.endDate).toBe('2026-07-15');
+    expect(out.source).toBe('unified');
+  });
+
+  test('clinician-internal fields never leak to families', () => {
+    const json = JSON.stringify(out);
+    expect(json).not.toContain('ملاحظة سريرية'); // goal notes stripped
+    expect(json).not.toContain('signatureChain');
+    expect(json).not.toContain('evidence');
+  });
+
+  test('every mapped status value is a known public token', () => {
+    for (const v of Object.values(GOAL_STATUS_PUBLIC)) {
+      expect(['NOT_STARTED', 'IN_PROGRESS', 'ACHIEVED', 'ON_HOLD']).toContain(v);
+    }
+  });
+
+  test('invalid input → null (route falls through to legacy)', () => {
+    expect(mapUnifiedPlanToPortalPayload(null)).toBeNull();
+  });
+});
+
+describe('W1272 route wiring guard', () => {
+  test('portal endpoint reads UnifiedCarePlan FIRST, fail-soft, legacy kept', () => {
+    expect(routeSrc).toContain('mapUnifiedPlanToPortalPayload');
+    expect(routeSrc).toContain("status: { $in: ['active', 'under_review'] }");
+    // legacy fallback retained verbatim
+    expect(routeSrc).toContain(
+      "CarePlan.findOne({ beneficiary: req.params.id, status: 'ACTIVE' })"
+    );
+    // the unified read sits INSIDE the ownership-checked handler (after the
+    // guardianOwnsBeneficiary 404), never before it
+    const ownershipIdx = routeSrc.indexOf('guardianOwnsBeneficiary(userId, req.params.id)');
+    const unifiedIdx = routeSrc.indexOf('mapUnifiedPlanToPortalPayload');
+    expect(ownershipIdx).toBeGreaterThan(-1);
+    expect(unifiedIdx).toBeGreaterThan(ownershipIdx);
+  });
+});

--- a/backend/intelligence/portal-plan-mapper.lib.js
+++ b/backend/intelligence/portal-plan-mapper.lib.js
@@ -1,0 +1,100 @@
+'use strict';
+
+/**
+ * portal-plan-mapper.lib.js — W1272.
+ *
+ * PURE mapper: UnifiedCarePlan → the parent-portal care-plan payload.
+ *
+ * Why: the portal's GET /beneficiaries/:id/care-plan read ONLY the legacy
+ * `CarePlan` model — so a parent of a beneficiary whose plan was authored
+ * through the UI (UnifiedCarePlan, the canonical model per ADR-041) saw
+ * "no active care plan", and the W1259 family version never reached the
+ * family's own portal. This mapper feeds the same public payload shape the
+ * portal UI already renders, plus the family-version markdown.
+ *
+ * Public-vocabulary guarantees (what families may see):
+ *   • goal titles + coarse status only — no clinician notes, no `why`,
+ *     no provenance, no evidence internals.
+ *   • familyVersion.body is the W43-generator output that already passed
+ *     the deterministic safety floor (readability + forbidden-term checks).
+ */
+
+const GOAL_STATUS_PUBLIC = Object.freeze({
+  pending: 'NOT_STARTED',
+  in_progress: 'IN_PROGRESS',
+  achieved: 'ACHIEVED',
+  discontinued: 'ON_HOLD',
+  modified: 'IN_PROGRESS',
+});
+
+// Section paths mirror the legacy portal flattening + the lifeSkills group
+// UnifiedCarePlan added; globalGoals are appended with MEDIUM priority.
+const UNIFIED_GOAL_PATHS = Object.freeze([
+  ['educational.domains.academic.goals', 'MEDIUM'],
+  ['educational.domains.classroom.goals', 'MEDIUM'],
+  ['educational.domains.communication.goals', 'HIGH'],
+  ['therapeutic.domains.speech.goals', 'HIGH'],
+  ['therapeutic.domains.occupational.goals', 'HIGH'],
+  ['therapeutic.domains.physical.goals', 'MEDIUM'],
+  ['therapeutic.domains.behavioral.goals', 'HIGH'],
+  ['therapeutic.domains.psychological.goals', 'HIGH'],
+  ['lifeSkills.domains.selfCare.goals', 'HIGH'],
+  ['lifeSkills.domains.homeSkills.goals', 'MEDIUM'],
+  ['lifeSkills.domains.social.goals', 'MEDIUM'],
+  ['lifeSkills.domains.transport.goals', 'LOW'],
+  ['lifeSkills.domains.financial.goals', 'LOW'],
+  ['lifeSkills.domains.vocational.goals', 'MEDIUM'],
+]);
+
+function _dig(obj, dotted) {
+  let cursor = obj;
+  for (const k of dotted.split('.')) {
+    cursor = cursor == null ? undefined : cursor[k];
+    if (cursor == null) return undefined;
+  }
+  return cursor;
+}
+
+function _publicGoal(g, priority) {
+  return {
+    id: String(g._id || ''),
+    nameAr: g.title || '—',
+    status: GOAL_STATUS_PUBLIC[g.status] || 'NOT_STARTED',
+    priority,
+  };
+}
+
+/**
+ * @param {Object} plan — a UnifiedCarePlan doc/lean object
+ * @returns the portal payload (same shape the legacy branch returns,
+ *          + familyVersion + source)
+ */
+function mapUnifiedPlanToPortalPayload(plan) {
+  if (!plan || typeof plan !== 'object') return null;
+  const src = typeof plan.toObject === 'function' ? plan.toObject() : plan;
+
+  const goals = [];
+  for (const [path, priority] of UNIFIED_GOAL_PATHS) {
+    const arr = _dig(src, path);
+    if (Array.isArray(arr)) for (const g of arr) goals.push(_publicGoal(g, priority));
+  }
+  for (const g of src.globalGoals || []) goals.push(_publicGoal(g, 'MEDIUM'));
+
+  return {
+    id: String(src._id || ''),
+    summary: src.title_ar || (src.planNumber ? `خطة رقم ${src.planNumber}` : null),
+    status: String(src.status || 'draft').toUpperCase(),
+    startDate: src.startDate ? new Date(src.startDate).toISOString().slice(0, 10) : '',
+    endDate: src.nextReviewDate ? new Date(src.nextReviewDate).toISOString().slice(0, 10) : null,
+    goals,
+    // W1259 family version — already safety-floor-gated at generation time.
+    familyVersion: (src.familyVersion && src.familyVersion.body) || null,
+    source: 'unified',
+  };
+}
+
+module.exports = {
+  mapUnifiedPlanToPortalPayload,
+  GOAL_STATUS_PUBLIC,
+  UNIFIED_GOAL_PATHS,
+};

--- a/backend/routes/parent-portal-v1.routes.js
+++ b/backend/routes/parent-portal-v1.routes.js
@@ -448,6 +448,26 @@ router.get('/beneficiaries/:id/care-plan', authenticate, async (req, res) => {
       return res.status(404).json({ error: 'NotFound', message: 'not found' });
     }
 
+    // ── W1272: the canonical UnifiedCarePlan FIRST (ADR-041) ───────────
+    // The UI authors UnifiedCarePlan; reading only the legacy CarePlan left
+    // parents seeing "no active care plan" for real plans — and the W1259
+    // family version never reached the family's own portal. Fail-soft:
+    // any error here falls through to the legacy branch unchanged.
+    try {
+      const { UnifiedCarePlan } = require('../domains/care-plans/models/UnifiedCarePlan');
+      const { mapUnifiedPlanToPortalPayload } = require('../intelligence/portal-plan-mapper.lib');
+      const uPlan = await UnifiedCarePlan.findOne({
+        beneficiaryId: req.params.id,
+        isDeleted: { $ne: true },
+        status: { $in: ['active', 'under_review'] },
+      })
+        .sort({ createdAt: -1 })
+        .lean();
+      if (uPlan) return res.json(mapUnifiedPlanToPortalPayload(uPlan));
+    } catch (_e) {
+      /* fall through to legacy */
+    }
+
     const CarePlan = require('../models/CarePlan');
     const plan = await CarePlan.findOne({ beneficiary: req.params.id, status: 'ACTIVE' }).lean();
     if (!plan)

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1039,3 +1039,4 @@ __tests__/smartreport-clinical-assessments-wave1261.test.js
 __tests__/care-plan-composer-wave1264.test.js
 __tests__/care-plan-from-proposal-wave1266.test.js
 __tests__/center-ops-wave1269.test.js
+__tests__/portal-plan-mapper-wave1272.test.js


### PR DESCRIPTION
## W1272 - a NEW split found and closed (the W1239 trace applied to the parent portal)

The portal's \GET /beneficiaries/:id/care-plan\ read **only the legacy \CarePlan\** — a parent of a UI-authored (\UnifiedCarePlan\) plan saw *'no active care plan'*, and the W1259 family version never reached the family's own portal.

### What
- \intelligence/portal-plan-mapper.lib.js\ — PURE mapper to the portal's public payload: goals flattened across all section groups (incl. the new lifeSkills) + globalGoals; lowercase→public status map; \amilyVersion.body\ rides along (already safety-floor-gated at generation). **Clinician-internal fields (notes/why/evidence/signatures) never leak — proven by test.**
- Portal endpoint: UnifiedCarePlan FIRST (active/under_review, newest), **fail-soft**, legacy branch retained verbatim; the unified read sits strictly AFTER the guardian-ownership 404 (W411 doctrine — guarded by test).

### Tests — 6/6 (mapper + route wiring guard). Sprint-enumerated.