### PR TITLE
fix(journey): W1277 - the journey care-plan slot reads UnifiedCarePlan first

### DIFF
--- a/backend/__tests__/beneficiary-journey-wave1247.test.js
+++ b/backend/__tests__/beneficiary-journey-wave1247.test.js
@@ -96,6 +96,18 @@ describe('W1247 branch isolation (W269 doctrine)', () => {
   });
 });
 
+describe('W1277 care-plan slot reads the canonical model first', () => {
+  test('unified-first with live statuses, legacy fallback, source tag, family version', () => {
+    expect(routeSrc).toContain("tryModel('UnifiedCarePlan')");
+    expect(routeSrc).toContain(
+      "status: { $in: ['draft', 'pending_approval', 'active', 'under_review'] }"
+    );
+    expect(routeSrc).toContain("__source: 'unified'");
+    expect(routeSrc).toContain("__source: 'legacy'");
+    expect(routeSrc).toContain('carePlan.familyVersion && carePlan.familyVersion.body');
+  });
+});
+
 describe('W1247 mount', () => {
   test('mounted via dualMountAuth in features.registry (never plain dualMount)', () => {
     expect(registrySrc).toContain(

--- a/backend/routes/beneficiary-journey.routes.js
+++ b/backend/routes/beneficiary-journey.routes.js
@@ -171,6 +171,9 @@ router.get('/by-beneficiary/:beneficiaryId', requireRole(READ_ROLES), async (req
 
     const Transition = tryModel('BeneficiaryLifecycleTransition');
     const Episode = tryModel('EpisodeOfCare');
+    // W1277 — the canonical UnifiedCarePlan FIRST (ADR-041); the legacy
+    // CarePlanVersion stays as fallback during the retirement window.
+    const UnifiedPlan = tryModel('UnifiedCarePlan');
     const CarePlan = tryModel('CarePlanVersion');
     const TransitionPlan = tryModel('TransitionPlan');
     const PostRehabCase = tryModel('PostRehabCase');
@@ -182,9 +185,22 @@ router.get('/by-beneficiary/:beneficiaryId', requireRole(READ_ROLES), async (req
       Episode
         ? Episode.findOne({ beneficiaryId }).sort({ createdAt: -1 }).lean()
         : Promise.resolve(null),
-      CarePlan
-        ? CarePlan.findOne({ beneficiaryId }).sort({ createdAt: -1 }).lean()
-        : Promise.resolve(null),
+      // W1277: unified first, legacy fallback inside one settled slot
+      (async () => {
+        if (UnifiedPlan) {
+          const u = await UnifiedPlan.findOne({
+            beneficiaryId,
+            isDeleted: { $ne: true },
+            status: { $in: ['draft', 'pending_approval', 'active', 'under_review'] },
+          })
+            .sort({ createdAt: -1 })
+            .lean();
+          if (u) return { ...u, __source: 'unified' };
+        }
+        if (!CarePlan) return null;
+        const legacy = await CarePlan.findOne({ beneficiaryId }).sort({ createdAt: -1 }).lean();
+        return legacy ? { ...legacy, __source: 'legacy' } : null;
+      })(),
       TransitionPlan
         ? TransitionPlan.findOne({ beneficiaryId }).sort({ createdAt: -1 }).lean()
         : Promise.resolve(null),
@@ -233,8 +249,12 @@ router.get('/by-beneficiary/:beneficiaryId', requireRole(READ_ROLES), async (req
           ? {
               id: carePlan._id,
               status: carePlan.status || null,
-              version: carePlan.version || null,
+              version: carePlan.version || carePlan.versionNumber || null,
               updatedAt: carePlan.updatedAt || null,
+              source: carePlan.__source || 'legacy', // W1277
+              titleAr: carePlan.title_ar || null,
+              // W1259 family version — staff preview of what the family sees
+              familyVersion: (carePlan.familyVersion && carePlan.familyVersion.body) || null,
             }
           : null,
         transitionPlan: transitionPlan


### PR DESCRIPTION
Found by turning the split lens on this cycle's own code: the W1247 journey aggregator's care-plan card read \CarePlanVersion\ only.

- Unified-first (live statuses, newest) with legacy in-slot fallback, source-tagged
- Payload additions: \source\, \	itleAr\, and the W1259 \amilyVersion\ body — **staff preview of exactly what the family sees** (frontend already merged: platform #123)
- W1247 guard extended, 11/11 green