### PR TITLE
W1270: EmailManager registry bridge (10 legacy keys) + notify-channel migration

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1744,6 +1744,8 @@ on:
       - 'backend/__tests__/portal-plan-mapper-wave1272.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/parent-v2-unified-plan-wave1273.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/email-registry-bridge-wave1270.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3471,6 +3473,8 @@ on:
       - 'backend/__tests__/portal-plan-mapper-wave1272.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/parent-v2-unified-plan-wave1273.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/email-registry-bridge-wave1270.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/email-registry-bridge-wave1270.test.js
+++ b/backend/__tests__/email-registry-bridge-wave1270.test.js
@@ -1,0 +1,139 @@
+'use strict';
+
+/**
+ * W1270 — EmailManager → registry bridge + notify-channel migration.
+ *
+ *  1. BRIDGE — every mapped legacy key renders through the registry from a
+ *     realistic legacy data shape; an UNSATISFIABLE shape returns null
+ *     (legacy fallback) instead of throwing; unmapped keys return null.
+ *  2. EmailManager.sendTemplate consults the bridge BEFORE the legacy engine
+ *     (static) and tags metadata.registryBridge.
+ *  3. notify-channel-email: zero inline HTML left; renders via the new
+ *     MEASURE_ALERT_REASSIGNED template with direction semantics preserved
+ *     (from/to) — behavioral through the exported _renderEmail.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const BACKEND = path.join(__dirname, '..');
+const read = (rel) => fs.readFileSync(path.join(BACKEND, rel), 'utf8');
+
+const { BRIDGE, tryRegistryRender } = require('../services/email/registryBridge');
+
+describe('W1270 bridge — legacy keys render through the registry', () => {
+  const HAPPY = {
+    WELCOME: { email: 'u@x.sa', name: 'سارة' },
+    OTP_CODE: { email: 'u@x.sa', otp: '123456', expiry: 10 },
+    APPOINTMENT_REMINDER: {
+      beneficiaryName: 'محمد',
+      serviceType: 'نطق',
+      therapistName: 'أ. ريم',
+      date: '2026-06-15',
+      time: '10:30',
+    },
+    APPOINTMENT_CANCELLATION: {
+      beneficiaryName: 'محمد',
+      serviceType: 'نطق',
+      date: '2026-06-15',
+      time: '10:30',
+    },
+    SESSION_SUMMARY: {
+      beneficiaryName: 'محمد',
+      serviceType: 'نطق',
+      therapistName: 'أ. ريم',
+      summary: 'عمل ممتاز اليوم على المفردات',
+    },
+    INVOICE: { customerName: 'أ. سعود', invoiceNumber: 'INV-1', amount: '2400', dueDate: '2026-06-25' },
+    PAYMENT_CONFIRMATION: { customerName: 'أ. سعود', amount: '2400', receiptNumber: 'RC-1' },
+    NEW_COMMUNICATION: { title: 'تعميم', referenceNumber: 'C-1', senderName: 'HR', subject: 'نص' },
+    APPROVAL_REQUEST: {
+      title: 'اعتماد',
+      referenceNumber: 'C-2',
+      stageName: 'مدير',
+      subject: 'نص',
+      approveUrl: 'https://x/a',
+      rejectUrl: 'https://x/r',
+    },
+    STATUS_CHANGE: { title: 'طلب', referenceNumber: 'C-3', oldStatus: 'قيد', newStatus: 'مكتمل' },
+  };
+
+  test('every mapped key has a happy-path fixture in this guard (closed list)', () => {
+    expect(Object.keys(HAPPY).sort()).toEqual(Object.keys(BRIDGE).sort());
+  });
+
+  for (const [legacyKey, data] of Object.entries(HAPPY)) {
+    test(`${legacyKey} → ${BRIDGE[legacyKey].key} renders (rtl + text alt)`, () => {
+      const out = tryRegistryRender(legacyKey, data);
+      expect(out).not.toBeNull();
+      expect(out.key).toBe(BRIDGE[legacyKey].key);
+      expect(out.html).toContain('dir="rtl"');
+      expect(out.text.length).toBeGreaterThan(10);
+      expect(out.html).not.toMatch(/\{\{\s*[A-Za-z_]/);
+    });
+  }
+
+  test('unsatisfiable data → null (legacy fallback), never a throw', () => {
+    expect(tryRegistryRender('APPOINTMENT_REMINDER', { foo: 'bar' })).toBeNull();
+    expect(tryRegistryRender('INVOICE', {})).toBeNull();
+  });
+
+  test('unmapped legacy keys → null untouched', () => {
+    expect(tryRegistryRender('EMAIL_VERIFICATION', { email: 'a@b.c' })).toBeNull();
+    expect(tryRegistryRender('TOTALLY_UNKNOWN', {})).toBeNull();
+  });
+
+  test('OTP bridge maps expiry → expiryMinutes into the reset copy', () => {
+    const out = tryRegistryRender('OTP_CODE', { email: 'u@x.sa', otp: '99', expiry: 7 });
+    expect(out.subject).toContain('7');
+    expect(out.html).toContain('99');
+  });
+});
+
+describe('W1270 static wiring', () => {
+  test('EmailManager.sendTemplate consults the bridge BEFORE the legacy engine', () => {
+    const src = read('services/email/EmailManager.js');
+    const fnStart = src.indexOf('async sendTemplate(');
+    const block = src.slice(fnStart, fnStart + 1600);
+    const bridgeIdx = block.indexOf('tryRegistryRender');
+    const legacyIdx = block.indexOf('this.templateEngine.render');
+    expect(bridgeIdx).toBeGreaterThan(-1);
+    expect(legacyIdx).toBeGreaterThan(-1);
+    expect(bridgeIdx).toBeLessThan(legacyIdx);
+    expect(block).toContain('registryBridge: true');
+    expect(block).toContain('text: bridged.text');
+  });
+
+  test('notify-channel-email: zero inline HTML; renders via the new template', () => {
+    const src = read('services/notify-channel-email.service.js');
+    expect(src).not.toMatch(/dir="rtl"/);
+    expect(src).toContain("renderTemplate('MEASURE_ALERT_REASSIGNED'");
+  });
+});
+
+describe('W1270 behavioral — notify-channel direction semantics preserved', () => {
+  const { _renderEmail } = require('../services/notify-channel-email.service');
+  const payload = {
+    alertType: 'PLATEAU_DETECTED',
+    severity: 'high',
+    fromTherapistId: 'aaaaaaaaaaaaaaaaaaaa1111',
+    toTherapistId: 'bbbbbbbbbbbbbbbbbbbb2222',
+    reason: 'إعادة توزيع',
+  };
+  const recipient = { firstName_ar: 'نورة', lastName_ar: 'الشمري' };
+
+  test('isTo → «استلمت حالة جديدة» + other = FROM therapist tail', () => {
+    const out = _renderEmail({ payload, recipient, isFrom: false, isTo: true });
+    expect(out.subject).toContain('استلمت حالة جديدة');
+    expect(out.html).toContain('نورة الشمري');
+    expect(out.html).toContain('aaaa1111'.slice(-8));
+    expect(out.html).toContain('PLATEAU_DETECTED');
+    expect(out.text).toContain('PLATEAU_DETECTED');
+  });
+
+  test('isFrom → «تم نقل حالة من قائمتك» + other = TO therapist tail', () => {
+    const out = _renderEmail({ payload, recipient, isFrom: true, isTo: false });
+    expect(out.subject).toContain('تم نقل حالة من قائمتك');
+    expect(out.html).toContain('bbbb2222'.slice(-8));
+  });
+});

--- a/backend/intelligence/email-templates.registry.js
+++ b/backend/intelligence/email-templates.registry.js
@@ -609,6 +609,38 @@ const EMAIL_TEMPLATES = Object.freeze({
     }),
   }),
 
+  MEASURE_ALERT_REASSIGNED: T({
+    key: 'MEASURE_ALERT_REASSIGNED',
+    category: 'clinical',
+    titleAr: 'إعادة تعيين تنبيه قياس',
+    subjectAr: '[الأوائل] {{directionLabel}} — {{alertType}}',
+    subjectEn: 'Measure alert reassigned — {{alertType}}',
+    preheaderAr: 'خطورة {{severity}} — افتح صندوق العمل للمتابعة',
+    blocks: Object.freeze([
+      T({ type: 'greeting', ar: 'مرحباً {{recipientName}}،' }),
+      T({ type: 'panel', tone: 'warning', ar: '{{directionLabel}}' }),
+      T({
+        type: 'kv',
+        rows: Object.freeze([
+          T({ labelAr: 'المعالج الآخر', value: '{{otherTherapist}}' }),
+          T({ labelAr: 'نوع التنبيه', value: '{{alertType}}' }),
+          T({ labelAr: 'الخطورة', value: '{{severity}}' }),
+          T({ labelAr: 'السبب', value: '{{reason}}' }),
+        ]),
+      }),
+      T({ type: 'cta', labelAr: 'فتح صندوق العمل الذكي', urlVar: 'inboxUrl' }),
+    ]),
+    variables: Object.freeze({
+      recipientName: T({ required: true, labelAr: 'المستلم', sample: 'أ. نورة' }),
+      directionLabel: T({ required: true, labelAr: 'الاتجاه', sample: 'استلمت حالة جديدة' }),
+      otherTherapist: T({ required: false, labelAr: 'المعالج الآخر', sample: 'a4f2c1b9' }),
+      alertType: T({ required: true, labelAr: 'نوع التنبيه', sample: 'PLATEAU_DETECTED' }),
+      severity: T({ required: false, labelAr: 'الخطورة', sample: 'متوسطة' }),
+      reason: T({ required: false, labelAr: 'السبب', sample: 'إعادة توزيع الحالات' }),
+      inboxUrl: T({ required: false, labelAr: 'الرابط', sample: 'https://alaweal.org/smart-inbox' }),
+    }),
+  }),
+
   STAFF_ANNOUNCEMENT: T({
     key: 'STAFF_ANNOUNCEMENT',
     category: 'hr',

--- a/backend/services/email/EmailManager.js
+++ b/backend/services/email/EmailManager.js
@@ -446,6 +446,23 @@ class EmailManager {
     if (!to) return { success: false, error: 'MISSING_RECIPIENT' };
 
     try {
+      // W1270 — registry bridge: render through the W1242 professional
+      // catalogue when an adapter can satisfy its variable contract from
+      // this data shape; otherwise fall through to the legacy engine
+      // untouched (refuse-to-fabricate — a send never breaks on adoption).
+      const { tryRegistryRender } = require('./registryBridge');
+      const bridged = tryRegistryRender(templateName, data);
+      if (bridged) {
+        return this.send({
+          to,
+          subject: options.subject || bridged.subject,
+          html: bridged.html,
+          text: bridged.text,
+          metadata: { template: bridged.key, registryBridge: true, ...options.metadata },
+          ...options,
+        });
+      }
+
       const rendered = this.templateEngine.render(templateName, data);
       return this.send({
         to,

--- a/backend/services/email/registryBridge.js
+++ b/backend/services/email/registryBridge.js
@@ -1,0 +1,169 @@
+'use strict';
+
+/**
+ * registryBridge.js — W1270 (جسر EmailManager → سجل القوالب W1242)
+ *
+ * EmailManager.sendTemplate(to, KEY, data) is the single chokepoint behind
+ * every convenience method (sendWelcome/sendOTP/sendAppointmentReminder/
+ * sendInvoice/…). This bridge lets that chokepoint render through the
+ * professional registry FIRST, with per-key ADAPTERS that translate the
+ * legacy data shapes into registry variable contracts.
+ *
+ * SAFETY CONTRACT (refuse-to-fabricate, never block a send):
+ *   tryRegistryRender returns NULL whenever
+ *     • the legacy key has no mapping, or
+ *     • the adapter can't satisfy the registry contract from the given data
+ *       (renderer throws TEMPLATE_VARS_MISSING)
+ *   — and the caller falls back to the legacy EmailTemplateEngine untouched.
+ *   So adoption is incremental and a malformed payload degrades to exactly
+ *   yesterday's behaviour, never to a failed send.
+ */
+
+const { renderTemplate } = require('./templateRenderer.service');
+
+const APP_URL = () => process.env.FRONTEND_URL || 'https://alaweal.org';
+
+const arDate = (v) => {
+  if (!v) return null;
+  const d = new Date(v);
+  return Number.isNaN(d.getTime()) ? String(v) : d.toLocaleDateString('ar-SA');
+};
+
+const pick = (...vals) => {
+  for (const v of vals) if (v !== undefined && v !== null && String(v).trim() !== '') return v;
+  return null;
+};
+
+/** legacy EmailManager key → { key: registry key, adapt(data) → vars } */
+const BRIDGE = Object.freeze({
+  WELCOME: {
+    key: 'WELCOME_USER',
+    adapt: (d) => ({
+      name: pick(d.name, d.fullName, d.username, d.email),
+      email: d.email,
+      role: pick(d.role, d.roleLabel),
+      loginUrl: `${APP_URL()}/login`,
+    }),
+  },
+  // The OTP flow here is the password-reset flow (auth/otp-service
+  // sendPasswordResetOTP) — the registry copy is reset-specific by design.
+  OTP_CODE: {
+    key: 'PASSWORD_RESET',
+    adapt: (d) => ({
+      name: pick(d.name, d.fullName, d.username, d.email, 'المستخدم'),
+      otp: d.otp,
+      expiryMinutes: String(pick(d.expiry, d.expiryMinutes, 5)),
+    }),
+  },
+  APPOINTMENT_REMINDER: {
+    key: 'APPOINTMENT_REMINDER',
+    adapt: (d) => ({
+      beneficiaryName: pick(d.beneficiaryName, d.patientName, d.beneficiary && d.beneficiary.name, d.patient && d.patient.name),
+      serviceType: pick(d.serviceType, d.service, d.type),
+      therapistName: pick(d.therapistName, d.therapist && d.therapist.name, d.doctorName),
+      date: pick(d.dateLabel, arDate(pick(d.date, d.scheduledDate, d.appointmentDate))),
+      time: pick(d.time, d.timeLabel),
+      branchName: pick(d.branchName, d.branch && d.branch.name),
+    }),
+  },
+  APPOINTMENT_CANCELLATION: {
+    key: 'APPOINTMENT_CANCELLED',
+    adapt: (d) => ({
+      beneficiaryName: pick(d.beneficiaryName, d.patientName, d.beneficiary && d.beneficiary.name),
+      serviceType: pick(d.serviceType, d.service, d.type),
+      date: pick(d.dateLabel, arDate(pick(d.date, d.scheduledDate))),
+      time: pick(d.time, d.timeLabel),
+      reason: pick(d.reason, d.cancellationReason),
+    }),
+  },
+  SESSION_SUMMARY: {
+    key: 'SESSION_SUMMARY_GUARDIAN',
+    adapt: (d) => ({
+      beneficiaryName: pick(d.beneficiaryName, d.beneficiary && d.beneficiary.name),
+      serviceType: pick(d.serviceType, d.type),
+      therapistName: pick(d.therapistName, d.therapist && d.therapist.name),
+      summary: pick(d.summary, d.notes),
+      goalsWorked: pick(d.goalsWorked, Array.isArray(d.goals) ? d.goals.join(' — ') : null),
+      homework: d.homework,
+    }),
+  },
+  INVOICE: {
+    key: 'INVOICE_ISSUED',
+    adapt: (d) => ({
+      guardianName: pick(d.customerName, d.guardianName, 'العميل'),
+      beneficiaryName: pick(d.beneficiaryName, d.customerName, 'المستفيد'),
+      invoiceNumber: pick(d.number, d.invoiceNumber),
+      period: d.period,
+      amount: pick(d.amountLabel, d.amount, d.total),
+      dueDate: pick(d.dueDateLabel, arDate(d.dueDate)),
+      invoiceUrl: pick(d.invoiceUrl, `${APP_URL()}/portal/invoices`),
+    }),
+  },
+  PAYMENT_CONFIRMATION: {
+    key: 'PAYMENT_RECEIPT',
+    adapt: (d) => ({
+      guardianName: pick(d.customerName, d.guardianName, d.name, 'العميل'),
+      amount: pick(d.amountLabel, d.amount, d.total),
+      receiptNumber: pick(d.receiptNumber, d.number, d.reference),
+      invoiceNumber: pick(d.invoiceNumber, d.invoice && d.invoice.number),
+      method: pick(d.method, d.paymentMethod),
+      paidAt: pick(d.paidAtLabel, arDate(pick(d.paidAt, d.date)), arDate(Date.now())),
+    }),
+  },
+  NEW_COMMUNICATION: {
+    key: 'NEW_COMMUNICATION',
+    adapt: (d) => ({
+      title: d.title,
+      referenceNumber: pick(d.referenceNumber, d.reference),
+      type: d.type,
+      priority: d.priority,
+      sentDate: pick(d.sentDateLabel, arDate(d.sentDate)),
+      senderName: pick(d.senderName, d.sender && d.sender.name),
+      senderDepartment: pick(d.senderDepartment, d.sender && d.sender.department),
+      subjectText: pick(d.subjectText, d.subject, d.body),
+      viewUrl: d.viewUrl,
+    }),
+  },
+  APPROVAL_REQUEST: {
+    key: 'APPROVAL_REQUEST',
+    adapt: (d) => ({
+      title: d.title,
+      referenceNumber: pick(d.referenceNumber, d.reference),
+      stageName: pick(d.stageName, d.stage && d.stage.name),
+      priority: d.priority,
+      subjectText: pick(d.subjectText, d.subject, d.body),
+      approveUrl: d.approveUrl,
+      rejectUrl: d.rejectUrl,
+    }),
+  },
+  STATUS_CHANGE: {
+    key: 'STATUS_CHANGE',
+    adapt: (d) => ({
+      title: d.title,
+      referenceNumber: pick(d.referenceNumber, d.reference),
+      oldStatusLabel: pick(d.oldStatusLabel, d.oldStatus),
+      newStatusLabel: pick(d.newStatusLabel, d.newStatus),
+      viewUrl: d.viewUrl,
+    }),
+  },
+});
+
+/**
+ * Try rendering a legacy EmailManager template key through the registry.
+ * @returns {{key, subject, html, text}|null} null → caller uses legacy engine.
+ */
+function tryRegistryRender(legacyKey, data = {}) {
+  const entry = BRIDGE[legacyKey];
+  if (!entry) return null;
+  try {
+    const vars = entry.adapt(data || {});
+    return renderTemplate(entry.key, vars);
+  } catch (err) {
+    if (err && (err.code === 'TEMPLATE_VARS_MISSING' || err.code === 'TEMPLATE_NOT_FOUND')) {
+      return null; // contract unsatisfied → safe legacy fallback
+    }
+    throw err;
+  }
+}
+
+module.exports = { BRIDGE, tryRegistryRender };

