### PR TITLE
feat(whatsapp): W1366 stateful menu-bot + guardian-verified live data

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1751,6 +1751,9 @@ on:
       - 'backend/__tests__/parent-v2-unified-plan-wave1273.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/email-registry-bridge-wave1270.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/whatsapp-bot-data-lookup-wave1366.test.js'
+      - 'backend/__tests__/whatsapp-bot-flow-menu-wave1366.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3480,6 +3483,9 @@ on:
       - 'backend/__tests__/parent-v2-unified-plan-wave1273.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/email-registry-bridge-wave1270.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/whatsapp-bot-data-lookup-wave1366.test.js'
+      - 'backend/__tests__/whatsapp-bot-flow-menu-wave1366.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -272,6 +272,12 @@ UNIVERSAL_CODE_PREFIX=RH
 # WHATSAPP_WEBHOOK_SECRET=<random>      # Meta "App Secret" for X-Hub HMAC
 # WHATSAPP_VERIFY_TOKEN=<random>        # value Meta sends in GET /webhook?hub.verify_token
 # WHATSAPP_TEMPLATE_NAMESPACE=          # optional, for namespaced templates
+# ENABLE_WHATSAPP_BOT_MENU=true         # W1366: stateful menu-bot on inbound
+#   When set, a deterministic FSM drives inbound replies — a welcome menu (with
+#   bot-identity disclosure) + 10 multi-step flows (registration / appointment /
+#   complaint / human callback / read-only lookups). Runs BEFORE the stateless
+#   auto-reply classifier and short-circuits it when it handles a turn. Default
+#   OFF: existing auto-reply behavior is unchanged until you opt in.
 #
 # OTP delivery: WhatsApp OTP requires an APPROVED Meta template named
 # "otp_verification" (language "ar"), body params {{1}}=code, {{2}}=expiry-minutes.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -278,6 +278,14 @@ UNIVERSAL_CODE_PREFIX=RH
 #   complaint / human callback / read-only lookups). Runs BEFORE the stateless
 #   auto-reply classifier and short-circuits it when it handles a turn. Default
 #   OFF: existing auto-reply behavior is unchanged until you opt in.
+# ENABLE_WHATSAPP_BOT_LIVE_DATA=true     # W1366 Wave 2: guardian-verified live data
+#   Requires ENABLE_WHATSAPP_BOT_MENU. When set, the attendance / session-report
+#   / billing menu units return REAL data instead of escalating — but ONLY for a
+#   beneficiary the inbound phone is a registered AUTHORIZED guardian of
+#   (portalAccess.enabled / isLegalGuardian / isPrimaryContact). It never looks a
+#   beneficiary up by typed name; if the phone is unverified or the child is
+#   ambiguous, it falls back to staff escalation. Default OFF — sensitive
+#   clinical/financial data is never auto-sent until you explicitly opt in.
 #
 # OTP delivery: WhatsApp OTP requires an APPROVED Meta template named
 # "otp_verification" (language "ar"), body params {{1}}=code, {{2}}=expiry-minutes.

--- a/backend/__tests__/whatsapp-bot-data-lookup-wave1366.test.js
+++ b/backend/__tests__/whatsapp-bot-data-lookup-wave1366.test.js
@@ -1,0 +1,183 @@
+'use strict';
+
+/**
+ * W1366 Wave 2 — guardian-verified live-data lookups.
+ *
+ * PURE unit tests for the privacy-critical logic: the authorization gate
+ * (`isAuthorizedMember` + `selectBeneficiary`), the period/day parsers, and the
+ * Arabic formatters. The DB-touching resolvers are thin wrappers over these and
+ * are intentionally NOT exercised here (no Mongo) — the security guarantee
+ * lives entirely in the pure functions tested below.
+ */
+
+const svc = require('../services/whatsapp/whatsappBotData.service');
+
+describe('W1366 Wave 2 — authorization gate', () => {
+  test('isAuthorizedMember: portal/legal-guardian/primary-contact qualify; bare contact does not', () => {
+    expect(svc.isAuthorizedMember({ portalAccess: { enabled: true } })).toBe(true);
+    expect(svc.isAuthorizedMember({ isLegalGuardian: true })).toBe(true);
+    expect(svc.isAuthorizedMember({ isPrimaryContact: true })).toBe(true);
+    expect(svc.isAuthorizedMember({ relationship: 'uncle_aunt' })).toBe(false);
+    expect(svc.isAuthorizedMember({ portalAccess: { enabled: false } })).toBe(false);
+    expect(svc.isAuthorizedMember(null)).toBe(false);
+  });
+
+  test('selectBeneficiary: zero candidates → not_authorized (never guesses)', () => {
+    expect(svc.selectBeneficiary([], 'سارة')).toEqual({ ok: false, reason: 'not_authorized' });
+  });
+
+  test('selectBeneficiary: single child → returned regardless of typed name', () => {
+    const r = svc.selectBeneficiary([{ beneficiaryId: 'b1', name: 'سارة أحمد' }], 'اسم مختلف');
+    expect(r).toEqual({ ok: true, beneficiaryId: 'b1' });
+  });
+
+  test('selectBeneficiary: multiple children → typed name disambiguates to one', () => {
+    const cands = [
+      { beneficiaryId: 'b1', name: 'سارة أحمد' },
+      { beneficiaryId: 'b2', name: 'خالد أحمد' },
+    ];
+    expect(svc.selectBeneficiary(cands, 'خالد')).toEqual({ ok: true, beneficiaryId: 'b2' });
+  });
+
+  test('selectBeneficiary: multiple children + no name → ambiguous (declines)', () => {
+    const cands = [
+      { beneficiaryId: 'b1', name: 'سارة' },
+      { beneficiaryId: 'b2', name: 'خالد' },
+    ];
+    const r = svc.selectBeneficiary(cands, '');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('ambiguous_no_name');
+    expect(r.count).toBe(2);
+  });
+
+  test('selectBeneficiary: multiple children + non-matching name → declines (no leak)', () => {
+    const cands = [
+      { beneficiaryId: 'b1', name: 'سارة' },
+      { beneficiaryId: 'b2', name: 'خالد' },
+    ];
+    const r = svc.selectBeneficiary(cands, 'محمد');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('ambiguous_no_match');
+  });
+
+  test('selectBeneficiary: name matching two siblings → declines rather than pick', () => {
+    const cands = [
+      { beneficiaryId: 'b1', name: 'سارة أحمد' },
+      { beneficiaryId: 'b2', name: 'سارة محمد' },
+    ];
+    const r = svc.selectBeneficiary(cands, 'سارة');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('ambiguous_multiple_match');
+  });
+});
+
+describe('W1366 Wave 2 — formatters', () => {
+  test('formatAttendance present record shows status + times', () => {
+    const rec = {
+      status: 'present',
+      checkInTime: new Date('2026-06-16T08:05:00'),
+      checkOutTime: new Date('2026-06-16T13:30:00'),
+    };
+    const out = svc.formatAttendance(rec, 'سارة', '2026-06-16');
+    expect(out).toMatch(/سارة/);
+    expect(out).toMatch(/حاضر/);
+    expect(out).toMatch(/08:05/);
+    expect(out).toMatch(/13:30/);
+  });
+
+  test('formatAttendance with no record states absence of a log', () => {
+    const out = svc.formatAttendance(null, 'سارة', 'اليوم');
+    expect(out).toMatch(/لا يوجد سجل حضور/);
+  });
+
+  test('formatSessionReports renders specialty, therapist, goal counts + privacy footer', () => {
+    const sessions = [
+      {
+        scheduledDate: new Date('2026-06-15T10:00:00'),
+        specialty: 'speech_therapy',
+        therapistId: { firstName: 'منى', lastName: 'سعد' },
+        plan: 'العمل على نطق حرف الراء',
+        goalProgress: [{ rating: 'achieved' }, { rating: 'emerging' }],
+      },
+    ];
+    const out = svc.formatSessionReports(sessions, 'سارة');
+    expect(out).toMatch(/نطق وتخاطب/);
+    expect(out).toMatch(/منى سعد/);
+    expect(out).toMatch(/نطق حرف الراء/);
+    expect(out).toMatch(/1\/2/);
+    expect(out).toMatch(/خاص بولي الأمر/);
+  });
+
+  test('formatSessionReports empty → no-report message', () => {
+    expect(svc.formatSessionReports([], 'سارة')).toMatch(/لا يوجد تقرير جلسة/);
+  });
+
+  test('formatBilling sums outstanding balance + shows latest status + card warning', () => {
+    const invoices = [
+      {
+        balance_due: 300,
+        status: 'partially_paid',
+        invoice_number: 'INV-2',
+        due_date: new Date('2026-06-20'),
+      },
+      { balance_due: 150, status: 'issued', invoice_number: 'INV-1' },
+    ];
+    const out = svc.formatBilling(invoices, 'سارة');
+    expect(out).toMatch(/450/); // 300 + 150
+    expect(out).toMatch(/مدفوعة جزئياً/);
+    expect(out).toMatch(/لا تشاركوا بيانات البطاقات/);
+  });
+
+  test('formatBilling empty → no-invoices message', () => {
+    expect(svc.formatBilling([], 'سارة')).toMatch(/لا توجد فواتير/);
+  });
+});
+
+describe('W1366 Wave 2 — period / day parsing (deterministic via injected now)', () => {
+  const now = new Date('2026-06-16T10:00:00');
+
+  test('parsePeriod resolves the 4 spec windows', () => {
+    expect(svc.parsePeriod('آخر تقرير', now).latestOnly).toBe(true);
+    expect(svc.parsePeriod('هذا الأسبوع', now).gte.getTime()).toBe(now.getTime() - 7 * 86400000);
+    expect(svc.parsePeriod('هذا الشهر', now).gte.getTime()).toBe(now.getTime() - 30 * 86400000);
+    expect(svc.parsePeriod('اليوم', now).label).toBe('اليوم');
+  });
+
+  test('parsePeriod default falls back to last 30 days', () => {
+    const p = svc.parsePeriod('شيء غامض', now);
+    expect(p.latestOnly).toBe(false);
+    expect(p.gte.getTime()).toBe(now.getTime() - 30 * 86400000);
+  });
+
+  test('parseDay: blank / "اليوم" → today; explicit date → that day window', () => {
+    expect(svc.parseDay('اليوم', now).label).toBe('اليوم');
+    expect(svc.parseDay('', now).label).toBe('اليوم');
+    const d = svc.parseDay('2026-06-10', now);
+    expect(d.label).toMatch(/2026-06-10/);
+    expect(d.start.getTime()).toBeLessThanOrEqual(d.end.getTime());
+  });
+});
+
+describe('W1366 Wave 2 — dispatch guards', () => {
+  test('isLookupKind only matches the 3 read-only lookups', () => {
+    expect(svc.isLookupKind('lookup_attendance')).toBe(true);
+    expect(svc.isLookupKind('lookup_session_report')).toBe(true);
+    expect(svc.isLookupKind('lookup_billing')).toBe(true);
+    expect(svc.isLookupKind('create_complaint')).toBe(false);
+    expect(svc.isLookupKind('none')).toBe(false);
+  });
+
+  test('answerLookup rejects a non-lookup kind before touching any model', async () => {
+    const r = await svc.answerLookup('create_complaint', '966500000000', {});
+    expect(r).toEqual({ ok: false, reason: 'unsupported_kind' });
+  });
+
+  test('DEPT_KEY_TO_SPECIALTY maps the 4 department keys', () => {
+    expect(svc.DEPT_KEY_TO_SPECIALTY).toEqual({
+      occupational: 'occupational_therapy',
+      speech: 'speech_therapy',
+      special_education: 'educational',
+      behavior: 'behavioral_therapy',
+    });
+  });
+});

