### PR TITLE
W1287: fix 2 false-negative collection names in launch-readiness checker

### DIFF
--- a/backend/__tests__/launch-readiness-wave1286.test.js
+++ b/backend/__tests__/launch-readiness-wave1286.test.js
@@ -32,6 +32,16 @@ describe('W1286 launch-readiness — read-only safety', () => {
     expect(SRC).toMatch(/countDocuments\(/);
     expect(SRC).toMatch(/function countSafe/);
   });
+
+  // W1287 — collection names must match the REAL mongoose collection of each
+  // model, or a check silently false-negatives (prod had 105 ICF codes the
+  // checker reported as 0; ClinicalSession is collection:'clinical_sessions').
+  test('queries the correct (model-true) collection names', () => {
+    expect(SRC).toContain("countSafe('icfcodereferences')"); // ICFCodeReference → default plural
+    expect(SRC).toContain("countSafe('clinical_sessions')"); // explicit collection in the schema
+    expect(SRC).not.toMatch(/countSafe\('icfcodes'\)/); // the W1286 false-negative name
+    expect(SRC).not.toMatch(/countSafe\('clinicalsessions'\)/); // wrong default plural
+  });
 });
 
 describe('W1286 launch-readiness — checklist coverage', () => {

--- a/backend/scripts/launch-readiness.js
+++ b/backend/scripts/launch-readiness.js
@@ -74,7 +74,9 @@ async function main() {
     ? PASS('goal bank seeded (R4 pathway bundles need it)', `${goalbank} goals`)
     : NOTYET('goal bank seeded', `${goalbank} goals`, 'npm run seed:goal-bank');
 
-  const icf = await countSafe('icfcodes');
+  // W1287 — ICFCodeReference → mongoose default plural 'icfcodereferences'
+  // (the earlier 'icfcodes' guess was a false-negative: prod has 105 codes).
+  const icf = await countSafe('icfcodereferences');
   icf > 0
     ? PASS('ICF codes seeded', `${icf} codes`)
     : INFO('ICF codes seeded', `${icf == null ? 'collection absent' : icf} codes`, 'npm run seed:icf-codes');
@@ -99,7 +101,9 @@ async function main() {
   // ── 4. Session write/read split RESOLVED (Definition #6, W1240) ──
   // The UI writes ClinicalSession; analytics read TherapySession. If any
   // ClinicalSession exists, at least one must have a TherapySession projection.
-  const clinSessions = await countSafe('clinicalsessions');
+  // W1287 — ClinicalSession declares collection:'clinical_sessions' (explicit,
+  // underscored) — NOT the mongoose default 'clinicalsessions'.
+  const clinSessions = await countSafe('clinical_sessions');
   if (!clinSessions) {
     INFO('session projection (W1240)', 'no ClinicalSessions yet — nothing to project', null);
   } else {


### PR DESCRIPTION
Running the W1286 checker live on prod surfaced **its own bug** — it queried wrong collection names:

| check | wrong name | real name | prod truth |
|---|---|---|---|
| ICF codes | `icfcodes` | `icfcodereferences` | **105 codes** (was reported 0 → now PASS) |
| ClinicalSession | `clinicalsessions` | `clinical_sessions` (explicit in schema) | 0 (right by luck; name now correct) |

A readiness checker that lies is worse than none. Verified live: ICF flips INFO→PASS, verdict **✅ GO with 2 owner-gated INFO** (was 3). Guard +1 assertion locks both model-true names. (The other 6 checks returned non-zero → names already proven correct.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)