### PR TITLE
W1288: connect GO-LIVE runbook to the executable readiness trio (docs)

### DIFF
--- a/docs/GO_LIVE_RUNBOOK_2026-06-11.md
+++ b/docs/GO_LIVE_RUNBOOK_2026-06-11.md
@@ -153,13 +153,29 @@ constraint; adoption is.
 
 ---
 
+## Executable verification (W1285/W1286/W1287 — added 2026-06-16)
+
+Most of the "verify that…" lines below now have a one-command equivalent. Run
+these (read-only / safe-by-design; all proven LIVE on prod):
+
+| Command | Answers | Covers |
+| --- | --- | --- |
+| `npm run launch:readiness` | **GO / NOT-YET** (read-only: counts + env) | SMTP · branches/users · beneficiary · session-split · seeds · demo-data |
+| `npm run smoke:launch-spine` | data-ENTRY spine (register→session→form, incl. W1240 projection) | Phase-B paths 2–4 |
+| `npm run smoke:clinical-spine` | clinical VALUE-LOOP closes (goal↔measure→thread→NBA→roll-up) | the golden-thread spine |
+
+Last live run (prod, 2026-06-16): `launch:readiness` = **✅ GO** — 83 forms /
+8 measures / 72 goal-bank / 105 ICF / 4 branches / 13 users / 18 beneficiaries
+/ SMTP configured; 2 owner-gated INFO (demo-data fate, no real sessions yet).
+The smokes create-then-delete their own docs (prod data untouched).
+
 ## Definition of "launched"
 
-- [ ] SMTP provisioned; a password-reset email actually arrives.
-- [ ] ≥1 real branch + real admin/clinician users created (demo users removed or clearly tagged).
-- [ ] A real beneficiary registered via the Arabic form (persists, no 500).
-- [ ] A real therapy session logged against that beneficiary with goal progress.
-- [ ] The four Phase-B paths pass for a non-demo account.
+- [ ] SMTP provisioned; a password-reset email actually arrives. _(`launch:readiness`)_
+- [ ] ≥1 real branch + real admin/clinician users created (demo users removed or clearly tagged). _(`launch:readiness`)_
+- [ ] A real beneficiary registered via the Arabic form (persists, no 500). _(`smoke:launch-spine`)_
+- [ ] A real therapy session logged against that beneficiary with goal progress. _(`smoke:clinical-spine`)_
+- [ ] The four Phase-B paths pass for a non-demo account. _(`smoke:launch-spine`)_
 - [ ] **Session write/read split RESOLVED** (UI-logged `ClinicalSession` reaches Session-Center/episodes/goal-progress, not only the 360) — coordinated with `feat/w928-core-linkage`.
 - [ ] Other canonical models confirmed (no new writes to deprecated IEP/goal models).
 - [ ] Demo-showcase data decision made (kept-and-tagged or cleared).


### PR DESCRIPTION
Pure docs. The runbook's 'Definition of launched' was manual verify-prose; this session shipped the executable equivalents (W1285/W1286/W1287). Adds an 'Executable verification' table (command → checklist items + last live ✅ GO result) and annotates each checklist line with its `npm run` command — so the tooling is discoverable from where operators look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)