--- a/backend/__tests__/whatsapp-bot-flow-menu-wave1366.test.js
+++ b/backend/__tests__/whatsapp-bot-flow-menu-wave1366.test.js
@@ -1,0 +1,358 @@
+'use strict';
+
+/**
+ * W1366 — WhatsApp stateful menu-bot engine.
+ *
+ * Two layers (per the W356-W384 static+behavioral doctrine), both PURE — the
+ * FSM does no I/O, so the "behavioral" layer is a deterministic state-machine
+ * walk needing no MongoMemoryServer:
+ *
+ *   1. STATIC drift guard — registry shape (10 units in menu order, steps,
+ *      confirm flags, side-effect mapping) + helper correctness (digit folding,
+ *      menu-selection parsing, keyword routing, yes/no/cancel/skip detection).
+ *   2. BEHAVIORAL — handleTurn() walks: welcome → menu → enter unit → collect →
+ *      summary → confirm → closing + side effect; cancel / menu-reset; zero-step
+ *      static units; read-only lookup units; home-exercise content; the unit-3
+ *      "إلغاء" answer surviving (not mis-read as an abort).
+ */
+
+const reg = require('../intelligence/whatsapp-bot-flow.registry');
+const engine = require('../intelligence/whatsapp-bot-flow.service');
+
+// Drive a sequence of inbound turns, threading nextFlowState forward.
+function walk(turns, ctx = {}) {
+  let state = { unit: null, step: 0, collected: {}, phase: null };
+  const out = [];
+  for (const text of turns) {
+    const plan = engine.handleTurn(state, text, ctx);
+    state = plan.nextFlowState;
+    out.push(plan);
+  }
+  return { plans: out, finalState: state, last: out[out.length - 1] };
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// 1. STATIC — registry shape
+// ════════════════════════════════════════════════════════════════════════════
+describe('W1366 static — registry shape', () => {
+  test('exactly 10 units in menu order with ids + labels', () => {
+    expect(reg.UNITS).toHaveLength(10);
+    const ids = reg.UNITS.map(u => u.id);
+    expect(ids).toEqual([
+      'info',
+      'register',
+      'appointment',
+      'attendance',
+      'session_reports',
+      'home_exercises',
+      'billing',
+      'notifications',
+      'complaint',
+      'human',
+    ]);
+    for (const u of reg.UNITS) {
+      expect(typeof u.label).toBe('string');
+      expect(u.label.length).toBeGreaterThan(0);
+      expect(Array.isArray(u.steps)).toBe(true);
+    }
+  });
+
+  test('UNIT_BY_ID resolves every unit', () => {
+    for (const u of reg.UNITS) expect(reg.UNIT_BY_ID[u.id]).toBe(u);
+  });
+
+  test('every collecting step has a non-empty key + prompt', () => {
+    for (const u of reg.UNITS) {
+      for (const s of u.steps) {
+        expect(typeof s.key).toBe('string');
+        expect(s.key.length).toBeGreaterThan(0);
+        expect(typeof s.prompt).toBe('string');
+        expect(s.prompt.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test('confirm flag matches data-changing vs read-only intent', () => {
+    const confirm = reg.UNITS.filter(u => u.confirm)
+      .map(u => u.id)
+      .sort();
+    expect(confirm).toEqual(['appointment', 'complaint', 'human', 'register']);
+    // read-only / static units do NOT ask for a confirm
+    for (const id of [
+      'info',
+      'attendance',
+      'session_reports',
+      'home_exercises',
+      'billing',
+      'notifications',
+    ]) {
+      expect(reg.UNIT_BY_ID[id].confirm).toBe(false);
+    }
+  });
+
+  test('side-effect kinds map to the right units', () => {
+    expect(reg.UNIT_BY_ID.register.sideEffect).toBe(reg.SIDE_EFFECT.CREATE_REGISTRATION);
+    expect(reg.UNIT_BY_ID.appointment.sideEffect).toBe(reg.SIDE_EFFECT.CREATE_APPOINTMENT_REQUEST);
+    expect(reg.UNIT_BY_ID.attendance.sideEffect).toBe(reg.SIDE_EFFECT.LOOKUP_ATTENDANCE);
+    expect(reg.UNIT_BY_ID.session_reports.sideEffect).toBe(reg.SIDE_EFFECT.LOOKUP_SESSION_REPORT);
+    expect(reg.UNIT_BY_ID.billing.sideEffect).toBe(reg.SIDE_EFFECT.LOOKUP_BILLING);
+    expect(reg.UNIT_BY_ID.complaint.sideEffect).toBe(reg.SIDE_EFFECT.CREATE_COMPLAINT);
+    expect(reg.UNIT_BY_ID.human.sideEffect).toBe(reg.SIDE_EFFECT.CALLBACK_REQUEST);
+    expect(reg.UNIT_BY_ID.info.sideEffect).toBe(reg.SIDE_EFFECT.NONE);
+    expect(reg.UNIT_BY_ID.notifications.sideEffect).toBe(reg.SIDE_EFFECT.NONE);
+    expect(reg.UNIT_BY_ID.home_exercises.sideEffect).toBe(reg.SIDE_EFFECT.NONE);
+  });
+
+  test('registration collects the 8 spec fields', () => {
+    const keys = reg.UNIT_BY_ID.register.steps.map(s => s.key);
+    expect(keys).toEqual([
+      'guardianName',
+      'beneficiaryName',
+      'age',
+      'gender',
+      'city',
+      'guardianPhone',
+      'priorDiagnosis',
+      'hasReports',
+    ]);
+  });
+
+  test('HOME_EXERCISES covers the 4 departments', () => {
+    expect(Object.keys(reg.HOME_EXERCISES).sort()).toEqual([
+      'behavior',
+      'occupational',
+      'special_education',
+      'speech',
+    ]);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 2. STATIC — pure helpers
+// ════════════════════════════════════════════════════════════════════════════
+describe('W1366 static — helpers', () => {
+  test('toAsciiDigits folds Arabic-Indic + Extended digits', () => {
+    expect(reg.toAsciiDigits('٠١٢٣٤٥٦٧٨٩')).toBe('0123456789');
+    expect(reg.toAsciiDigits('۰۱۲۳')).toBe('0123');
+    expect(reg.toAsciiDigits('abc')).toBe('abc');
+  });
+
+  test('parseMenuSelection accepts 1..10 in ASCII, Arabic-Indic, decorated', () => {
+    expect(reg.parseMenuSelection('1')).toBe(1);
+    expect(reg.parseMenuSelection('١')).toBe(1);
+    expect(reg.parseMenuSelection('10')).toBe(10);
+    expect(reg.parseMenuSelection('١٠')).toBe(10);
+    expect(reg.parseMenuSelection('رقم 3')).toBe(3);
+    expect(reg.parseMenuSelection('1️⃣')).toBe(1);
+  });
+
+  test('parseMenuSelection rejects out-of-range + non-numeric', () => {
+    expect(reg.parseMenuSelection('0')).toBeNull();
+    expect(reg.parseMenuSelection('11')).toBeNull();
+    expect(reg.parseMenuSelection('99')).toBeNull();
+    expect(reg.parseMenuSelection('مرحبا')).toBeNull();
+    expect(reg.parseMenuSelection('')).toBeNull();
+  });
+
+  test('resolveUnitId routes free text + numbers to units', () => {
+    expect(reg.resolveUnitId('2')).toBe('register');
+    expect(reg.resolveUnitId('أبغى أحجز موعد')).toBe('appointment');
+    expect(reg.resolveUnitId('حضوره اليوم')).toBe('attendance');
+    expect(reg.resolveUnitId('عندي شكوى')).toBe('complaint');
+    expect(reg.resolveUnitId('أبي أكلم موظف')).toBe('human');
+    expect(reg.resolveUnitId('تمارين في البيت')).toBe('home_exercises');
+    expect(reg.resolveUnitId('بلا بلا بلا')).toBeNull();
+  });
+
+  test('menu / yes / no / cancel / skip detectors', () => {
+    expect(reg.isMenuTrigger('القائمة')).toBe(true);
+    expect(reg.isMenuTrigger('menu')).toBe(true);
+    expect(reg.isMenuTrigger('شكراً')).toBe(false);
+
+    expect(reg.isYes('نعم')).toBe(true);
+    expect(reg.isYes('أكد')).toBe(true);
+    expect(reg.isYes('لا')).toBe(false);
+
+    expect(reg.isNo('لا')).toBe(true);
+    expect(reg.isNo('إلغاء')).toBe(true);
+    expect(reg.isNo('نعم')).toBe(false);
+
+    expect(reg.isCancelTrigger('رجوع')).toBe(true);
+    expect(reg.isCancelTrigger('خروج')).toBe(true);
+    // "إلغاء" alone is NOT an abort — it's a valid unit-3 action answer.
+    expect(reg.isCancelTrigger('إلغاء')).toBe(false);
+
+    expect(reg.isSkip('-')).toBe(true);
+    expect(reg.isSkip('تخطي')).toBe(true);
+    expect(reg.isSkip('أحمد')).toBe(false);
+  });
+
+  test('resolveDepartmentKey maps Arabic department names', () => {
+    expect(reg.resolveDepartmentKey('علاج وظيفي')).toBe('occupational');
+    expect(reg.resolveDepartmentKey('نطق وتخاطب')).toBe('speech');
+    expect(reg.resolveDepartmentKey('تربية خاصة')).toBe('special_education');
+    expect(reg.resolveDepartmentKey('تعديل سلوك')).toBe('behavior');
+    expect(reg.resolveDepartmentKey('شيء غريب')).toBeNull();
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 3. BEHAVIORAL — FSM walk-through
+// ════════════════════════════════════════════════════════════════════════════
+describe('W1366 behavioral — state machine', () => {
+  test('greeting from idle → welcome menu, stays idle, discloses bot identity', () => {
+    const plan = engine.handleTurn(null, 'السلام عليكم');
+    expect(plan.handled).toBe(true);
+    expect(plan.reply).toMatch(/بوت افتراضي/);
+    expect(plan.reply).toMatch(/مساعد الأوائل الذكي/);
+    expect(plan.reply).toMatch(/التسجيل الأولي/); // a menu line is present
+    expect(plan.nextFlowState.unit).toBeNull();
+    expect(plan.sideEffect).toBeNull();
+  });
+
+  test('welcome personalizes with guardian name when known', () => {
+    const plan = engine.handleTurn(null, 'مرحبا', { guardianName: 'أبو خالد' });
+    expect(plan.reply).toMatch(/أبو خالد/);
+  });
+
+  test('selecting "2" enters registration at step 0', () => {
+    const plan = engine.handleTurn(null, '2');
+    expect(plan.nextFlowState.unit).toBe('register');
+    expect(plan.nextFlowState.step).toBe(0);
+    expect(plan.nextFlowState.phase).toBe('collecting');
+    expect(plan.reply).toMatch(/اسم ولي الأمر/);
+  });
+
+  test('full registration walk → summary → confirm → side effect', () => {
+    const turns = [
+      '2', // enter register
+      'أحمد علي محمد', // guardianName
+      'سارة أحمد علي محمد', // beneficiaryName
+      '5 سنوات', // age
+      'أنثى', // gender
+      'الرياض', // city
+      '-', // guardianPhone (skip)
+      'تأخر نطق', // priorDiagnosis
+      'نعم', // hasReports
+    ];
+    const { last, finalState } = walk(turns);
+
+    // After the 8th answer we are in the confirming phase with a summary.
+    expect(finalState.unit).toBe('register');
+    expect(finalState.phase).toBe('confirming');
+    expect(last.reply).toMatch(/ملخص طلبك/);
+    expect(last.reply).toMatch(/سارة أحمد علي محمد/);
+    expect(last.reply).toMatch(/هل تؤكد/);
+    // optional skipped field is omitted from the summary
+    expect(last.reply).not.toMatch(/رقم جوال ولي/);
+    expect(last.sideEffect).toBeNull();
+
+    // Confirm → closing + CREATE_REGISTRATION side effect, back to idle.
+    const confirm = engine.handleTurn(finalState, 'نعم');
+    expect(confirm.nextFlowState.unit).toBeNull();
+    expect(confirm.sideEffect).toEqual({
+      kind: reg.SIDE_EFFECT.CREATE_REGISTRATION,
+      unit: 'register',
+      collected: expect.objectContaining({
+        guardianName: 'أحمد علي محمد',
+        beneficiaryName: 'سارة أحمد علي محمد',
+        guardianPhone: '',
+        hasReports: 'نعم',
+      }),
+    });
+    expect(confirm.reply).toMatch(/قسم القبول والتسجيل/);
+    expect(confirm.reply).toMatch(/القائمة/); // menu hint footer
+  });
+
+  test('declining the confirmation cancels with no side effect', () => {
+    const turns = [
+      '10', // human callback
+      'أحمد', // name
+      '0501234567', // contactPhone
+      'بعد العصر', // bestTime
+      'استفسار تسجيل', // topic
+    ];
+    const { finalState } = walk(turns);
+    expect(finalState.phase).toBe('confirming');
+
+    const declined = engine.handleTurn(finalState, 'لا');
+    expect(declined.sideEffect).toBeNull();
+    expect(declined.nextFlowState.unit).toBeNull();
+    expect(declined.reply).toMatch(/لم يُرسَل/);
+  });
+
+  test('"القائمة" resets to the main menu mid-flow', () => {
+    const enter = engine.handleTurn(null, '9'); // complaint
+    expect(enter.nextFlowState.unit).toBe('complaint');
+    const reset = engine.handleTurn(enter.nextFlowState, 'القائمة');
+    expect(reset.nextFlowState.unit).toBeNull();
+    expect(reset.reply).toMatch(/مساعد الأوائل الذكي/);
+  });
+
+  test('"رجوع" aborts an in-progress flow', () => {
+    const enter = engine.handleTurn(null, '2');
+    const aborted = engine.handleTurn(enter.nextFlowState, 'رجوع');
+    expect(aborted.nextFlowState.unit).toBeNull();
+    expect(aborted.reply).toMatch(/تم إلغاء العملية/);
+  });
+
+  test('zero-step unit (info "1") returns content immediately, stays idle', () => {
+    const plan = engine.handleTurn(null, '1');
+    expect(plan.nextFlowState.unit).toBeNull();
+    expect(plan.reply).toMatch(/الفئات التي نستقبلها|اضطراب طيف التوحد/);
+    expect(plan.sideEffect).toBeNull();
+  });
+
+  test('read-only attendance lookup collects then escalates without a confirm step', () => {
+    const turns = ['4', 'سارة', 'اليوم'];
+    const { last } = walk(turns);
+    expect(last.nextFlowState.unit).toBeNull(); // no confirm; finalized
+    expect(last.sideEffect).toEqual({
+      kind: reg.SIDE_EFFECT.LOOKUP_ATTENDANCE,
+      unit: 'attendance',
+      collected: { beneficiaryName: 'سارة', date: 'اليوم' },
+    });
+    expect(last.reply).toMatch(/سجل الحضور/);
+  });
+
+  test('home-exercises unit returns department-specific content (no side effect)', () => {
+    const turns = ['6', 'سارة', 'نطق وتخاطب'];
+    const { last } = walk(turns);
+    expect(last.sideEffect).toBeNull();
+    expect(last.nextFlowState.unit).toBeNull();
+    expect(last.reply).toMatch(/نطق وتخاطب/);
+    expect(last.reply).toMatch(/تسمية الصور/); // speech-specific exercise
+  });
+
+  test('unit-3 "إلغاء" is recorded as the action, not treated as an abort', () => {
+    const enter = engine.handleTurn(null, '3');
+    expect(enter.nextFlowState.unit).toBe('appointment');
+    const afterAction = engine.handleTurn(enter.nextFlowState, 'إلغاء');
+    // still inside the flow, advanced to step 1 (beneficiary name)
+    expect(afterAction.nextFlowState.unit).toBe('appointment');
+    expect(afterAction.nextFlowState.step).toBe(1);
+    expect(afterAction.nextFlowState.collected.action).toBe('إلغاء');
+  });
+
+  test('free-text keyword (no number) enters the right unit from idle', () => {
+    const plan = engine.handleTurn(null, 'أبغى تمارين في البيت');
+    expect(plan.nextFlowState.unit).toBe('home_exercises');
+  });
+
+  test('invalid answer during confirm re-asks (does not advance or escalate)', () => {
+    const turns = ['9', 'أحمد', '0500000000', '-', 'تأخر الموعد', '-'];
+    const { finalState } = walk(turns);
+    expect(finalState.phase).toBe('confirming');
+    const noise = engine.handleTurn(finalState, 'ممكن توضح؟');
+    expect(noise.sideEffect).toBeNull();
+    expect(noise.nextFlowState.phase).toBe('confirming');
+    expect(noise.reply).toMatch(/نعم.*لا|للتأكيد/);
+  });
+
+  test('empty / media-only inbound mid-flow re-asks the current prompt', () => {
+    const enter = engine.handleTurn(null, '2');
+    const empty = engine.handleTurn(enter.nextFlowState, '');
+    expect(empty.nextFlowState.unit).toBe('register');
+    expect(empty.reply).toMatch(/اسم ولي الأمر/);
+  });
+});

--- a/backend/intelligence/whatsapp-bot-flow.registry.js
+++ b/backend/intelligence/whatsapp-bot-flow.registry.js
@@ -1,0 +1,534 @@
+'use strict';
+
+/**
+ * whatsapp-bot-flow.registry.js — W1366.
+ *
+ * Pure constants + helpers for the **stateful, menu-driven WhatsApp bot**
+ * ("مساعد الأوائل الذكي"). This is the conversational backbone the existing
+ * WhatsApp stack was missing: the inbound pipeline (whatsappWebhook →
+ * whatsappAI.classifyIntent → autoReply.decide) is **stateless** — one
+ * inbound message → one classification → one reply. It has no concept of
+ * "which step of a multi-turn flow is this user on".
+ *
+ * This registry + its sibling service (`whatsapp-bot-flow.service.js`) add
+ * a deterministic finite-state machine that implements the center's WhatsApp
+ * specification:
+ *
+ *   - A welcome message that DISCLOSES it is a bot ("بوت افتراضي") and offers
+ *     human escalation (WhatsApp business-bot policy + the center's spec §1).
+ *   - A numbered 10-unit main menu.
+ *   - Per-unit multi-step data-collection flows (registration, appointment
+ *     request, complaint, human callback) that gather fields one short question
+ *     at a time, summarize, ask for confirmation, then emit a structured
+ *     `sideEffect` for the dispatcher to act on.
+ *   - Read-only "lookup" units (attendance / session reports / billing) that
+ *     collect identifiers then hand off to staff (live-data wiring is a
+ *     deliberate follow-up wave — see PARITY note below).
+ *   - Static informational units (center info, home exercises, notifications).
+ *
+ * Design choices (mirrors `parent-chatbot.registry.js`):
+ *   - **Rule-based + PURE.** No LLM, no DB, no network in this module or its
+ *     service core. Deterministic to test, cheap to run, safe against prompt
+ *     injection. The dispatcher (webhook handler) owns ALL side effects
+ *     (sending, persistence, escalation).
+ *   - **Arabic-first.** All user-facing strings are Arabic; keyword catalogues
+ *     lean Arabic with English aliases.
+ *   - **Linear step machines.** Each unit's flow is an ordered list of steps;
+ *     no conditional branching inside a flow (keeps the FSM trivially testable).
+ *     Three-way actions (book/edit/cancel) are captured as a free-text answer,
+ *     not as branching.
+ *
+ * PARITY / scope (v1 — W1366): units 4/5/7 (attendance, session reports,
+ * billing) COLLECT the identifying inputs then escalate to staff with the
+ * structured payload. They do NOT yet query live attendance/report/invoice
+ * data — that is an explicit follow-up wave. The `sideEffect.kind` names
+ * (`LOOKUP_*`) let that future wave wire DB reads without touching the FSM.
+ *
+ * @module intelligence/whatsapp-bot-flow.registry
+ */
+
+// ─── Center identity (spec §3 — معلومات ثابتة) ───────────────────────────────
+const CENTER = Object.freeze({
+  nameAr: 'مراكز الأوائل للرعاية النهارية',
+  cityAr: 'الرياض',
+});
+
+// ─── Side-effect kinds the dispatcher knows how to act on ────────────────────
+// The FSM never performs I/O; it returns one of these so the webhook handler
+// can escalate / create a record / do nothing. All of them currently escalate
+// to staff with the collected payload; named kinds let future waves wire a
+// dedicated DB write (e.g. CREATE_COMPLAINT → ComplaintEnhanced.create).
+const SIDE_EFFECT = Object.freeze({
+  NONE: 'none',
+  CREATE_REGISTRATION: 'create_registration', // unit 2
+  CREATE_APPOINTMENT_REQUEST: 'create_appointment_request', // unit 3
+  LOOKUP_ATTENDANCE: 'lookup_attendance', // unit 4 (escalates in v1)
+  LOOKUP_SESSION_REPORT: 'lookup_session_report', // unit 5 (escalates in v1)
+  LOOKUP_BILLING: 'lookup_billing', // unit 7 (escalates in v1)
+  CREATE_COMPLAINT: 'create_complaint', // unit 9
+  CALLBACK_REQUEST: 'callback_request', // unit 10
+});
+
+// ─── Conversation phases inside an active flow ───────────────────────────────
+const PHASE = Object.freeze({
+  COLLECTING: 'collecting',
+  CONFIRMING: 'confirming',
+});
+
+// Footer appended to every closing message (spec §17 — "ذكّر بكلمة القائمة").
+const MENU_HINT = 'اكتب "القائمة" في أي وقت للعودة للقائمة الرئيسية.';
+
+// ─── Static informational content ────────────────────────────────────────────
+
+// Unit 1 — center / services / categories (spec §5).
+const INFO_TEXT = [
+  `🏥 *${CENTER.nameAr} – ${CENTER.cityAr}*`,
+  'مركز متخصص في تأهيل ورعاية ذوي الإعاقة، نضع لكل مستفيد خطة فردية تبدأ بتقييم أولي، ثم خطة علاجية، ثم متابعة وتقارير دورية.',
+  '',
+  '👥 *الفئات التي نستقبلها:*',
+  '• اضطراب طيف التوحد',
+  '• الإعاقة الذهنية',
+  '• الإعاقة الحركية',
+  '• صعوبات التعلم',
+  '• اضطرابات النطق والتخاطب',
+  '• تأخر النمو العام',
+  '',
+  '🩺 *الأقسام والبرامج:*',
+  '• علاج وظيفي',
+  '• علاج نطق وتخاطب',
+  '• تربية خاصة / مهارات الحياة اليومية',
+  '• تعديل السلوك / الدعم النفسي',
+  '• أنشطة جماعية (مهارية، اجتماعية، ترفيهية)',
+].join('\n');
+
+// Unit 8 — notifications & alerts (spec §12). Informational only.
+const NOTIFICATIONS_INFO = [
+  '🔔 *الإشعارات والتنبيهات*',
+  'نرسل لكم — بعد موافقتكم — تنبيهات تخص أبناءكم، مثل:',
+  '• تذكير بمواعيد الجلسات والتقييم',
+  '• إشعارات الحضور والانصراف',
+  '• إعلانات الفعاليات (يوم مفتوح، لقاء أولياء الأمور)',
+  '• تنبيهات طارئة (تعليق الدوام لظرف طارئ)',
+  '',
+  'لإيقاف الإشعارات في أي وقت اكتب: "إيقاف الإشعارات"، أو تواصل مع الاستقبال.',
+].join('\n');
+
+// Unit 6 — home-exercise suggestions per department (spec §10). Keyed by a
+// normalized department token; the service resolves the chosen department to
+// the closest key. These are GENERAL wellbeing activities, NOT a clinical
+// prescription (spec §2 — لا تقدّم تشخيصاً؛ شرح عام فقط).
+const HOME_EXERCISES = Object.freeze({
+  occupational: [
+    '🧩 *تمارين منزلية — علاج وظيفي:*',
+    '1) الإمساك والتلوين: 10 دقائق مرتين يومياً لتقوية عضلات اليد.',
+    '2) فرز الأشياء بالألوان أو الأحجام: مرة يومياً لتنمية التآزر البصري الحركي.',
+    '3) أنشطة اللصق والقص الآمن: 3 مرات أسبوعياً.',
+  ].join('\n'),
+  speech: [
+    '🗣️ *تمارين منزلية — نطق وتخاطب:*',
+    '1) تسمية الصور والأشياء أثناء اللعب: عدة مرات يومياً.',
+    '2) تكرار كلمات قصيرة بوضوح أمام المرآة: 5 دقائق مرتين يومياً.',
+    '3) استغلال مواقف اليوم (الأكل، الخروج) لتشجيع الكلام والحوار القصير.',
+  ].join('\n'),
+  special_education: [
+    '📚 *تمارين منزلية — تربية خاصة / مهارات الحياة:*',
+    '1) مهارة العناية بالذات (غسل اليدين، ارتداء الملابس): خطوة بخطوة يومياً.',
+    '2) ترتيب الألعاب بعد اللعب: مهمة يومية بسيطة لتعزيز الاستقلالية.',
+    '3) فرز وتصنيف الأدوات المنزلية الآمنة: مرة يومياً.',
+  ].join('\n'),
+  behavior: [
+    '🌟 *تمارين منزلية — دعم سلوكي:*',
+    '1) جدول تعزيز إيجابي بالنجوم عند ظهور السلوك المرغوب.',
+    '2) روتين يومي ثابت للنوم والأكل واللعب يقلّل السلوكيات غير المرغوبة.',
+    '3) تجاهل منظّم للسلوك البسيط مع تعزيز البديل المناسب.',
+  ].join('\n'),
+});
+
+// ─── Unit / menu definitions ─────────────────────────────────────────────────
+// Order here IS the menu numbering 1..10. `steps[i].key` is the field name
+// stored in `collected`; `optional:true` lets the user skip with "-"/"تخطي".
+// `confirm:false` units skip the summary→confirm step (read-only / info).
+const UNITS = Object.freeze([
+  // 1 — INFO (static, zero steps)
+  {
+    id: 'info',
+    label: 'معلومات عن المركز والخدمات',
+    steps: [],
+    confirm: false,
+    sideEffect: SIDE_EFFECT.NONE,
+    finalize: () => INFO_TEXT,
+  },
+  // 2 — REGISTER (spec §6)
+  {
+    id: 'register',
+    label: 'التسجيل الأولي / فتح ملف مستفيد جديد',
+    intro: 'شكراً لاهتمامك بالتسجيل في مراكز الأوائل. سأحتاج بعض المعلومات الأولية:',
+    steps: [
+      { key: 'guardianName', prompt: 'اسم ولي الأمر (ثلاثي):' },
+      { key: 'beneficiaryName', prompt: 'اسم المستفيد (رباعي):' },
+      { key: 'age', prompt: 'عمر المستفيد (بالسنوات والأشهر إن أمكن):' },
+      { key: 'gender', prompt: 'الجنس (ذكر / أنثى):' },
+      { key: 'city', prompt: 'المدينة:' },
+      {
+        key: 'guardianPhone',
+        prompt: 'رقم جوال ولي الأمر إن كان يختلف عن رقم الواتساب الحالي (أو اكتب "-" للتخطي):',
+        optional: true,
+      },
+      { key: 'priorDiagnosis', prompt: 'هل يوجد تشخيص سابق؟ إن نعم اذكره باختصار (أو اكتب "لا"):' },
+      { key: 'hasReports', prompt: 'هل توجد تقارير طبية أو تقارير أخصائيين سابقة؟ (نعم / لا)' },
+    ],
+    confirm: true,
+    sideEffect: SIDE_EFFECT.CREATE_REGISTRATION,
+    closing:
+      'تم إرسال طلب التسجيل لقسم القبول والتسجيل ✅\nسيتم التواصل معكم خلال (1–3) أيام عمل لتحديد موعد التقييم الأولي بإذن الله.',
+  },
+  // 3 — APPOINTMENT book/edit/cancel (spec §7)
+  {
+    id: 'appointment',
+    label: 'حجز / تعديل / إلغاء موعد',
+    intro: 'سأساعدك في الموعد. أجب على الأسئلة التالية:',
+    steps: [
+      { key: 'action', prompt: 'ماذا ترغب أن تفعل؟ (حجز / تعديل / إلغاء)' },
+      { key: 'beneficiaryName', prompt: 'اسم المستفيد:' },
+      { key: 'department', prompt: 'القسم: (علاج وظيفي / نطق / تربية خاصة / سلوك / آخر)' },
+      { key: 'preferredDay', prompt: 'اليوم أو التاريخ المفضل (مثال: الأحد القادم / 2026-06-20):' },
+      { key: 'preferredPeriod', prompt: 'الفترة الزمنية (صباح / مساء / وقت محدد إن أمكن):' },
+    ],
+    confirm: true,
+    sideEffect: SIDE_EFFECT.CREATE_APPOINTMENT_REQUEST,
+    closing: 'تم استلام طلب الموعد ✅\nسيتواصل معكم قسم الاستقبال لتأكيد الموعد المناسب بإذن الله.',
+  },
+  // 4 — ATTENDANCE lookup (spec §8.ب) — collects, escalates in v1
+  {
+    id: 'attendance',
+    label: 'تقارير الحضور والانصراف',
+    intro: 'للاستعلام عن الحضور والانصراف:',
+    steps: [
+      { key: 'beneficiaryName', prompt: 'اسم المستفيد:' },
+      { key: 'date', prompt: 'التاريخ المطلوب (أو اكتب: اليوم):' },
+    ],
+    confirm: false,
+    sideEffect: SIDE_EFFECT.LOOKUP_ATTENDANCE,
+    closing: 'تم استلام طلب سجل الحضور ✅\nسيتم تزويدكم بالنتيجة من قبل الاستقبال خلال وقت العمل.',
+  },
+  // 5 — SESSION REPORTS lookup (spec §9) — collects, escalates in v1
+  {
+    id: 'session_reports',
+    label: 'التقارير اليومية / الأسبوعية للجلسات',
+    intro: 'للاستعلام عن تقارير الجلسات:',
+    steps: [
+      { key: 'beneficiaryName', prompt: 'اسم المستفيد:' },
+      { key: 'department', prompt: 'القسم: (وظيفي / نطق / تربية خاصة / سلوك)' },
+      { key: 'period', prompt: 'الفترة: (اليوم / هذا الأسبوع / هذا الشهر / آخر تقرير)' },
+    ],
+    confirm: false,
+    sideEffect: SIDE_EFFECT.LOOKUP_SESSION_REPORT,
+    closing:
+      'تم استلام طلب التقرير ✅\nسيتم تجهيزه ومشاركته معكم من قبل الفريق المختص.\n🔒 حفاظاً على الخصوصية، يُرسَل التقرير لولي الأمر فقط.',
+  },
+  // 6 — HOME EXERCISES (static content per department, spec §10)
+  {
+    id: 'home_exercises',
+    label: 'المتابعة المنزلية والتمارين المقترحة',
+    intro: 'لاقتراح تمارين منزلية مناسبة:',
+    steps: [
+      { key: 'beneficiaryName', prompt: 'اسم المستفيد:' },
+      { key: 'department', prompt: 'القسم: (وظيفي / نطق / تربية خاصة / سلوك)' },
+    ],
+    confirm: false,
+    sideEffect: SIDE_EFFECT.NONE,
+    // finalize is provided by the service (needs department → content mapping).
+  },
+  // 7 — BILLING lookup (spec §11) — collects, escalates in v1
+  {
+    id: 'billing',
+    label: 'الرسوم والفواتير والاشتراكات',
+    intro: 'للاستعلام عن الرسوم والفواتير:',
+    steps: [
+      { key: 'guardianName', prompt: 'اسم ولي الأمر:' },
+      { key: 'beneficiaryName', prompt: 'اسم المستفيد:' },
+      {
+        key: 'fileNumber',
+        prompt: 'رقم الملف أو الهوية إن توفّر (أو اكتب "-" للتخطي):',
+        optional: true,
+      },
+    ],
+    confirm: false,
+    sideEffect: SIDE_EFFECT.LOOKUP_BILLING,
+    closing:
+      'تم استلام طلب كشف الحساب ✅\nسيتواصل معكم قسم المالية بالتفاصيل.\n⚠️ لا تشاركوا بيانات البطاقات البنكية في المحادثة حفاظاً على أمنكم.',
+  },
+  // 8 — NOTIFICATIONS (static, zero steps, spec §12)
+  {
+    id: 'notifications',
+    label: 'الإشعارات والتنبيهات',
+    steps: [],
+    confirm: false,
+    sideEffect: SIDE_EFFECT.NONE,
+    finalize: () => NOTIFICATIONS_INFO,
+  },
+  // 9 — COMPLAINT (spec §13)
+  {
+    id: 'complaint',
+    label: 'الشكاوى والملاحظات',
+    intro: 'نعتذر عن أي إزعاج، وشكراً لملاحظتك التي تساعدنا على التطوير. أجب على التالي:',
+    steps: [
+      { key: 'name', prompt: 'الاسم:' },
+      { key: 'contactPhone', prompt: 'رقم التواصل:' },
+      { key: 'beneficiaryName', prompt: 'اسم المستفيد (إن وجد، أو اكتب "-"):', optional: true },
+      { key: 'description', prompt: 'صف المشكلة أو الملاحظة باختصار:' },
+      { key: 'whenAt', prompt: 'وقت وتاريخ الواقعة تقريباً (أو اكتب "-"):', optional: true },
+    ],
+    confirm: true,
+    sideEffect: SIDE_EFFECT.CREATE_COMPLAINT,
+    closing:
+      'تم رفع الشكوى للإدارة المختصة ✅\nوسيتم التواصل معكم في أقرب وقت خلال أوقات العمل الرسمية.',
+  },
+  // 10 — HUMAN callback (spec §14)
+  {
+    id: 'human',
+    label: 'التواصل مع موظف أو أخصائي بشري',
+    intro: 'سأحوّلك لزميل مختص. أحتاج بعض المعلومات:',
+    steps: [
+      { key: 'name', prompt: 'الاسم:' },
+      { key: 'contactPhone', prompt: 'رقم التواصل:' },
+      { key: 'bestTime', prompt: 'أفضل وقت للتواصل:' },
+      { key: 'topic', prompt: 'موضوع الطلب (تسجيل / تقرير / شكوى / استفسار):' },
+    ],
+    confirm: true,
+    sideEffect: SIDE_EFFECT.CALLBACK_REQUEST,
+    closing:
+      'تم تحويل طلبك لأحد الزملاء المختصين ✅\nسيتم التواصل معك في أقرب وقت خلال أوقات العمل.',
+  },
+]);
+
+// Fast lookup: unit id → unit object.
+const UNIT_BY_ID = Object.freeze(
+  UNITS.reduce((acc, u) => {
+    acc[u.id] = u;
+    return acc;
+  }, {})
+);
+
+// ─── Triggers + free-text keyword routing (spec §15 — NLU lite) ──────────────
+// Words that ALWAYS reset to the main menu (even mid-flow).
+const MENU_TRIGGERS = Object.freeze([
+  'القائمة',
+  'القايمة',
+  'ابدأ',
+  'ابدا',
+  'البداية',
+  'بداية',
+  'الخيارات',
+  'menu',
+  'start',
+  'options',
+]);
+
+// Words that abort an in-progress flow back to the menu. Deliberately EXCLUDES
+// "إلغاء"/"الغاء" because those are valid answers to unit 3's action step
+// ("إلغاء موعد"). Aborting mid-flow uses distinct words instead.
+const CANCEL_TRIGGERS = Object.freeze([
+  'رجوع',
+  'خروج',
+  'توقف',
+  'الغاء الطلب',
+  'إلغاء الطلب',
+  'back',
+  'exit',
+  'cancel',
+]);
+
+const YES_TOKENS = Object.freeze([
+  'نعم',
+  'ايوه',
+  'اي',
+  'تمام',
+  'موافق',
+  'اكد',
+  'تاكيد',
+  'أكد',
+  'تأكيد',
+  'yes',
+  'y',
+  'ok',
+  'confirm',
+]);
+
+const NO_TOKENS = Object.freeze(['لا', 'لأ', 'كلا', 'الغاء', 'إلغاء', 'no', 'n', 'cancel']);
+
+const SKIP_TOKENS = Object.freeze(['-', '—', 'تخطي', 'تخطى', 'skip', 'لا يوجد', 'لايوجد']);
+
+// Free-text → unit id, for when the user types intent words instead of a number
+// (spec §15: "أبغى تقرير اليوم" → unit 5, "حضوره اليوم" → unit 4, etc.). Each
+// entry: unitId → keyword list (matched as normalized substrings).
+const UNIT_KEYWORDS = Object.freeze({
+  info: ['معلومات', 'خدماتكم', 'وش تقدمون', 'وش خدماتكم', 'عن المركز', 'الفئات', 'services'],
+  register: ['تسجيل', 'ملف جديد', 'مستفيد جديد', 'اسجل', 'التحاق', 'register', 'enroll'],
+  appointment: ['موعد', 'احجز', 'حجز', 'تقييم', 'appointment', 'booking'],
+  attendance: ['حضور', 'انصراف', 'حضوره', 'غياب', 'attendance'],
+  session_reports: [
+    'تقرير الجلسة',
+    'تقارير الجلسات',
+    'تقرير اليوم',
+    'تقرير الجلسة',
+    'session report',
+  ],
+  home_exercises: ['تمارين', 'تمرين', 'واجب منزلي', 'تمارين البيت', 'home exercise', 'homework'],
+  billing: [
+    'فاتورة',
+    'فواتير',
+    'رسوم',
+    'اشتراك',
+    'حسابي',
+    'مستحق',
+    'invoice',
+    'billing',
+    'payment',
+  ],
+  notifications: ['اشعارات', 'تنبيهات', 'notifications', 'alerts'],
+  complaint: ['شكوى', 'شكاوى', 'ملاحظة', 'مشكلة', 'اعتراض', 'complaint'],
+  human: ['موظف', 'انسان', 'بشري', 'اخصائي', 'تكلم مع', 'human', 'agent', 'representative'],
+});
+
+// ─── Pure helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Convert Arabic-Indic (٠-٩) and Extended/Persian (۰-۹) digits to ASCII so
+ * "١" and "۱" both parse as menu selection 1. Pure.
+ */
+function toAsciiDigits(s) {
+  if (!s || typeof s !== 'string') return '';
+  let out = '';
+  for (const ch of s) {
+    const code = ch.codePointAt(0);
+    if (code >= 0x0660 && code <= 0x0669)
+      out += String(code - 0x0660); // Arabic-Indic
+    else if (code >= 0x06f0 && code <= 0x06f9)
+      out += String(code - 0x06f0); // Extended
+    else out += ch;
+  }
+  return out;
+}
+
+/**
+ * Normalize text for keyword / token matching: ASCII-fold digits, lowercase,
+ * strip Arabic diacritics + tatweel, fold alef/ya/ta variants, collapse
+ * whitespace. Pure. (Stored field VALUES are kept raw; this is match-only.)
+ */
+function normalize(s) {
+  if (!s || typeof s !== 'string') return '';
+  return toAsciiDigits(s)
+    .toLowerCase()
+    .replace(/[ً-ْ]/g, '') // harakat
+    .replace(/ـ/g, '') // tatweel
+    .replace(/[أإآٱ]/g, 'ا') // أ إ آ ٱ → ا
+    .replace(/ى/g, 'ي') // ى → ي
+    .replace(/ة/g, 'ه') // ة → ه
+    .replace(/[٠-٩۰-۹]/g, '') // (already folded; safety)
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function matchesAny(text, tokens) {
+  const n = normalize(text);
+  if (!n) return false;
+  return tokens.some(t => {
+    const nt = normalize(t);
+    // Short tokens (≤2 chars, e.g. "لا", "اي", "y") must match the WHOLE message
+    // to avoid firing inside longer answers; longer tokens match as substrings.
+    return nt.length <= 2 ? n === nt : n.includes(nt);
+  });
+}
+
+function isMenuTrigger(text) {
+  return matchesAny(text, MENU_TRIGGERS);
+}
+
+function isCancelTrigger(text) {
+  return matchesAny(text, CANCEL_TRIGGERS);
+}
+
+function isYes(text) {
+  return matchesAny(text, YES_TOKENS);
+}
+
+function isNo(text) {
+  return matchesAny(text, NO_TOKENS);
+}
+
+function isSkip(text) {
+  const n = normalize(text);
+  return SKIP_TOKENS.some(t => normalize(t) === n);
+}
+
+/**
+ * Parse a main-menu selection. Accepts a bare number 1..10 (ASCII or
+ * Arabic-Indic), optionally wrapped in the numbered-emoji or punctuation a user
+ * might copy ("1️⃣", "٢-", "رقم 3"). Returns the 1-based index or null.
+ */
+function parseMenuSelection(text) {
+  if (!text) return null;
+  const ascii = toAsciiDigits(String(text)).trim();
+  const m = ascii.match(/(?:^|[^\d])(10|[1-9])(?:[^\d]|$)/);
+  if (!m) return null;
+  const n = parseInt(m[1], 10);
+  return n >= 1 && n <= UNITS.length ? n : null;
+}
+
+/**
+ * Resolve the unit a user wants from idle: numeric selection first, then
+ * free-text keyword routing (spec §15). Returns a unit id or null.
+ */
+function resolveUnitId(text) {
+  const sel = parseMenuSelection(text);
+  if (sel) return UNITS[sel - 1].id;
+  for (const [unitId, keywords] of Object.entries(UNIT_KEYWORDS)) {
+    if (matchesAny(text, keywords)) return unitId;
+  }
+  return null;
+}
+
+/**
+ * Map a free-text department answer (unit 6) to a HOME_EXERCISES key. Returns
+ * a key or null when unrecognized.
+ */
+function resolveDepartmentKey(text) {
+  const n = normalize(text);
+  if (!n) return null;
+  if (/(وظيف|occupation|ot\b)/.test(n)) return 'occupational';
+  if (/(نطق|تخاطب|لغ|speech|slp)/.test(n)) return 'speech';
+  if (/(تربي|مهارات|اكاديم|special|education)/.test(n)) return 'special_education';
+  if (/(سلوك|نفس|behav|psych)/.test(n)) return 'behavior';
+  return null;
+}
+
+module.exports = {
+  CENTER,
+  SIDE_EFFECT,
+  PHASE,
+  MENU_HINT,
+  INFO_TEXT,
+  NOTIFICATIONS_INFO,
+  HOME_EXERCISES,
+  UNITS,
+  UNIT_BY_ID,
+  MENU_TRIGGERS,
+  CANCEL_TRIGGERS,
+  YES_TOKENS,
+  NO_TOKENS,
+  SKIP_TOKENS,
+  UNIT_KEYWORDS,
+  // helpers
+  toAsciiDigits,
+  normalize,
+  matchesAny,
+  isMenuTrigger,
+  isCancelTrigger,
+  isYes,
+  isNo,
+  isSkip,
+  parseMenuSelection,
+  resolveUnitId,
+  resolveDepartmentKey,
+};

--- a/backend/intelligence/whatsapp-bot-flow.service.js
+++ b/backend/intelligence/whatsapp-bot-flow.service.js
@@ -1,0 +1,258 @@
+'use strict';
+
+/**
+ * whatsapp-bot-flow.service.js — W1366.
+ *
+ * The **stateful finite-state machine** for the menu-driven WhatsApp bot. It is
+ * PURE: `handleTurn(flowState, rawText, ctx)` takes the persisted flow state +
+ * the inbound message + light context and returns a plan:
+ *
+ *   {
+ *     reply: string,            // the text to send back
+ *     nextFlowState: object,    // persist this on the conversation (idle = {unit:null})
+ *     sideEffect: { kind, unit, collected } | null,  // dispatcher acts on this
+ *     handled: boolean,         // false ⇒ engine declined; caller may fall through
+ *   }
+ *
+ * No DB, no network, no `Date.now()`-dependent branching. The dispatcher
+ * (whatsappWebhook.service) owns ALL I/O: sending the reply, persisting
+ * `nextFlowState`, and acting on `sideEffect` (escalate / create record).
+ *
+ * State shape (persisted on WhatsAppConversation.botFlow):
+ *   { unit: <unitId|null>, step: <int>, collected: {…}, phase: 'collecting'|'confirming' }
+ * An "idle" state is `{ unit: null }` (or null/undefined).
+ *
+ * @module intelligence/whatsapp-bot-flow.service
+ */
+
+const reg = require('./whatsapp-bot-flow.registry');
+
+const IDLE = Object.freeze({ unit: null, step: 0, collected: {}, phase: null });
+
+/** Is the user currently inside a flow? */
+function isActive(flowState) {
+  return !!(flowState && flowState.unit && reg.UNIT_BY_ID[flowState.unit]);
+}
+
+// ─── Rendering helpers ───────────────────────────────────────────────────────
+
+/**
+ * Build the welcome + numbered main menu (spec §4). Discloses the bot identity
+ * and offers human escalation — required for WhatsApp business-bot policy. When
+ * `ctx.guardianName` is known, personalize the greeting.
+ */
+function renderWelcome(ctx = {}) {
+  const greeting = ctx.guardianName ? `مرحباً ${ctx.guardianName} 👋` : 'مرحباً بك 👋';
+  const lines = [
+    greeting,
+    `أنا *مساعد الأوائل الذكي* (بوت افتراضي 🤖) الخاص بـ ${reg.CENTER.nameAr} – ${reg.CENTER.cityAr}.`,
+    'أسعد بخدمتك في كل ما يتعلق بتأهيل ورعاية أبنائكم وبناتكم ❤️',
+    'يمكنك في أي وقت كتابة "موظف" للتحدث مع شخص بشري.',
+    '',
+    'يرجى اختيار أحد الخيارات بكتابة رقمه:',
+    '',
+  ];
+  reg.UNITS.forEach((u, i) => lines.push(`${i + 1}) ${u.label}`));
+  lines.push('');
+  lines.push(reg.MENU_HINT);
+  return lines.join('\n');
+}
+
+/** Prompt text for a given unit + step index. */
+function stepPrompt(unit, stepIndex) {
+  const step = unit.steps[stepIndex];
+  return step ? step.prompt : '';
+}
+
+/** First message when entering a multi-step unit: optional intro + step 0. */
+function enterUnitMessage(unit) {
+  const first = stepPrompt(unit, 0);
+  return unit.intro ? `${unit.intro}\n\n${first}` : first;
+}
+
+/**
+ * Build the "please review" summary from collected answers (spec: every flow
+ * summarizes before confirming). Skips empty optional fields.
+ */
+function renderSummary(unit, collected) {
+  const lines = [`📋 *ملخص طلبك (${unit.label}):*`, ''];
+  for (const step of unit.steps) {
+    const val = collected[step.key];
+    if (val == null || String(val).trim() === '') continue;
+    const label = step.prompt
+      .replace(/[:：].*$/s, '')
+      .replace(/\s*\(.*\)\s*$/s, '')
+      .trim();
+    lines.push(`• ${label}: ${val}`);
+  }
+  lines.push('');
+  lines.push('هل تؤكد إرسال الطلب؟ (نعم / لا)');
+  return lines.join('\n');
+}
+
+/**
+ * Closing message after a flow completes. Unit 6 (home exercises) resolves
+ * department-specific content; everything else uses the unit's `closing` (or a
+ * `finalize()` for the static units). Always appends the menu hint.
+ */
+function renderClosing(unit, collected) {
+  let body;
+  if (typeof unit.finalize === 'function') {
+    body = unit.finalize(collected);
+  } else if (unit.id === 'home_exercises') {
+    const key = reg.resolveDepartmentKey(collected.department || '');
+    body = key
+      ? reg.HOME_EXERCISES[key]
+      : [
+          'لم أتعرّف على القسم المطلوب بدقة. القسم المتاح: وظيفي / نطق / تربية خاصة / سلوك.',
+          'يمكنك إعادة المحاولة من القائمة، أو اكتب "موظف" للمساعدة.',
+        ].join('\n');
+  } else {
+    body = unit.closing || 'تم استلام طلبك بنجاح ✅';
+  }
+  return `${body}\n\n${reg.MENU_HINT}`;
+}
+
+// ─── Core state machine ──────────────────────────────────────────────────────
+
+function result(reply, nextFlowState, sideEffect = null, handled = true) {
+  return { reply, nextFlowState, sideEffect, handled };
+}
+
+/**
+ * Enter a unit from idle: zero-step units finalize immediately (and emit any
+ * side effect); multi-step units start collecting at step 0.
+ */
+function enterUnit(unitId, ctx) {
+  const unit = reg.UNIT_BY_ID[unitId];
+  if (!unit) return result(renderWelcome(ctx), { ...IDLE });
+
+  if (!unit.steps.length) {
+    // Static / zero-step unit (info, notifications): reply + back to idle.
+    const sideEffect =
+      unit.sideEffect && unit.sideEffect !== reg.SIDE_EFFECT.NONE
+        ? { kind: unit.sideEffect, unit: unit.id, collected: {} }
+        : null;
+    return result(renderClosing(unit, {}), { ...IDLE }, sideEffect);
+  }
+
+  return result(enterUnitMessage(unit), {
+    unit: unit.id,
+    step: 0,
+    collected: {},
+    phase: reg.PHASE.COLLECTING,
+  });
+}
+
+/**
+ * Advance a collecting flow after storing the current answer.
+ * Returns the next plan (more prompts, summary→confirm, or immediate closing).
+ */
+function advanceCollecting(unit, state, rawText) {
+  const collected = { ...(state.collected || {}) };
+  const step = unit.steps[state.step];
+  // Store the answer. Optional steps accept a skip token → empty string.
+  collected[step.key] = step.optional && reg.isSkip(rawText) ? '' : String(rawText).trim();
+
+  const nextIndex = state.step + 1;
+  if (nextIndex < unit.steps.length) {
+    return result(stepPrompt(unit, nextIndex), {
+      unit: unit.id,
+      step: nextIndex,
+      collected,
+      phase: reg.PHASE.COLLECTING,
+    });
+  }
+
+  // Collection complete.
+  if (unit.confirm) {
+    return result(renderSummary(unit, collected), {
+      unit: unit.id,
+      step: state.step,
+      collected,
+      phase: reg.PHASE.CONFIRMING,
+    });
+  }
+
+  // Read-only / informational unit: finalize now.
+  const sideEffect =
+    unit.sideEffect && unit.sideEffect !== reg.SIDE_EFFECT.NONE
+      ? { kind: unit.sideEffect, unit: unit.id, collected }
+      : null;
+  return result(renderClosing(unit, collected), { ...IDLE }, sideEffect);
+}
+
+/**
+ * Handle one inbound turn.
+ *
+ * @param {object|null} flowState - persisted state ({unit:null} when idle)
+ * @param {string} rawText - the inbound message text (raw, not normalized)
+ * @param {object} [ctx] - { guardianName?, beneficiaryName? } for personalization
+ * @returns {{reply:string, nextFlowState:object, sideEffect:object|null, handled:boolean}}
+ */
+function handleTurn(flowState, rawText, ctx = {}) {
+  const text = rawText == null ? '' : String(rawText);
+  const active = isActive(flowState);
+
+  // Empty / media-only inbound: if mid-flow, re-ask current prompt; else menu.
+  if (!text.trim()) {
+    if (active) {
+      const unit = reg.UNIT_BY_ID[flowState.unit];
+      if (flowState.phase === reg.PHASE.CONFIRMING) {
+        return result('يرجى الرد بـ (نعم) للتأكيد أو (لا) للإلغاء.', flowState);
+      }
+      return result(stepPrompt(unit, flowState.step), flowState);
+    }
+    return result(renderWelcome(ctx), { ...IDLE });
+  }
+
+  // Menu trigger ALWAYS resets to the main menu, even mid-flow.
+  if (reg.isMenuTrigger(text)) {
+    return result(renderWelcome(ctx), { ...IDLE });
+  }
+
+  // ─── Idle: route to a unit or show the menu ──────────────────────────────
+  if (!active) {
+    const unitId = reg.resolveUnitId(text);
+    if (unitId) return enterUnit(unitId, ctx);
+    // Unrecognized while idle → greet + show the menu (safe default, spec §15).
+    return result(renderWelcome(ctx), { ...IDLE });
+  }
+
+  // ─── Active flow ─────────────────────────────────────────────────────────
+  const unit = reg.UNIT_BY_ID[flowState.unit];
+
+  // Abort words (distinct from "إلغاء" so unit-3 action answers survive).
+  if (reg.isCancelTrigger(text)) {
+    return result(`تم إلغاء العملية الحالية.\n\n${reg.MENU_HINT}`, { ...IDLE });
+  }
+
+  if (flowState.phase === reg.PHASE.CONFIRMING) {
+    if (reg.isYes(text)) {
+      const collected = flowState.collected || {};
+      const sideEffect =
+        unit.sideEffect && unit.sideEffect !== reg.SIDE_EFFECT.NONE
+          ? { kind: unit.sideEffect, unit: unit.id, collected }
+          : null;
+      return result(renderClosing(unit, collected), { ...IDLE }, sideEffect);
+    }
+    if (reg.isNo(text)) {
+      return result(`تم إلغاء الطلب ولم يُرسَل.\n\n${reg.MENU_HINT}`, { ...IDLE });
+    }
+    return result('يرجى الرد بـ (نعم) للتأكيد أو (لا) للإلغاء.', flowState);
+  }
+
+  // Collecting phase.
+  return advanceCollecting(unit, flowState, text);
+}
+
+module.exports = {
+  IDLE,
+  isActive,
+  handleTurn,
+  // exported for tests / dispatcher reuse
+  renderWelcome,
+  renderSummary,
+  renderClosing,
+  enterUnit,
+};

--- a/backend/models/WhatsAppConversation.js
+++ b/backend/models/WhatsAppConversation.js
@@ -179,6 +179,21 @@ const whatsappConversationSchema = new mongoose.Schema(
     resolvedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
     resolutionNote: String,
 
+    // ── W1366: stateful menu-bot flow state ──────────────────────────────
+    // Persists where the inbound sender is within a multi-step bot flow
+    // (registration / appointment / complaint / human callback, etc.). `unit`
+    // is null when idle (between flows). `collected` holds the partial answers
+    // gathered so far. The FSM lives in intelligence/whatsapp-bot-flow.service;
+    // this field is just its persisted cursor. `Mixed` keeps the engine free to
+    // evolve its collected-field shape without a schema migration.
+    botFlow: {
+      unit: { type: String, default: null }, // active unit id (null = idle)
+      step: { type: Number, default: 0 },
+      phase: { type: String, enum: ['collecting', 'confirming', null], default: null },
+      collected: { type: mongoose.Schema.Types.Mixed, default: {} },
+      updatedAt: Date,
+    },
+
     // Embedded data
     messages: [messageSchema],
     latestInsight: insightSchema,

--- a/backend/services/whatsapp/whatsappBotData.service.js
+++ b/backend/services/whatsapp/whatsappBotData.service.js
@@ -1,0 +1,471 @@
+'use strict';
+
+/**
+ * whatsappBotData.service.js — W1366 Wave 2.
+ *
+ * The **guardian-verified live-data layer** for the WhatsApp menu-bot. When the
+ * FSM finishes a read-only lookup unit (attendance / session report / billing)
+ * it emits a `LOOKUP_*` side effect carrying the collected inputs. This service
+ * resolves that into a real answer — but ONLY for a beneficiary the inbound
+ * phone is a *registered, authorized guardian* of.
+ *
+ * ─── PRIVACY / AUTHORIZATION (the whole point of this module) ────────────────
+ * The center's spec (§16) is explicit: detailed beneficiary data goes ONLY to
+ * an authorized guardian, and the SYSTEM verifies that via the phone number.
+ * So the authorization rule here is strict and binding-based, never name-based:
+ *
+ *   1. The inbound phone must resolve to a FamilyMember record (not deleted).
+ *   2. That member must be an AUTHORIZED guardian — `portalAccess.enabled`,
+ *      `isLegalGuardian`, or `isPrimaryContact`. A bare "other contact" is NOT
+ *      enough to receive clinical/financial detail.
+ *   3. The data returned is ALWAYS for a beneficiary in the phone's OWN
+ *      authorized set. The typed beneficiary name is used only to DISAMBIGUATE
+ *      among that phone's children (siblings) — never to look up a stranger's
+ *      child. If the phone has several children and the name doesn't confidently
+ *      match exactly one, we DECLINE (→ escalate to staff) rather than guess.
+ *
+ * Because every query is keyed by an authorized `beneficiaryId`, cross-branch
+ * leakage is structurally impossible — we never query by branch, only by the
+ * specific beneficiary the guardian is bound to.
+ *
+ * Env-gated SEPARATELY from the menu via `ENABLE_WHATSAPP_BOT_LIVE_DATA`
+ * (default OFF): the menu bot can run (escalation-only) without ever
+ * auto-sending sensitive data until the owner opts in.
+ *
+ * The pure helpers (authorization gate, sibling selection, formatters) are
+ * exported and unit-tested without a DB; the model-touching functions are thin
+ * wrappers that load data then delegate to the pure formatters. Every model
+ * load is defensive — a missing model/path returns null → the dispatcher falls
+ * back to escalation (fail-safe, never throws into the webhook).
+ *
+ * @module services/whatsapp/whatsappBotData.service
+ */
+
+const mongoose = require('mongoose');
+const logger = require('../../utils/logger');
+const reg = require('../../intelligence/whatsapp-bot-flow.registry');
+const whatsappService = require('./whatsappService');
+
+// Side-effect kinds this service answers.
+const LOOKUP_KINDS = Object.freeze(
+  new Set([
+    reg.SIDE_EFFECT.LOOKUP_ATTENDANCE,
+    reg.SIDE_EFFECT.LOOKUP_SESSION_REPORT,
+    reg.SIDE_EFFECT.LOOKUP_BILLING,
+  ])
+);
+
+function isLookupKind(kind) {
+  return LOOKUP_KINDS.has(kind);
+}
+
+// ─── Arabic label maps ───────────────────────────────────────────────────────
+const ATTENDANCE_STATUS_AR = Object.freeze({
+  present: 'حاضر ✅',
+  absent: 'غائب ⚠️',
+  late: 'متأخر ⏰',
+  excused: 'غياب بعذر',
+  sent_home: 'أُعيد للمنزل',
+});
+
+const SPECIALTY_AR = Object.freeze({
+  speech_therapy: 'نطق وتخاطب',
+  occupational_therapy: 'علاج وظيفي',
+  physical_therapy: 'علاج طبيعي',
+  behavioral_therapy: 'تعديل سلوك',
+  psychological: 'دعم نفسي',
+  educational: 'تربية خاصة',
+  social_work: 'خدمة اجتماعية',
+  nursing: 'تمريض',
+  vocational: 'تأهيل مهني',
+  recreational: 'أنشطة ترفيهية',
+  multidisciplinary: 'متعدد التخصصات',
+  other: 'أخرى',
+});
+
+const INVOICE_STATUS_AR = Object.freeze({
+  paid: 'مدفوعة',
+  partially_paid: 'مدفوعة جزئياً',
+  issued: 'صادرة (غير مدفوعة)',
+  overdue: 'متأخرة السداد',
+  draft: 'مسودة',
+  cancelled: 'ملغاة',
+  void: 'ملغاة',
+});
+
+// Maps the bot's department answer (unit 5) → ClinicalSession.specialty filter.
+const DEPT_KEY_TO_SPECIALTY = Object.freeze({
+  occupational: 'occupational_therapy',
+  speech: 'speech_therapy',
+  special_education: 'educational',
+  behavior: 'behavioral_therapy',
+});
+
+// ─── Lazy + defensive model loaders ──────────────────────────────────────────
+function loadModel(registeredName, requirePath) {
+  try {
+    return mongoose.model(registeredName);
+  } catch {
+    try {
+      return require(requirePath);
+    } catch (err) {
+      logger.warn(`[WhatsApp BotData] model ${registeredName} unavailable: ${err.message}`);
+      return null;
+    }
+  }
+}
+
+const getFamilyMemberModel = () =>
+  loadModel('FamilyMember', '../../domains/family/models/FamilyMember');
+const getBeneficiaryModel = () => loadModel('Beneficiary', '../../models/Beneficiary');
+const getAttendanceModel = () =>
+  loadModel('BeneficiaryDayAttendance', '../../models/BeneficiaryDayAttendance');
+const getClinicalSessionModel = () =>
+  loadModel('ClinicalSession', '../../domains/sessions/models/ClinicalSession');
+const getInvoiceModel = () => loadModel('FinanceInvoice', '../../models/finance/Invoice');
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PURE helpers (unit-tested without a DB)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Is this FamilyMember authorized to receive a beneficiary's detailed data?
+ * Portal access, legal guardianship, or primary-contact status all qualify; a
+ * bare secondary contact does not.
+ */
+function isAuthorizedMember(m) {
+  if (!m) return false;
+  return !!((m.portalAccess && m.portalAccess.enabled) || m.isLegalGuardian || m.isPrimaryContact);
+}
+
+/**
+ * Pick which beneficiary to answer for, from the phone's OWN authorized set.
+ *
+ * @param {Array<{beneficiaryId:string, name:string}>} candidates
+ * @param {string} typedName - the name the user typed (disambiguation only)
+ * @returns {{ok:true, beneficiaryId:string} | {ok:false, reason:string, count?:number}}
+ */
+function selectBeneficiary(candidates, typedName) {
+  const list = (candidates || []).filter(c => c && c.beneficiaryId);
+  if (list.length === 0) return { ok: false, reason: 'not_authorized' };
+  if (list.length === 1) return { ok: true, beneficiaryId: list[0].beneficiaryId };
+
+  // Multiple authorized children (siblings) → must match the typed name to one.
+  const n = reg.normalize(typedName || '');
+  if (!n) return { ok: false, reason: 'ambiguous_no_name', count: list.length };
+  const matches = list.filter(c => {
+    const cn = reg.normalize(c.name || '');
+    return cn && (cn.includes(n) || n.includes(cn));
+  });
+  if (matches.length === 1) return { ok: true, beneficiaryId: matches[0].beneficiaryId };
+  return {
+    ok: false,
+    reason: matches.length > 1 ? 'ambiguous_multiple_match' : 'ambiguous_no_match',
+    count: list.length,
+  };
+}
+
+/** Format a single attendance record (or its absence) for the guardian. */
+function formatAttendance(record, beneficiaryName, dateLabel) {
+  const who = beneficiaryName || 'المستفيد';
+  if (!record) {
+    return `📅 لا يوجد سجل حضور مُدوّن لـ ${who} بتاريخ ${dateLabel}.`;
+  }
+  const lines = [`📅 *سجل حضور ${who}* — ${dateLabel}`, ''];
+  lines.push(`• الحالة: ${ATTENDANCE_STATUS_AR[record.status] || record.status || 'غير محدد'}`);
+  if (record.checkInTime) lines.push(`• وقت الحضور: ${fmtTime(record.checkInTime)}`);
+  if (record.checkOutTime) lines.push(`• وقت الانصراف: ${fmtTime(record.checkOutTime)}`);
+  if (record.notes) lines.push(`• ملاحظة: ${record.notes}`);
+  return lines.join('\n');
+}
+
+/** Format up to N recent clinical sessions into a parent-friendly summary. */
+function formatSessionReports(sessions, beneficiaryName) {
+  const who = beneficiaryName || 'المستفيد';
+  if (!sessions || !sessions.length) {
+    return `📝 لا يوجد تقرير جلسة مكتمل لـ ${who} ضمن الفترة المطلوبة.`;
+  }
+  const lines = [`📝 *تقارير جلسات ${who}*`, ''];
+  for (const s of sessions) {
+    const spec = SPECIALTY_AR[s.specialty] || s.specialty || 'جلسة';
+    const date = fmtDate(s.scheduledDate);
+    const therapist =
+      s.therapistId && (s.therapistId.firstName || s.therapistId.lastName)
+        ? `${s.therapistId.firstName || ''} ${s.therapistId.lastName || ''}`.trim()
+        : null;
+    lines.push(`— *${spec}* (${date})${therapist ? ` مع ${therapist}` : ''}`);
+    const worked = s.plan || s.objective || s.assessment || s.subjective;
+    if (worked) lines.push(`  ${String(worked).slice(0, 200)}`);
+    if (Array.isArray(s.goalProgress) && s.goalProgress.length) {
+      const achieved = s.goalProgress.filter(
+        g => g && (g.rating === 'achieved' || g.rating === 'maintained')
+      ).length;
+      lines.push(`  الأهداف: ${achieved}/${s.goalProgress.length} محقّقة/مستمرة`);
+    }
+    lines.push('');
+  }
+  lines.push('🔒 هذا التقرير خاص بولي الأمر — يُرجى عدم مشاركته في مجموعات عامة.');
+  return lines.join('\n').trim();
+}
+
+/** Format an outstanding-balance summary from a beneficiary's invoices. */
+function formatBilling(invoices, beneficiaryName) {
+  const who = beneficiaryName || 'المستفيد';
+  if (!invoices || !invoices.length) {
+    return `💳 لا توجد فواتير مسجّلة لـ ${who} حالياً.`;
+  }
+  const outstanding = invoices.reduce((sum, inv) => sum + (Number(inv.balance_due) || 0), 0);
+  const latest = invoices[0];
+  const lines = [`💳 *كشف حساب ${who}*`, ''];
+  lines.push(`• إجمالي المبلغ المستحق: ${formatSar(outstanding)} ريال`);
+  if (latest) {
+    lines.push(`• حالة أحدث فاتورة: ${INVOICE_STATUS_AR[latest.status] || latest.status}`);
+    if (latest.due_date) lines.push(`• تاريخ الاستحقاق: ${fmtDate(latest.due_date)}`);
+    if (latest.invoice_number) lines.push(`• رقم الفاتورة: ${latest.invoice_number}`);
+  }
+  lines.push('');
+  lines.push('⚠️ لا تشاركوا بيانات البطاقات البنكية في المحادثة.');
+  return lines.join('\n');
+}
+
+/**
+ * Resolve a free-text period (unit 5) into a query window. `now` is injectable
+ * for deterministic tests. "آخر تقرير" → latest only (no date floor).
+ */
+function parsePeriod(text, now) {
+  const ref = now instanceof Date ? new Date(now.getTime()) : new Date();
+  const n = reg.normalize(text || '');
+  if (/(اخر|الاخير|last)/.test(n)) return { latestOnly: true, gte: null, label: 'آخر تقرير' };
+  if (/(اسبوع|week)/.test(n)) {
+    const gte = new Date(ref.getTime() - 7 * 86400000);
+    return { latestOnly: false, gte, label: 'هذا الأسبوع' };
+  }
+  if (/(شهر|month)/.test(n)) {
+    const gte = new Date(ref.getTime() - 30 * 86400000);
+    return { latestOnly: false, gte, label: 'هذا الشهر' };
+  }
+  if (/(اليوم|today)/.test(n)) {
+    const gte = startOfDay(ref);
+    return { latestOnly: false, gte, label: 'اليوم' };
+  }
+  // Default: last 30 days.
+  return { latestOnly: false, gte: new Date(ref.getTime() - 30 * 86400000), label: 'آخر فترة' };
+}
+
+/**
+ * Resolve a free-text date (unit 4) into a [start,end) day window. "اليوم" or
+ * blank → today; an ISO-ish date → that day; otherwise today. `now` injectable.
+ */
+function parseDay(text, now) {
+  const ref = now instanceof Date ? new Date(now.getTime()) : new Date();
+  const raw = reg.toAsciiDigits(String(text || '')).trim();
+  const n = reg.normalize(text || '');
+  let day = ref;
+  let label = 'اليوم';
+  if (n && !/(اليوم|today)/.test(n)) {
+    const parsed = new Date(raw);
+    if (!isNaN(parsed.getTime())) {
+      day = parsed;
+      label = fmtDate(parsed);
+    }
+  }
+  return { start: startOfDay(day), end: endOfDay(day), label };
+}
+
+// ─── small pure date/number formatters ───────────────────────────────────────
+function startOfDay(d) {
+  const x = new Date(d.getTime());
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+function endOfDay(d) {
+  const x = new Date(d.getTime());
+  x.setHours(23, 59, 59, 999);
+  return x;
+}
+function pad2(n) {
+  return String(n).padStart(2, '0');
+}
+function fmtDate(d) {
+  if (!d) return '';
+  const x = new Date(d);
+  if (isNaN(x.getTime())) return '';
+  return `${x.getFullYear()}-${pad2(x.getMonth() + 1)}-${pad2(x.getDate())}`;
+}
+function fmtTime(d) {
+  if (!d) return '';
+  const x = new Date(d);
+  if (isNaN(x.getTime())) return '';
+  return `${pad2(x.getHours())}:${pad2(x.getMinutes())}`;
+}
+function formatSar(amount) {
+  return (Math.round((Number(amount) || 0) * 100) / 100).toLocaleString('en-US');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// DB-touching resolvers (thin wrappers over the pure helpers)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Resolve the inbound phone to an AUTHORIZED beneficiary (see module authZ
+ * doctrine). Returns the selection + the beneficiary's display name.
+ */
+async function resolveAuthorizedBeneficiary(phone, typedName) {
+  const FamilyMember = getFamilyMemberModel();
+  const Beneficiary = getBeneficiaryModel();
+  if (!FamilyMember || !Beneficiary) return { ok: false, reason: 'models_unavailable' };
+
+  const norm = whatsappService.normalizePhone(phone);
+  const members = await FamilyMember.find({
+    $or: [
+      { phone },
+      { phone: norm },
+      { 'contactInfo.phone': phone },
+      { 'contactInfo.phone': norm },
+    ],
+    isDeleted: { $ne: true },
+  })
+    .lean()
+    .catch(() => []);
+
+  const authorizedIds = [
+    ...new Set(
+      (members || [])
+        .filter(isAuthorizedMember)
+        .map(m => m.beneficiaryId && String(m.beneficiaryId))
+        .filter(Boolean)
+    ),
+  ];
+  if (!authorizedIds.length) return { ok: false, reason: 'not_authorized' };
+
+  const bens = await Beneficiary.find({ _id: { $in: authorizedIds } })
+    .select('personalInfo.firstName personalInfo.lastName fileNumber')
+    .lean()
+    .catch(() => []);
+  const candidates = (bens || []).map(b => ({
+    beneficiaryId: String(b._id),
+    name: `${b.personalInfo?.firstName || ''} ${b.personalInfo?.lastName || ''}`.trim(),
+  }));
+
+  const sel = selectBeneficiary(candidates, typedName);
+  if (!sel.ok) return sel;
+  const chosen = candidates.find(c => c.beneficiaryId === sel.beneficiaryId);
+  return { ok: true, beneficiaryId: sel.beneficiaryId, beneficiaryName: chosen?.name || typedName };
+}
+
+async function getAttendance(beneficiaryId, beneficiaryName, dateText) {
+  const Attendance = getAttendanceModel();
+  if (!Attendance) return null;
+  const { start, end, label } = parseDay(dateText);
+  const record = await Attendance.findOne({
+    beneficiaryId: new mongoose.Types.ObjectId(beneficiaryId),
+    date: { $gte: start, $lte: end },
+  })
+    .lean()
+    .catch(() => null);
+  return formatAttendance(record, beneficiaryName, label);
+}
+
+async function getSessionReport(beneficiaryId, beneficiaryName, departmentText, periodText) {
+  const ClinicalSession = getClinicalSessionModel();
+  if (!ClinicalSession) return null;
+  const period = parsePeriod(periodText);
+  const deptKey = reg.resolveDepartmentKey(departmentText || '');
+  const specialty = deptKey ? DEPT_KEY_TO_SPECIALTY[deptKey] : null;
+
+  const filter = {
+    beneficiaryId: new mongoose.Types.ObjectId(beneficiaryId),
+    status: 'completed',
+    isDeleted: { $ne: true },
+  };
+  if (specialty) filter.specialty = specialty;
+  if (period.gte) filter.scheduledDate = { $gte: period.gte };
+
+  const sessions = await ClinicalSession.find(filter)
+    .sort({ scheduledDate: -1 })
+    .limit(period.latestOnly ? 1 : 3)
+    .select(
+      'scheduledDate specialty therapistId subjective objective assessment plan goalProgress status'
+    )
+    .populate('therapistId', 'firstName lastName')
+    .lean()
+    .catch(() => []);
+  return formatSessionReports(sessions, beneficiaryName);
+}
+
+async function getBilling(beneficiaryId, beneficiaryName) {
+  const Invoice = getInvoiceModel();
+  if (!Invoice) return null;
+  const invoices = await Invoice.find({
+    beneficiary_id: new mongoose.Types.ObjectId(beneficiaryId),
+    deleted_at: null,
+    status: { $nin: ['cancelled', 'void', 'draft'] },
+  })
+    .sort({ invoice_date: -1 })
+    .limit(20)
+    .select('invoice_number total_amount paid_amount balance_due status due_date invoice_date')
+    .lean()
+    .catch(() => []);
+  return formatBilling(invoices, beneficiaryName);
+}
+
+/**
+ * Top-level entry the webhook calls for a LOOKUP_* side effect. Resolves the
+ * authorized beneficiary, runs the matching query, and returns ready-to-send
+ * text (incl. menu hint) — or `{ok:false, reason}` so the caller escalates.
+ */
+async function answerLookup(kind, phone, collected = {}) {
+  if (!isLookupKind(kind)) return { ok: false, reason: 'unsupported_kind' };
+  let sel;
+  try {
+    sel = await resolveAuthorizedBeneficiary(phone, collected.beneficiaryName);
+  } catch (err) {
+    logger.warn(`[WhatsApp BotData] resolve failed: ${err.message}`);
+    return { ok: false, reason: 'resolve_error' };
+  }
+  if (!sel.ok) return { ok: false, reason: sel.reason };
+
+  let text = null;
+  try {
+    if (kind === reg.SIDE_EFFECT.LOOKUP_ATTENDANCE) {
+      text = await getAttendance(sel.beneficiaryId, sel.beneficiaryName, collected.date);
+    } else if (kind === reg.SIDE_EFFECT.LOOKUP_SESSION_REPORT) {
+      text = await getSessionReport(
+        sel.beneficiaryId,
+        sel.beneficiaryName,
+        collected.department,
+        collected.period
+      );
+    } else if (kind === reg.SIDE_EFFECT.LOOKUP_BILLING) {
+      text = await getBilling(sel.beneficiaryId, sel.beneficiaryName);
+    }
+  } catch (err) {
+    logger.warn(`[WhatsApp BotData] lookup ${kind} failed: ${err.message}`);
+    return { ok: false, reason: 'lookup_error' };
+  }
+  if (!text) return { ok: false, reason: 'no_data_model' };
+  return { ok: true, text: `${text}\n\n${reg.MENU_HINT}` };
+}
+
+module.exports = {
+  isLookupKind,
+  LOOKUP_KINDS,
+  answerLookup,
+  resolveAuthorizedBeneficiary,
+  getAttendance,
+  getSessionReport,
+  getBilling,
+  // pure helpers (exported for unit tests)
+  isAuthorizedMember,
+  selectBeneficiary,
+  formatAttendance,
+  formatSessionReports,
+  formatBilling,
+  parsePeriod,
+  parseDay,
+  // label maps
+  ATTENDANCE_STATUS_AR,
+  SPECIALTY_AR,
+  INVOICE_STATUS_AR,
+  DEPT_KEY_TO_SPECIALTY,
+};

--- a/backend/services/whatsapp/whatsappWebhook.service.js
+++ b/backend/services/whatsapp/whatsappWebhook.service.js
@@ -357,7 +357,38 @@ async function handleIncomingMessage(msg, contact, _phoneNumberId) {
       });
 
       if (plan && plan.handled) {
-        const sent = await whatsappService.sendText(fromPhone, plan.reply).catch(err => {
+        // W1366 Wave 2: for read-only lookup side effects (attendance / session
+        // report / billing), attempt a GUARDIAN-VERIFIED live answer — env-gated
+        // SEPARATELY via ENABLE_WHATSAPP_BOT_LIVE_DATA (default OFF). On success
+        // the real data REPLACES the generic "we'll get back to you" closing and
+        // escalation is suppressed. On any failure (not authorized / ambiguous /
+        // no data / model missing) we keep the closing and escalate to staff.
+        let replyToSend = plan.reply;
+        let suppressEscalation = false;
+        if (process.env.ENABLE_WHATSAPP_BOT_LIVE_DATA === 'true' && plan.sideEffect) {
+          try {
+            const botData = require('./whatsappBotData.service');
+            if (botData.isLookupKind(plan.sideEffect.kind)) {
+              const ans = await botData.answerLookup(
+                plan.sideEffect.kind,
+                fromPhone,
+                plan.sideEffect.collected
+              );
+              if (ans && ans.ok && ans.text) {
+                replyToSend = ans.text;
+                suppressEscalation = true;
+              } else {
+                logger.info(
+                  `[WhatsApp BotData] lookup not delivered (${ans?.reason}) → escalating`
+                );
+              }
+            }
+          } catch (err) {
+            logger.warn(`[WhatsApp BotData] answerLookup error, escalating: ${err.message}`);
+          }
+        }
+
+        const sent = await whatsappService.sendText(fromPhone, replyToSend).catch(err => {
           logger.warn(`[WhatsApp BotMenu] send failed: ${err.message}`);
           return null;
         });
@@ -374,7 +405,7 @@ async function handleIncomingMessage(msg, contact, _phoneNumberId) {
             messages: {
               direction: 'outgoing',
               type: 'text',
-              text: plan.reply,
+              text: replyToSend,
               providerMessageId: sent.messageId,
               timestamp: new Date(),
               isAutoReply: true,
@@ -386,15 +417,15 @@ async function handleIncomingMessage(msg, contact, _phoneNumberId) {
           logger.warn(`[WhatsApp BotMenu] state persist failed: ${err.message}`)
         );
 
-        // A completed flow that produced a side effect → flag for staff + notify.
-        if (plan.sideEffect) {
+        // A completed flow whose side effect was NOT served live → flag staff.
+        if (plan.sideEffect && !suppressEscalation) {
           await escalateForBot(Conversation, conv, fromPhone, senderName, plan.sideEffect);
         }
 
         logger.info(
           `[WhatsApp BotMenu] handled inbound from ${fromPhone} | ` +
             `nextUnit=${plan.nextFlowState?.unit || 'idle'} | ` +
-            `sideEffect=${plan.sideEffect?.kind || 'none'}`
+            `sideEffect=${plan.sideEffect?.kind || 'none'} | liveData=${suppressEscalation}`
         );
         return; // bot owns this turn; skip the stateless auto-reply path
       }

--- a/backend/services/whatsapp/whatsappWebhook.service.js
+++ b/backend/services/whatsapp/whatsappWebhook.service.js
@@ -337,6 +337,72 @@ async function handleIncomingMessage(msg, contact, _phoneNumberId) {
     : senderName;
   const beneficiaryName = familyMember?.beneficiaryName || ctxName;
 
+  // ─── W1366: stateful menu-bot (env-gated, default OFF) ───────────────────
+  // When ENABLE_WHATSAPP_BOT_MENU=true, a deterministic FSM drives the inbound
+  // turn (welcome menu + multi-step flows: registration / appointment request /
+  // complaint / human callback / read-only lookups). It runs BEFORE the
+  // stateless autoReply classifier and, when it handles the turn, short-circuits
+  // it. Inert unless the flag is set, so existing behavior is unchanged by
+  // default. Any engine error falls through to the stateless path (fail-safe).
+  if (process.env.ENABLE_WHATSAPP_BOT_MENU === 'true' && content.text && Conversation && conv) {
+    try {
+      const botFlow = require('../../intelligence/whatsapp-bot-flow.service');
+      const priorState =
+        conv.botFlow && conv.botFlow.unit !== undefined
+          ? conv.botFlow
+          : { unit: null, step: 0, collected: {}, phase: null };
+      const plan = botFlow.handleTurn(priorState, content.text, {
+        guardianName: ctxName,
+        beneficiaryName,
+      });
+
+      if (plan && plan.handled) {
+        const sent = await whatsappService.sendText(fromPhone, plan.reply).catch(err => {
+          logger.warn(`[WhatsApp BotMenu] send failed: ${err.message}`);
+          return null;
+        });
+
+        const update = {
+          $set: {
+            botFlow: { ...plan.nextFlowState, updatedAt: new Date() },
+            lastMessageAt: new Date(),
+            unreadCount: 0,
+          },
+        };
+        if (sent && sent.success) {
+          update.$push = {
+            messages: {
+              direction: 'outgoing',
+              type: 'text',
+              text: plan.reply,
+              providerMessageId: sent.messageId,
+              timestamp: new Date(),
+              isAutoReply: true,
+              deliveryStatus: 'sent',
+            },
+          };
+        }
+        await Conversation.updateOne({ _id: conv._id }, update).catch(err =>
+          logger.warn(`[WhatsApp BotMenu] state persist failed: ${err.message}`)
+        );
+
+        // A completed flow that produced a side effect → flag for staff + notify.
+        if (plan.sideEffect) {
+          await escalateForBot(Conversation, conv, fromPhone, senderName, plan.sideEffect);
+        }
+
+        logger.info(
+          `[WhatsApp BotMenu] handled inbound from ${fromPhone} | ` +
+            `nextUnit=${plan.nextFlowState?.unit || 'idle'} | ` +
+            `sideEffect=${plan.sideEffect?.kind || 'none'}`
+        );
+        return; // bot owns this turn; skip the stateless auto-reply path
+      }
+    } catch (err) {
+      logger.warn(`[WhatsApp BotMenu] engine error, falling through: ${err.message}`);
+    }
+  }
+
   // After recording inbound, the 24h service window is open by definition.
   const decision = autoReply.decide(classified, {
     canReplyFreeForm: true,
@@ -512,6 +578,64 @@ async function handleIncomingMessage(msg, contact, _phoneNumberId) {
   logger.info(
     `[WhatsApp] Inbound from ${fromPhone} | intent=${classified.intent} | urgency=${classified.urgencyLevel}`
   );
+}
+
+// ─── W1366: escalate a completed bot-flow side effect to staff ──────────────
+// The menu-bot FSM is pure and performs no I/O; when a flow finishes with a
+// `sideEffect` (registration / appointment / complaint / callback / a v1
+// read-only lookup), the dispatcher flags the conversation for the staff
+// pending-review queue and fires an in-app notification carrying the structured
+// `collected` payload. A future wave can branch on `sideEffect.kind` to create
+// a dedicated record (ComplaintEnhanced, PublicBookingRequest, …) instead of —
+// or in addition to — escalating. Never throws.
+const BOT_SIDE_EFFECT_REASON = Object.freeze({
+  create_registration: 'طلب تسجيل جديد عبر بوت الواتساب',
+  create_appointment_request: 'طلب موعد عبر بوت الواتساب',
+  lookup_attendance: 'استعلام حضور/انصراف عبر بوت الواتساب',
+  lookup_session_report: 'طلب تقرير جلسة عبر بوت الواتساب',
+  lookup_billing: 'استعلام فواتير عبر بوت الواتساب',
+  create_complaint: 'شكوى جديدة عبر بوت الواتساب',
+  callback_request: 'طلب تواصل بشري عبر بوت الواتساب',
+});
+
+async function escalateForBot(Conversation, conv, fromPhone, senderName, sideEffect) {
+  const reason = BOT_SIDE_EFFECT_REASON[sideEffect.kind] || `بوت الواتساب: ${sideEffect.kind}`;
+  try {
+    await Conversation.updateOne(
+      { _id: conv._id },
+      {
+        $set: {
+          requiresHumanReview: true,
+          status: 'pending_review',
+          escalationReason: reason,
+          escalatedAt: new Date(),
+        },
+      }
+    );
+  } catch (err) {
+    logger.warn(`[WhatsApp BotMenu] escalate flag failed: ${err.message}`);
+  }
+  try {
+    const notifService = require('../notifications/notification-enhanced.service');
+    if (notifService?.send) {
+      await notifService.send({
+        title: `🤖 بوت واتساب — ${reason} (${senderName})`,
+        body: JSON.stringify(sideEffect.collected || {}).slice(0, 500),
+        type: 'alert',
+        priority: sideEffect.kind === 'create_complaint' ? 'high' : 'medium',
+        category: 'whatsapp_bot_request',
+        channels: ['inApp'],
+        metadata: {
+          phone: fromPhone,
+          conversationId: conv?._id,
+          sideEffectKind: sideEffect.kind,
+          collected: sideEffect.collected || {},
+        },
+      });
+    }
+  } catch (err) {
+    logger.warn(`[WhatsApp BotMenu] notify failed: ${err.message}`);
+  }
 }
 
 module.exports = {

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -870,6 +870,7 @@ __tests__/warehouse-routes-branch-isolation-wave877.test.js
 __tests__/wbci-trigger-engine-wave471.test.js
 __tests__/weighted-progress-link-index-wave243.test.js
 __tests__/whatsapp-autoreply-template-gate-wave738.test.js
+__tests__/whatsapp-bot-data-lookup-wave1366.test.js
 __tests__/whatsapp-bot-flow-menu-wave1366.test.js
 __tests__/whatsapp-broadcast-preview-wave747.test.js
 __tests__/whatsapp-byid-org-scope-wave744.test.js

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -870,6 +870,7 @@ __tests__/warehouse-routes-branch-isolation-wave877.test.js
 __tests__/wbci-trigger-engine-wave471.test.js
 __tests__/weighted-progress-link-index-wave243.test.js
 __tests__/whatsapp-autoreply-template-gate-wave738.test.js
+__tests__/whatsapp-bot-flow-menu-wave1366.test.js
 __tests__/whatsapp-broadcast-preview-wave747.test.js
 __tests__/whatsapp-byid-org-scope-wave744.test.js
 __tests__/whatsapp-canonical-consolidation-wave725.test.js


### PR DESCRIPTION
## What

Adds the **stateful, menu-driven WhatsApp bot** ("مساعد الأوائل الذكي") the center spec called for. The existing WhatsApp inbound pipeline was **stateless** (one message → one classification → one reply); this adds a deterministic finite-state machine on top: a welcome menu (with bot-identity disclosure + human escalation) and 10 multi-step flows, fully gated behind env flags so existing behavior is unchanged until opted in.

## Two waves (both env-gated, default OFF)

**Wave 1 — menu engine** (`ENABLE_WHATSAPP_BOT_MENU`)
- `intelligence/whatsapp-bot-flow.registry.js` — pure constants + helpers (10-unit menu, per-unit step defs, triggers, Arabic-digit-aware menu parsing, keyword routing, yes/no/cancel/skip detection).
- `intelligence/whatsapp-bot-flow.service.js` — `handleTurn(flowState, text, ctx) → {reply, nextFlowState, sideEffect, handled}`. No DB/network/`Date.now`. Welcome → menu → collect → summary → confirm → closing + structured side effect.
- `WhatsAppConversation.botFlow` — persisted flow cursor.
- `whatsappWebhook.service` — runs the FSM **before** the stateless `autoReply` classifier and short-circuits it when handled; `escalateForBot()` flags completed requests for the staff pending-review queue.

**Wave 2 — guardian-verified live data** (`ENABLE_WHATSAPP_BOT_LIVE_DATA`, requires Wave 1)
- `services/whatsapp/whatsappBotData.service.js` — the attendance / session-report / billing units return **real data** instead of escalating, but strictly gated on guardian authorization.

### Authorization doctrine (privacy-critical, spec §16)
- Inbound phone must resolve to a `FamilyMember` that is an **authorized guardian** (`portalAccess.enabled` / `isLegalGuardian` / `isPrimaryContact`).
- Data is **always** for a beneficiary in the phone's **own** authorized set; the typed name only disambiguates among that phone's children (siblings). Ambiguous / unverified → decline + escalate (never look a stranger's child up by name).
- Every query is keyed by an authorized `beneficiaryId`, so cross-branch leakage is structurally impossible.

## Tests
- 46 W1366 tests (27 menu FSM static+behavioral, 19 live-data pure authZ + formatters). All green.
- Full WhatsApp suite (35 files / 288 tests) green — no regression.
- Enumerated in `sprint-tests.txt` + CI `paths:` synced.

## Enabling in prod
1. `ENABLE_WHATSAPP_BOT_MENU=true` → menu + flows (escalation-only, fully safe).
2. Optionally `ENABLE_WHATSAPP_BOT_LIVE_DATA=true` → guardian-verified live data.
Both require WhatsApp live (`WHATSAPP_API_TOKEN` + `WHATSAPP_WEBHOOK_SECRET`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)