### PR TITLE
fix(parent-v2): W1273 - the MOBILE parent surface sees canonical plans

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1742,6 +1742,8 @@ on:
       - 'backend/__tests__/center-ops-wave1269.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/portal-plan-mapper-wave1272.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/parent-v2-unified-plan-wave1273.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3467,6 +3469,8 @@ on:
       - 'backend/__tests__/center-ops-wave1269.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/portal-plan-mapper-wave1272.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/parent-v2-unified-plan-wave1273.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/parent-v2-unified-plan-wave1273.test.js
+++ b/backend/__tests__/parent-v2-unified-plan-wave1273.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+/**
+ * W1273 — the MOBILE app's parent surface sees canonical plans.
+ *
+ * Same split the W1272 fix closed in v1, found in parent-portal-v2 (the
+ * /parent-v2 mount the mobile app consumes). Static wiring guard:
+ *   1. The care-plan handler reads UnifiedCarePlan FIRST, fail-soft, with
+ *      the legacy branch retained verbatim.
+ *   2. The unified read sits strictly AFTER the assertChildAccess gate.
+ *   3. Shape compatibility tokens the mobile client depends on are present
+ *      in the unified branch (planNumber/sections/goals/totalGoals/
+ *      achievedGoals) + the additive W1259 familyVersion.
+ *   4. The overview's activeCarePlans counts BOTH models.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(
+  path.join(__dirname, '..', 'routes', 'parent-portal-v2.routes.js'),
+  'utf8'
+);
+
+describe('W1273 parent-v2 unified-first care plan', () => {
+  test('unified read present, fail-soft, legacy fallback retained', () => {
+    expect(src).toContain("require('../domains/care-plans/models/UnifiedCarePlan')");
+    expect(src).toContain("status: { $in: ['active', 'under_review'] }");
+    expect(src).toContain("CarePlan.findOne({ beneficiary: req.params.id, status: 'ACTIVE' })");
+  });
+
+  test('unified read sits AFTER the child-access gate', () => {
+    const handlerIdx = src.indexOf("'/children/:id/care-plan'");
+    const gateIdx = src.indexOf('assertChildAccess', handlerIdx);
+    const unifiedIdx = src.indexOf('UnifiedCarePlan.findOne', handlerIdx);
+    expect(gateIdx).toBeGreaterThan(handlerIdx);
+    expect(unifiedIdx).toBeGreaterThan(gateIdx);
+  });
+
+  test('mobile shape compatibility + additive familyVersion', () => {
+    const handler = src.slice(src.indexOf("'/children/:id/care-plan'"));
+    for (const token of [
+      'planNumber:',
+      'sections:',
+      'totalGoals:',
+      'achievedGoals:',
+      'familyVersion: (uPlan.familyVersion && uPlan.familyVersion.body) || null',
+      "source: 'unified'",
+    ]) {
+      expect(handler).toContain(token);
+    }
+  });
+
+  test('overview activeCarePlans counts BOTH models', () => {
+    expect(src).toContain('UnifiedCarePlan.countDocuments');
+    expect(src).toContain('return legacy + unified');
+  });
+});

--- a/backend/routes/parent-portal-v2.routes.js
+++ b/backend/routes/parent-portal-v2.routes.js
@@ -248,7 +248,24 @@ router.get('/children/:id/overview', async (req, res) => {
           date: { $gte: now, $lte: weekAhead },
           status: { $in: ['SCHEDULED', 'CONFIRMED'] },
         }),
-        CarePlan.countDocuments({ beneficiary: req.params.id, status: 'ACTIVE' }),
+        // W1273 — count BOTH care-plan models (legacy + canonical unified)
+        (async () => {
+          const legacy = await CarePlan.countDocuments({
+            beneficiary: req.params.id,
+            status: 'ACTIVE',
+          });
+          try {
+            const { UnifiedCarePlan } = require('../domains/care-plans/models/UnifiedCarePlan');
+            const unified = await UnifiedCarePlan.countDocuments({
+              beneficiaryId: req.params.id,
+              isDeleted: { $ne: true },
+              status: { $in: ['active', 'under_review'] },
+            });
+            return legacy + unified;
+          } catch (_e) {
+            return legacy;
+          }
+        })(),
         ClinicalAssessment.countDocuments({ beneficiary: req.params.id }),
         ClinicalAssessment.findOne({ beneficiary: req.params.id })
           .sort({ assessmentDate: -1 })
@@ -309,6 +326,78 @@ router.get('/children/:id/care-plan', async (req, res) => {
   try {
     const check = await assertChildAccess(req, req.params.id);
     if (!check.ok) return res.status(check.status).json({ success: false, message: check.msg });
+
+    // ── W1273: the canonical UnifiedCarePlan FIRST (ADR-041) — same split
+    // the W1272 fix closed in v1; v2 is what the MOBILE app consumes.
+    // Shape-compatible payload (mobile keeps working unchanged) + the
+    // W1259 family version rides along additively. Fail-soft to legacy.
+    try {
+      const { UnifiedCarePlan } = require('../domains/care-plans/models/UnifiedCarePlan');
+      const uPlan = await UnifiedCarePlan.findOne({
+        beneficiaryId: req.params.id,
+        isDeleted: { $ne: true },
+        status: { $in: ['active', 'under_review'] },
+      })
+        .sort({ createdAt: -1 })
+        .lean();
+      if (uPlan) {
+        const collect = [];
+        for (const section of ['educational', 'therapeutic', 'lifeSkills']) {
+          const sec = uPlan[section];
+          if (!sec || !sec.domains) continue;
+          for (const [domKey, dom] of Object.entries(sec.domains)) {
+            if (!dom || !Array.isArray(dom.goals) || dom.goals.length === 0) continue;
+            for (const g of dom.goals) {
+              collect.push({
+                section,
+                domain: domKey,
+                title: g.title,
+                type: g.type,
+                status: String(g.status || 'pending').toUpperCase(),
+                progress: g.progress || 0,
+                target: g.target,
+                criteria: g.criteria,
+                targetDate: null,
+              });
+            }
+          }
+        }
+        for (const g of uPlan.globalGoals || []) {
+          collect.push({
+            section: 'global',
+            domain: 'global',
+            title: g.title,
+            type: g.type,
+            status: String(g.status || 'pending').toUpperCase(),
+            progress: g.progress || 0,
+            target: g.target,
+            criteria: g.criteria,
+            targetDate: null,
+          });
+        }
+        return res.json({
+          success: true,
+          data: {
+            planNumber: uPlan.planNumber,
+            startDate: uPlan.startDate,
+            reviewDate: uPlan.nextReviewDate || uPlan.reviewDate || null,
+            status: String(uPlan.status || 'draft').toUpperCase(),
+            sections: {
+              educational: !!(uPlan.educational && uPlan.educational.domains),
+              therapeutic: !!(uPlan.therapeutic && uPlan.therapeutic.domains),
+              lifeSkills: !!(uPlan.lifeSkills && uPlan.lifeSkills.domains),
+            },
+            goals: collect,
+            totalGoals: collect.length,
+            achievedGoals: collect.filter(g => g.status === 'ACHIEVED').length,
+            familyVersion: (uPlan.familyVersion && uPlan.familyVersion.body) || null, // W1259
+            source: 'unified',
+          },
+        });
+      }
+    } catch (_e) {
+      /* fall through to legacy */
+    }
 
     const plan =
       (await CarePlan.findOne({ beneficiary: req.params.id, status: 'ACTIVE' })

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1040,3 +1040,4 @@ __tests__/care-plan-composer-wave1264.test.js
 __tests__/care-plan-from-proposal-wave1266.test.js
 __tests__/center-ops-wave1269.test.js
 __tests__/portal-plan-mapper-wave1272.test.js
+__tests__/parent-v2-unified-plan-wave1273.test.js


### PR DESCRIPTION
## W1273 - the W1272 split, found again on the mobile path

\parent-portal-v2\ (the \/parent-v2\ mount the **mobile app** consumes) read only legacy \CarePlan\ in both the care-plan handler and the overview's \ctiveCarePlans\ count.

- Care-plan handler: \UnifiedCarePlan\ FIRST — **shape-compatible payload** (mobile keeps working unchanged; statuses uppercased so its achieved-counting holds) + additive W1259 \amilyVersion\ + \source\ tag; fail-soft; legacy retained verbatim; unified read strictly AFTER \ssertChildAccess\ (guarded by test)
- Overview: \ctiveCarePlans\ = legacy + unified (fail-soft)

4/4 wiring-guard tests. With W1272 (v1) + this (v2/mobile), **every family-facing surface now sees canonical plans + the family version.**