--- a/backend/services/notify-channel-email.service.js
+++ b/backend/services/notify-channel-email.service.js
@@ -80,32 +80,29 @@ function _defaultGetUserById(userId) {
 }
 
 function _renderEmail({ payload, recipient, isFrom, isTo }) {
+  // W1270 — render via the W1242 registry (MEASURE_ALERT_REASSIGNED): shared
+  // professional RTL layout + auto plain-text. Same return shape (+text).
   const direction = isFrom
     ? 'تم نقل حالة من قائمتك'
     : isTo
       ? 'استلمت حالة جديدة'
       : 'إعادة تعيين حالة قياس';
   const otherId = isFrom ? payload.toTherapistId : payload.fromTherapistId;
-  const otherShort = otherId ? String(otherId).slice(-8) : '—';
-  const subject = `[Alawael] ${direction} — ${payload.alertType || 'تنبيه قياس'}`;
   const recipientName =
     [recipient?.firstName_ar, recipient?.lastName_ar].filter(Boolean).join(' ').trim() ||
     [recipient?.firstName, recipient?.lastName].filter(Boolean).join(' ').trim() ||
     'الزميل/ة';
-  const html = `
-    <div dir="rtl" style="font-family:Arial,sans-serif;font-size:14px;color:#1f2937;">
-      <p>مرحباً ${escapeHtml(recipientName)},</p>
-      <p><strong>${escapeHtml(direction)}</strong></p>
-      <ul>
-        <li>المعالج الآخر: ${escapeHtml(otherShort)}</li>
-        <li>نوع التنبيه: ${escapeHtml(payload.alertType || 'غير محدد')}</li>
-        <li>الخطورة: ${escapeHtml(payload.severity || 'متوسطة')}</li>
-        ${payload.reason ? `<li>السبب: ${escapeHtml(payload.reason)}</li>` : ''}
-      </ul>
-      <p>افتح صندوق العمل لمتابعة الحالة في النظام.</p>
-    </div>
-  `;
-  return { subject, html };
+  const { renderTemplate } = require('./email/templateRenderer.service');
+  const rendered = renderTemplate('MEASURE_ALERT_REASSIGNED', {
+    recipientName,
+    directionLabel: direction,
+    otherTherapist: otherId ? String(otherId).slice(-8) : null,
+    alertType: payload.alertType || 'تنبيه قياس',
+    severity: payload.severity || 'متوسطة',
+    reason: payload.reason || null,
+    inboxUrl: (process.env.FRONTEND_URL || 'https://alaweal.org') + '/smart-inbox',
+  });
+  return { subject: rendered.subject, html: rendered.html, text: rendered.text };
 }
 
 function escapeHtml(s) {

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1041,3 +1041,4 @@ __tests__/care-plan-from-proposal-wave1266.test.js
 __tests__/center-ops-wave1269.test.js
 __tests__/portal-plan-mapper-wave1272.test.js
 __tests__/parent-v2-unified-plan-wave1273.test.js
+__tests__/email-registry-bridge-wave1270.test.js


### PR DESCRIPTION
`EmailManager.sendTemplate` — the chokepoint behind every convenience method — now renders through the W1242 registry first via `registryBridge.js` (10 legacy keys with data-shape adapters). **Safety contract**: unsatisfiable data or unmapped key → `null` → legacy engine path runs unchanged (adoption can never break a send); bridged sends gain the plain-text alt + `metadata.registryBridge`.

Plus: registry +`MEASURE_ALERT_REASSIGNED` (catalogue **18**) and the LIVE `notify-channel-email` migrated (zero inline HTML left; from/to semantics behaviorally preserved).

32 local assertions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)