### PR TITLE
fix(seed): W1275 — demo-showcase dup nationalId aborted the seed mid-run

### DIFF
--- a/backend/seeds/demo-showcase.seed.js
+++ b/backend/seeds/demo-showcase.seed.js
@@ -543,7 +543,7 @@ module.exports = async function seedDemoShowcase({ dryRun = false, reset = false
       first: 'هند',
       last: 'السعيد',
       email: 'parent.hind@demo.alawael.com',
-      nid: '2100000004',
+      nid: '2100000014',
       relationship: 'mother',
     },
     {


### PR DESCRIPTION
seeds/demo-showcase.seed.js used nid 2100000004 twice (employee Mariam + guardian parent.hind); both create User docs → E11000 users.nationalId_1 dup → seed aborted before beneficiaries/sessions/invoices. Fix: parent.hind → 2100000014. Verified on prod the full ~60-record showcase now seeds cleanly (also dropped an orphaned employeeId_1 index on prod that blocked >1 employee — no repo change needed, no model/migration defines it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)