### PR TITLE
W1286: executable launch-readiness checker (GO/NO-GO)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1753,6 +1753,8 @@ on:
       - 'backend/__tests__/email-registry-bridge-wave1270.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/smoke-clinical-spine-wave1285.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/launch-readiness-wave1286.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3484,6 +3486,8 @@ on:
       - 'backend/__tests__/email-registry-bridge-wave1270.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/smoke-clinical-spine-wave1285.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/launch-readiness-wave1286.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/launch-readiness-wave1286.test.js
+++ b/backend/__tests__/launch-readiness-wave1286.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+/**
+ * W1286 — guard for the launch-readiness checker.
+ *
+ * The checker runs LIVE read-only against a DB (verified on prod by hand);
+ * this guard is STATIC, locking its safety + semantics so a future edit can't
+ * turn it destructive or make INFO items block launch.
+ *
+ *  1. READ-ONLY — only countDocuments; never any write/mutate op.
+ *  2. CHECKLIST COVERAGE — maps the runbook's "Definition of launched" items
+ *     (forms/measures/branches/users/beneficiary/session-split/mail/demo).
+ *  3. SEMANTICS — INFO never blocks; verdict GO iff zero NOT-YET; owner-gated
+ *     items (SMTP, demo-data) are INFO not NOT-YET (refuse to fail someone
+ *     else's decision); every NOT-YET carries a fix command.
+ *  4. WIRED — npm run launch:readiness exists; points to the active smokes.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const BACKEND = path.join(__dirname, '..');
+const SRC = fs.readFileSync(path.join(BACKEND, 'scripts', 'launch-readiness.js'), 'utf8');
+const PKG = JSON.parse(fs.readFileSync(path.join(BACKEND, 'package.json'), 'utf8'));
+
+describe('W1286 launch-readiness — read-only safety', () => {
+  test('NEVER mutates: no write/destructive mongo ops', () => {
+    expect(SRC).not.toMatch(/\.(insertOne|insertMany|create|updateOne|updateMany|deleteOne|deleteMany|drop|save)\(/);
+  });
+
+  test('reads via countDocuments only', () => {
+    expect(SRC).toMatch(/countDocuments\(/);
+    expect(SRC).toMatch(/function countSafe/);
+  });
+});
+
+describe('W1286 launch-readiness — checklist coverage', () => {
+  const required = [
+    'forms catalog seeded',
+    'measures library seeded',
+    'goal bank seeded',
+    'branch exists',
+    'user exists',
+    'beneficiary registered',
+    'session write/read split',
+    'mail transport configured',
+    'demo-data fate',
+  ];
+  test.each(required)('covers checklist item: %s', (item) => {
+    expect(SRC).toContain(item);
+  });
+});
+
+describe('W1286 launch-readiness — verdict semantics', () => {
+  test('GO iff zero NOT-YET; exit 0 on GO else 1', () => {
+    expect(SRC).toMatch(/const go = blocking\.length === 0/);
+    expect(SRC).toMatch(/blocking = checks\.filter\(\(c\) => c\.status === 'NOT-YET'\)/);
+    expect(SRC).toMatch(/process\.exit\(go \? 0 : 1\)/);
+  });
+
+  test('owner-gated items use INFO with their fix hint (mail + demo-data)', () => {
+    // mail: the no-creds detail must sit inside an INFO( call
+    expect(SRC).toMatch(/INFO\(\s*\n?\s*'mail transport configured'/);
+    // demo-data: the present-demo branch must be INFO (not NOTYET)
+    expect(SRC).toMatch(/if \(demo > 0\) \{[\s\S]{0,200}INFO\(/);
+    // and demo INFO must NOT be a NOTYET anywhere
+    expect(SRC).not.toMatch(/NOTYET\(\s*\n?\s*'demo-data/);
+    expect(SRC).not.toMatch(/NOTYET\(\s*\n?\s*'mail transport/);
+  });
+
+  test('NOT-YET items carry npm/provision fix commands', () => {
+    // every NOTYET fix string in the file references a runnable action
+    const fixHints = SRC.match(/'(npm run [^']+|provision[^']+|register[^']+|verify the[^']+)'/g) || [];
+    expect(fixHints.length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe('W1286 launch-readiness — wiring', () => {
+  test('npm run launch:readiness + :json exist', () => {
+    expect(PKG.scripts['launch:readiness']).toBe('node scripts/launch-readiness.js');
+    expect(PKG.scripts['launch:readiness:json']).toBe('node scripts/launch-readiness.js --json');
+  });
+
+  test('points operators to the active smokes', () => {
+    expect(SRC).toMatch(/smoke:launch-spine/);
+    expect(SRC).toMatch(/smoke:clinical-spine/);
+  });
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,6 +37,8 @@
     "seed:cbahi": "node scripts/seed-cbahi-attestations.js",
     "seed:cbahi:list": "node scripts/seed-cbahi-attestations.js --list",
     "seed:cbahi:dry": "node scripts/seed-cbahi-attestations.js --dry-run",
+    "launch:readiness": "node scripts/launch-readiness.js",
+    "launch:readiness:json": "node scripts/launch-readiness.js --json",
     "provision:staff": "node scripts/provision-launch-staff.js",
     "provision:staff:dry": "node scripts/provision-launch-staff.js --dry-run",
     "provision:staff:list": "node scripts/provision-launch-staff.js --list",

--- a/backend/scripts/launch-readiness.js
+++ b/backend/scripts/launch-readiness.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * launch-readiness.js — W1286.
+ *
+ * The EXECUTABLE form of docs/GO_LIVE_RUNBOOK_2026-06-11.md's "Definition of
+ * launched" checklist. The runbook sequences the steps; this gives an operator
+ * a single GO / NOT-YET verdict against the REAL database — turning ~8 manual
+ * "verify that…" lines into one mechanical read-only status with the exact
+ * remaining command for each gap.
+ *
+ * 100% READ-ONLY: counts + env presence only. No writes, no smoke docs (active
+ * verification stays in the explicit `npm run smoke:launch-spine` /
+ * `smoke:clinical-spine`, which this report points to). Safe to run anytime,
+ * including against prod.
+ *
+ * Each check is PASS / NOT-YET / INFO:
+ *   PASS    — mechanically satisfied.
+ *   NOT-YET — a concrete launch gap; the fix command is printed.
+ *   INFO    — owner-gated / judgement call (SMTP, demo-data fate); never a
+ *             hard fail (refuse to declare someone else's decision "wrong").
+ *
+ * Verdict: GO when zero NOT-YET; otherwise NOT-YET with the blocking list.
+ * INFO items never block (they're surfaced for the owner).
+ *
+ * Usage:  npm run launch:readiness   (or node scripts/launch-readiness.js [--json])
+ * Exit:   0 when GO (no NOT-YET) · 1 otherwise
+ */
+
+const path = require('path');
+try {
+  require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
+} catch (_e) {
+  /* optional */
+}
+
+const JSON_OUT = process.argv.includes('--json');
+const mongoose = require('mongoose');
+
+const checks = [];
+function record(status, name, detail, fix) {
+  checks.push({ status, name, detail, fix });
+}
+const PASS = (n, d) => record('PASS', n, d);
+const NOTYET = (n, d, fix) => record('NOT-YET', n, d, fix);
+const INFO = (n, d, fix) => record('INFO', n, d, fix);
+
+async function countSafe(coll, query = {}) {
+  try {
+    return await mongoose.connection.db.collection(coll).countDocuments(query);
+  } catch (_e) {
+    return null;
+  }
+}
+
+async function main() {
+  if (!process.env.MONGODB_URI) throw new Error('MONGODB_URI is required');
+  await mongoose.connect(process.env.MONGODB_URI);
+
+  // ── 1. Reference/config data seeded (runbook Phase A.2) ──────────
+  const forms = await countSafe('formtemplates');
+  forms > 0
+    ? PASS('forms catalog seeded', `${forms} templates`)
+    : NOTYET('forms catalog seeded', `${forms} templates`, 'npm run seed:forms-catalog');
+
+  const measures = await countSafe('measures_library', { status: 'active' });
+  measures > 0
+    ? PASS('measures library seeded', `${measures} active instruments`)
+    : NOTYET('measures library seeded', `${measures} active`, 'npm run seed:measures');
+
+  const goalbank = await countSafe('goalbanks');
+  goalbank > 0
+    ? PASS('goal bank seeded (R4 pathway bundles need it)', `${goalbank} goals`)
+    : NOTYET('goal bank seeded', `${goalbank} goals`, 'npm run seed:goal-bank');
+
+  const icf = await countSafe('icfcodes');
+  icf > 0
+    ? PASS('ICF codes seeded', `${icf} codes`)
+    : INFO('ICF codes seeded', `${icf == null ? 'collection absent' : icf} codes`, 'npm run seed:icf-codes');
+
+  // ── 2. Real org + staff exist (runbook A.3 / Definition #2) ──────
+  const branches = await countSafe('branches');
+  branches > 0
+    ? PASS('≥1 branch exists', `${branches} branch(es)`)
+    : NOTYET('≥1 branch exists', `${branches}`, 'provision via UI/admin or npm run provision:branches');
+
+  const users = await countSafe('users');
+  users > 0
+    ? PASS('≥1 user exists', `${users} user(s)`)
+    : NOTYET('≥1 user exists', `${users}`, 'provision via UI/admin or npm run provision:staff');
+
+  // ── 3. A beneficiary registered (Definition #3) ──────────────────
+  const bens = await countSafe('beneficiaries', { isDeleted: { $ne: true } });
+  bens > 0
+    ? PASS('≥1 beneficiary registered', `${bens}`)
+    : NOTYET('≥1 beneficiary registered', '0', 'register via the Arabic UI form');
+
+  // ── 4. Session write/read split RESOLVED (Definition #6, W1240) ──
+  // The UI writes ClinicalSession; analytics read TherapySession. If any
+  // ClinicalSession exists, at least one must have a TherapySession projection.
+  const clinSessions = await countSafe('clinicalsessions');
+  if (!clinSessions) {
+    INFO('session projection (W1240)', 'no ClinicalSessions yet — nothing to project', null);
+  } else {
+    const projected = await countSafe('therapysessions', { sourceClinicalSessionId: { $exists: true } });
+    projected > 0
+      ? PASS('session write/read split resolved (W1240 projection live)', `${projected} projected`)
+      : NOTYET(
+          'session write/read split resolved (W1240 projection)',
+          `${clinSessions} ClinicalSessions, 0 projected → analytics blind`,
+          'verify the W1240 projection hook; run npm run smoke:launch-spine'
+        );
+  }
+
+  // ── 5. Mail provisioned (Definition #1 — THE blocker) ────────────
+  const smtp = !!(process.env.SMTP_USER && process.env.SMTP_PASS) || !!process.env.SENDGRID_API_KEY;
+  smtp
+    ? PASS('mail transport configured', process.env.SENDGRID_API_KEY ? 'sendgrid' : 'smtp')
+    : INFO(
+        'mail transport configured',
+        'no SMTP_USER/PASS or SENDGRID_API_KEY → all mail no-ops (owner-gated)',
+        'set SMTP_USER + SMTP_PASS in .env + pm2 restart alawael-api --update-env'
+      );
+
+  // ── 6. Demo-data fate (Definition #8 — owner decision) ───────────
+  // The demo seed creates sequential national ids 11000000xx.
+  const demo = await countSafe('beneficiaries', { nationalId: { $regex: '^11000000' } });
+  if (demo > 0) {
+    INFO(
+      'demo-data fate decided',
+      `${demo} demo beneficiary(ies) present (sequential 11000000xx)`,
+      'keep-and-tag for soft launch OR seed:demo --reset to clear (DESTRUCTIVE, owner-gated)'
+    );
+  } else {
+    PASS('demo-data fate decided', 'no demo-tagged beneficiaries present');
+  }
+
+  await mongoose.disconnect().catch(() => null);
+
+  // ── verdict ──────────────────────────────────────────────────────
+  const blocking = checks.filter((c) => c.status === 'NOT-YET');
+  const infos = checks.filter((c) => c.status === 'INFO');
+  const go = blocking.length === 0;
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify({ go, checks }, null, 2));
+  } else {
+    const icon = { PASS: '✓', 'NOT-YET': '✗', INFO: 'ℹ' };
+    for (const c of checks) {
+      console.log(`${icon[c.status]} [${c.status}] ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
+      if (c.status === 'NOT-YET' && c.fix) console.log(`      → fix: ${c.fix}`);
+    }
+    console.log('');
+    console.log(
+      go
+        ? `✅ GO — all mechanical launch checks pass (${infos.length} owner-gated INFO item(s) to confirm)`
+        : `⛔ NOT-YET — ${blocking.length} launch gap(s): ${blocking.map((b) => b.name).join(', ')}`
+    );
+    if (infos.length && !go) {
+      console.log(`   (plus ${infos.length} owner-gated INFO item(s))`);
+    }
+    console.log('\nActive verification (run separately): npm run smoke:launch-spine · npm run smoke:clinical-spine');
+  }
+  process.exit(go ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('launch-readiness fatal:', err.message);
+  process.exit(1);
+});

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1043,3 +1043,4 @@ __tests__/portal-plan-mapper-wave1272.test.js
 __tests__/parent-v2-unified-plan-wave1273.test.js
 __tests__/email-registry-bridge-wave1270.test.js
 __tests__/smoke-clinical-spine-wave1285.test.js
+__tests__/launch-readiness-wave1286.test.js


### PR DESCRIPTION
Makes `docs/GO_LIVE_RUNBOOK_2026-06-11.md`'s 'Definition of launched' (8 manual verify-lines) into one read-only command: `npm run launch:readiness`.

100% read-only (countDocuments + env). Each check PASS / NOT-YET / INFO; **INFO (owner-gated: SMTP, demo-data) never blocks** — refuse to fail someone's decision. Verdict GO iff zero NOT-YET. Covers forms/measures/goal-bank/ICF · branches/users/beneficiary · W1240 session split · mail · demo-data. Points to the active smokes.

**Verified LIVE on prod: ✅ GO** — 83 forms / 8 measures / 72 goals / 4 branches / 13 users / 18 beneficiaries / **SMTP now configured (the runbook's #1 blocker RESOLVED)**; 3 owner-gated INFO.

16-assertion guard (read-only-safety + INFO-never-blocks + fix-commands). Sprint-enumerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)