### PR TITLE
W1375: shared launch-readiness evaluator + read-only route (backs web-admin screen)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1758,6 +1758,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/whatsapp-bot-data-lookup-wave1372.test.js'
       - 'backend/__tests__/whatsapp-bot-flow-menu-wave1372.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/launch-readiness-service-wave1375.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3494,6 +3496,8 @@ on:
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/whatsapp-bot-data-lookup-wave1372.test.js'
       - 'backend/__tests__/whatsapp-bot-flow-menu-wave1372.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/launch-readiness-service-wave1375.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/launch-readiness-service-wave1375.test.js
+++ b/backend/__tests__/launch-readiness-service-wave1375.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+/**
+ * W1375 — shared launch-readiness evaluator + read-only route.
+ *
+ *  1. BEHAVIORAL — evaluateLaunchReadiness against a FAKE db (no Mongo): drives
+ *     every check via stubbed counts. Proves: GO iff zero NOT-YET; INFO
+ *     (SMTP/demo) never blocks; model-true collection names are queried; the
+ *     fix command rides each NOT-YET; summary tallies.
+ *  2. STATIC — CLI + route both consume the service (DRY); route is read-only,
+ *     admin-gated, registry-mounted.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const BACKEND = path.join(__dirname, '..');
+const read = (rel) => fs.readFileSync(path.join(BACKEND, rel), 'utf8');
+const { evaluateLaunchReadiness } = require('../services/launchReadiness.service');
+
+// Fake mongoose db: counts keyed by collection name; supports the $regex/query
+// args the evaluator passes (we only vary by collection name here).
+function fakeDb(counts) {
+  const queried = [];
+  return {
+    queried,
+    collection(name) {
+      queried.push(name);
+      return {
+        countDocuments: async () => {
+          if (!(name in counts)) return null; // unknown collection → null (absent)
+          return counts[name];
+        },
+      };
+    },
+  };
+}
+
+const FULL = {
+  formtemplates: 83,
+  measures_library: 8,
+  goalbanks: 72,
+  icfcodereferences: 105,
+  branches: 4,
+  users: 13,
+  beneficiaries: 18, // also used for the demo regex query → returns 18 unless overridden
+  clinical_sessions: 0,
+  therapysessions: 19,
+};
+
+describe('W1375 evaluator — verdict semantics', () => {
+  test('all seeded + no NOT-YET → GO; INFO items do not block', async () => {
+    // beneficiaries query is used twice (active + demo-regex); keep both >0 so
+    // "beneficiary registered" PASSes and "demo-data" INFOs.
+    const r = await evaluateLaunchReadiness({
+      db: fakeDb(FULL),
+      env: { SMTP_USER: 'u', SMTP_PASS: 'p' },
+    });
+    expect(r.go).toBe(true);
+    expect(r.summary.notYet).toBe(0);
+    expect(r.summary.info).toBeGreaterThanOrEqual(1); // demo-data INFO at least
+    expect(r.checks.find((c) => c.name.startsWith('mail')).status).toBe('PASS');
+  });
+
+  test('missing seeds → NOT-YET with a fix command each; verdict NOT-YET', async () => {
+    const r = await evaluateLaunchReadiness({
+      db: fakeDb({ ...FULL, formtemplates: 0, measures_library: 0, goalbanks: 0 }),
+      env: { SMTP_USER: 'u', SMTP_PASS: 'p' },
+    });
+    expect(r.go).toBe(false);
+    const notyets = r.checks.filter((c) => c.status === 'NOT-YET');
+    expect(notyets.length).toBeGreaterThanOrEqual(3);
+    for (const c of notyets) expect(typeof c.fix).toBe('string');
+  });
+
+  test('no SMTP → mail is INFO (owner-gated), NOT a blocker', async () => {
+    const r = await evaluateLaunchReadiness({ db: fakeDb(FULL), env: {} });
+    const mail = r.checks.find((c) => c.name.startsWith('mail'));
+    expect(mail.status).toBe('INFO');
+    // mail being unset must not flip GO on its own
+    expect(r.go).toBe(true);
+  });
+
+  test('queries the model-true collection names (W1287 lesson)', async () => {
+    const db = fakeDb(FULL);
+    await evaluateLaunchReadiness({ db, env: {} });
+    expect(db.queried).toContain('icfcodereferences');
+    expect(db.queried).toContain('clinical_sessions');
+    expect(db.queried).not.toContain('icfcodes');
+    expect(db.queried).not.toContain('clinicalsessions');
+  });
+
+  test('session split: ClinicalSessions present but 0 projected → NOT-YET', async () => {
+    const r = await evaluateLaunchReadiness({
+      db: fakeDb({ ...FULL, clinical_sessions: 5, therapysessions: 0 }),
+      env: { SMTP_USER: 'u', SMTP_PASS: 'p' },
+    });
+    const split = r.checks.find((c) => c.name.includes('session write/read split'));
+    expect(split.status).toBe('NOT-YET');
+    expect(r.go).toBe(false);
+  });
+
+  test('requires a db handle', async () => {
+    await expect(evaluateLaunchReadiness({})).rejects.toThrow(/db handle/);
+  });
+});
+
+describe('W1375 static wiring', () => {
+  test('CLI consumes the shared service (DRY, no inline check duplication)', () => {
+    const cli = read('scripts/launch-readiness.js');
+    expect(cli).toMatch(/require\('\.\.\/services\/launchReadiness\.service'\)/);
+    expect(cli).toMatch(/evaluateLaunchReadiness\(/);
+    // the inline check helpers must be GONE from the CLI
+    expect(cli).not.toMatch(/countSafe\('formtemplates'\)/);
+  });
+
+  test('route: read-only, admin-gated, consumes the service', () => {
+    const r = read('routes/launch-readiness.routes.js');
+    expect(r).not.toMatch(/router\.(post|put|patch|delete)\(/);
+    expect(r).toMatch(/requireRole\(ADMIN_ROLES\)/);
+    expect(r).toMatch(/evaluateLaunchReadiness\(/);
+  });
+
+  test('mounted via dualMountAuth in features.registry', () => {
+    const reg = read('routes/registries/features.registry.js');
+    expect(reg).toMatch(/safeRequire\('\.\.\/routes\/launch-readiness\.routes'\)/);
+    expect(reg).toMatch(/dualMountAuth\(app, 'launch-readiness', launchReadinessRoutes, authenticate\)/);
+  });
+});

--- a/backend/__tests__/launch-readiness-wave1286.test.js
+++ b/backend/__tests__/launch-readiness-wave1286.test.js
@@ -20,7 +20,12 @@ const fs = require('fs');
 const path = require('path');
 
 const BACKEND = path.join(__dirname, '..');
-const SRC = fs.readFileSync(path.join(BACKEND, 'scripts', 'launch-readiness.js'), 'utf8');
+// W1375 — the check logic moved from the CLI script into the shared
+// services/launchReadiness.service.js (consumed by CLI + HTTP route). The
+// content assertions below now target the service (one source of truth);
+// npm-wiring assertions still target package.json.
+const SRC = fs.readFileSync(path.join(BACKEND, 'services', 'launchReadiness.service.js'), 'utf8');
+const CLI = fs.readFileSync(path.join(BACKEND, 'scripts', 'launch-readiness.js'), 'utf8');
 const PKG = JSON.parse(fs.readFileSync(path.join(BACKEND, 'package.json'), 'utf8'));
 
 describe('W1286 launch-readiness — read-only safety', () => {
@@ -30,7 +35,7 @@ describe('W1286 launch-readiness — read-only safety', () => {
 
   test('reads via countDocuments only', () => {
     expect(SRC).toMatch(/countDocuments\(/);
-    expect(SRC).toMatch(/function countSafe/);
+    expect(SRC).toMatch(/countSafe\(/);
   });
 
   // W1287 — collection names must match the REAL mongoose collection of each
@@ -62,10 +67,10 @@ describe('W1286 launch-readiness — checklist coverage', () => {
 });
 
 describe('W1286 launch-readiness — verdict semantics', () => {
-  test('GO iff zero NOT-YET; exit 0 on GO else 1', () => {
+  test('GO iff zero NOT-YET (service); CLI exits 0 on GO else 1', () => {
     expect(SRC).toMatch(/const go = blocking\.length === 0/);
     expect(SRC).toMatch(/blocking = checks\.filter\(\(c\) => c\.status === 'NOT-YET'\)/);
-    expect(SRC).toMatch(/process\.exit\(go \? 0 : 1\)/);
+    expect(CLI).toMatch(/process\.exit\(go \? 0 : 1\)/);
   });
 
   test('owner-gated items use INFO with their fix hint (mail + demo-data)', () => {
@@ -91,8 +96,8 @@ describe('W1286 launch-readiness — wiring', () => {
     expect(PKG.scripts['launch:readiness:json']).toBe('node scripts/launch-readiness.js --json');
   });
 
-  test('points operators to the active smokes', () => {
-    expect(SRC).toMatch(/smoke:launch-spine/);
-    expect(SRC).toMatch(/smoke:clinical-spine/);
+  test('CLI points operators to the active smokes', () => {
+    expect(CLI).toMatch(/smoke:launch-spine/);
+    expect(CLI).toMatch(/smoke:clinical-spine/);
   });
 });

--- a/backend/routes/launch-readiness.routes.js
+++ b/backend/routes/launch-readiness.routes.js
@@ -1,0 +1,41 @@
+'use strict';
+
+/**
+ * launch-readiness.routes.js — W1375.
+ *
+ * Read-only HTTP surface over services/launchReadiness.service.js so the
+ * web-admin /launch-readiness page can show the operator the same GO / NOT-YET
+ * verdict the `npm run launch:readiness` CLI produces — without shelling out.
+ *
+ *   GET / → { go, generatedAt, summary, checks }
+ *
+ * READ-ONLY (the evaluator only counts + reads env). Admin-scoped: launch
+ * readiness is a system/ops view. Mounted via features.registry dualMountAuth
+ * at /api(/v1)/launch-readiness.
+ */
+
+const express = require('express');
+const mongoose = require('mongoose');
+const { authenticateToken, requireRole } = require('../middleware/auth');
+const safeError = require('../utils/safeError');
+const { evaluateLaunchReadiness } = require('../services/launchReadiness.service');
+
+const router = express.Router();
+
+const ADMIN_ROLES = ['admin', 'superadmin', 'super_admin', 'manager'];
+
+router.use(authenticateToken);
+
+// ── GET / — launch-readiness verdict (read-only) ─────────────────────────────
+router.get('/', requireRole(ADMIN_ROLES), async (_req, res) => {
+  try {
+    const db = mongoose.connection && mongoose.connection.db;
+    if (!db) return res.status(503).json({ success: false, message: 'قاعدة البيانات غير متاحة' });
+    const data = await evaluateLaunchReadiness({ db, env: process.env });
+    return res.json({ success: true, data });
+  } catch (err) {
+    return safeError(res, err, 'launch-readiness');
+  }
+});
+
+module.exports = router;

--- a/backend/routes/registries/features.registry.js
+++ b/backend/routes/registries/features.registry.js
@@ -33,6 +33,7 @@ module.exports = function registerFeatureRoutes(
   const pathwayBundlesRoutes = safeRequire('../routes/pathway-bundles.routes');
   const nextBestActionRoutes = safeRequire('../routes/next-best-action.routes');
   const outcomesRollupRoutes = safeRequire('../routes/outcomes-rollup.routes');
+  const launchReadinessRoutes = safeRequire('../routes/launch-readiness.routes');
   const emailTemplatesRoutes = safeRequire('../routes/email-templates.routes');
   const beneficiaryTransfersRoutes = safeRequire('../routes/beneficiary-transfers.routes');
   const beneficiaryDayAttendanceRoutes = safeRequire('../routes/beneficiary-day-attendance.routes');
@@ -155,6 +156,9 @@ module.exports = function registerFeatureRoutes(
   // aggregation goal → beneficiary → program(domain) → branch → center.
   // Center tier is cross-branch-roles-only (restricted callers get 403).
   dualMountAuth(app, 'outcomes-rollup', outcomesRollupRoutes, authenticate);
+  // W1375: read-only launch-readiness verdict (shared evaluator) for the
+  // web-admin /launch-readiness operator screen.
+  dualMountAuth(app, 'launch-readiness', launchReadinessRoutes, authenticate);
   // Wave 1242: professional bilingual email-template catalogue — registry-driven
   // RTL layout renderer + preview + admin test-send (converges the 55 scattered
   // inline-HTML email call sites onto one contract-validated formatting layer).

--- a/backend/scripts/launch-readiness.js
+++ b/backend/scripts/launch-readiness.js
@@ -2,27 +2,13 @@
 'use strict';
 
 /**
- * launch-readiness.js — W1286.
+ * launch-readiness.js — W1286/W1287, refactored W1375 onto the shared
+ * services/launchReadiness.service.js evaluator (one source of truth shared
+ * with the read-only HTTP route + the web-admin /launch-readiness page).
  *
  * The EXECUTABLE form of docs/GO_LIVE_RUNBOOK_2026-06-11.md's "Definition of
- * launched" checklist. The runbook sequences the steps; this gives an operator
- * a single GO / NOT-YET verdict against the REAL database — turning ~8 manual
- * "verify that…" lines into one mechanical read-only status with the exact
- * remaining command for each gap.
- *
- * 100% READ-ONLY: counts + env presence only. No writes, no smoke docs (active
- * verification stays in the explicit `npm run smoke:launch-spine` /
- * `smoke:clinical-spine`, which this report points to). Safe to run anytime,
- * including against prod.
- *
- * Each check is PASS / NOT-YET / INFO:
- *   PASS    — mechanically satisfied.
- *   NOT-YET — a concrete launch gap; the fix command is printed.
- *   INFO    — owner-gated / judgement call (SMTP, demo-data fate); never a
- *             hard fail (refuse to declare someone else's decision "wrong").
- *
- * Verdict: GO when zero NOT-YET; otherwise NOT-YET with the blocking list.
- * INFO items never block (they're surfaced for the owner).
+ * launched" — a single GO / NOT-YET verdict against the REAL database, with
+ * the exact remaining command per gap. 100% READ-ONLY; safe anytime incl. prod.
  *
  * Usage:  npm run launch:readiness   (or node scripts/launch-readiness.js [--json])
  * Exit:   0 when GO (no NOT-YET) · 1 otherwise
@@ -37,118 +23,22 @@ try {
 
 const JSON_OUT = process.argv.includes('--json');
 const mongoose = require('mongoose');
-
-const checks = [];
-function record(status, name, detail, fix) {
-  checks.push({ status, name, detail, fix });
-}
-const PASS = (n, d) => record('PASS', n, d);
-const NOTYET = (n, d, fix) => record('NOT-YET', n, d, fix);
-const INFO = (n, d, fix) => record('INFO', n, d, fix);
-
-async function countSafe(coll, query = {}) {
-  try {
-    return await mongoose.connection.db.collection(coll).countDocuments(query);
-  } catch (_e) {
-    return null;
-  }
-}
+const { evaluateLaunchReadiness } = require('../services/launchReadiness.service');
 
 async function main() {
   if (!process.env.MONGODB_URI) throw new Error('MONGODB_URI is required');
   await mongoose.connect(process.env.MONGODB_URI);
 
-  // ── 1. Reference/config data seeded (runbook Phase A.2) ──────────
-  const forms = await countSafe('formtemplates');
-  forms > 0
-    ? PASS('forms catalog seeded', `${forms} templates`)
-    : NOTYET('forms catalog seeded', `${forms} templates`, 'npm run seed:forms-catalog');
-
-  const measures = await countSafe('measures_library', { status: 'active' });
-  measures > 0
-    ? PASS('measures library seeded', `${measures} active instruments`)
-    : NOTYET('measures library seeded', `${measures} active`, 'npm run seed:measures');
-
-  const goalbank = await countSafe('goalbanks');
-  goalbank > 0
-    ? PASS('goal bank seeded (R4 pathway bundles need it)', `${goalbank} goals`)
-    : NOTYET('goal bank seeded', `${goalbank} goals`, 'npm run seed:goal-bank');
-
-  // W1287 — ICFCodeReference → mongoose default plural 'icfcodereferences'
-  // (the earlier 'icfcodes' guess was a false-negative: prod has 105 codes).
-  const icf = await countSafe('icfcodereferences');
-  icf > 0
-    ? PASS('ICF codes seeded', `${icf} codes`)
-    : INFO('ICF codes seeded', `${icf == null ? 'collection absent' : icf} codes`, 'npm run seed:icf-codes');
-
-  // ── 2. Real org + staff exist (runbook A.3 / Definition #2) ──────
-  const branches = await countSafe('branches');
-  branches > 0
-    ? PASS('≥1 branch exists', `${branches} branch(es)`)
-    : NOTYET('≥1 branch exists', `${branches}`, 'provision via UI/admin or npm run provision:branches');
-
-  const users = await countSafe('users');
-  users > 0
-    ? PASS('≥1 user exists', `${users} user(s)`)
-    : NOTYET('≥1 user exists', `${users}`, 'provision via UI/admin or npm run provision:staff');
-
-  // ── 3. A beneficiary registered (Definition #3) ──────────────────
-  const bens = await countSafe('beneficiaries', { isDeleted: { $ne: true } });
-  bens > 0
-    ? PASS('≥1 beneficiary registered', `${bens}`)
-    : NOTYET('≥1 beneficiary registered', '0', 'register via the Arabic UI form');
-
-  // ── 4. Session write/read split RESOLVED (Definition #6, W1240) ──
-  // The UI writes ClinicalSession; analytics read TherapySession. If any
-  // ClinicalSession exists, at least one must have a TherapySession projection.
-  // W1287 — ClinicalSession declares collection:'clinical_sessions' (explicit,
-  // underscored) — NOT the mongoose default 'clinicalsessions'.
-  const clinSessions = await countSafe('clinical_sessions');
-  if (!clinSessions) {
-    INFO('session projection (W1240)', 'no ClinicalSessions yet — nothing to project', null);
-  } else {
-    const projected = await countSafe('therapysessions', { sourceClinicalSessionId: { $exists: true } });
-    projected > 0
-      ? PASS('session write/read split resolved (W1240 projection live)', `${projected} projected`)
-      : NOTYET(
-          'session write/read split resolved (W1240 projection)',
-          `${clinSessions} ClinicalSessions, 0 projected → analytics blind`,
-          'verify the W1240 projection hook; run npm run smoke:launch-spine'
-        );
+  let result;
+  try {
+    result = await evaluateLaunchReadiness({ db: mongoose.connection.db, env: process.env });
+  } finally {
+    await mongoose.disconnect().catch(() => null);
   }
 
-  // ── 5. Mail provisioned (Definition #1 — THE blocker) ────────────
-  const smtp = !!(process.env.SMTP_USER && process.env.SMTP_PASS) || !!process.env.SENDGRID_API_KEY;
-  smtp
-    ? PASS('mail transport configured', process.env.SENDGRID_API_KEY ? 'sendgrid' : 'smtp')
-    : INFO(
-        'mail transport configured',
-        'no SMTP_USER/PASS or SENDGRID_API_KEY → all mail no-ops (owner-gated)',
-        'set SMTP_USER + SMTP_PASS in .env + pm2 restart alawael-api --update-env'
-      );
-
-  // ── 6. Demo-data fate (Definition #8 — owner decision) ───────────
-  // The demo seed creates sequential national ids 11000000xx.
-  const demo = await countSafe('beneficiaries', { nationalId: { $regex: '^11000000' } });
-  if (demo > 0) {
-    INFO(
-      'demo-data fate decided',
-      `${demo} demo beneficiary(ies) present (sequential 11000000xx)`,
-      'keep-and-tag for soft launch OR seed:demo --reset to clear (DESTRUCTIVE, owner-gated)'
-    );
-  } else {
-    PASS('demo-data fate decided', 'no demo-tagged beneficiaries present');
-  }
-
-  await mongoose.disconnect().catch(() => null);
-
-  // ── verdict ──────────────────────────────────────────────────────
-  const blocking = checks.filter((c) => c.status === 'NOT-YET');
-  const infos = checks.filter((c) => c.status === 'INFO');
-  const go = blocking.length === 0;
-
+  const { go, checks, summary } = result;
   if (JSON_OUT) {
-    console.log(JSON.stringify({ go, checks }, null, 2));
+    console.log(JSON.stringify(result, null, 2));
   } else {
     const icon = { PASS: '✓', 'NOT-YET': '✗', INFO: 'ℹ' };
     for (const c of checks) {
@@ -156,14 +46,13 @@ async function main() {
       if (c.status === 'NOT-YET' && c.fix) console.log(`      → fix: ${c.fix}`);
     }
     console.log('');
+    const blocking = checks.filter((c) => c.status === 'NOT-YET');
     console.log(
       go
-        ? `✅ GO — all mechanical launch checks pass (${infos.length} owner-gated INFO item(s) to confirm)`
-        : `⛔ NOT-YET — ${blocking.length} launch gap(s): ${blocking.map((b) => b.name).join(', ')}`
+        ? `✅ GO — all mechanical launch checks pass (${summary.info} owner-gated INFO item(s) to confirm)`
+        : `⛔ NOT-YET — ${summary.notYet} launch gap(s): ${blocking.map((b) => b.name).join(', ')}`
     );
-    if (infos.length && !go) {
-      console.log(`   (plus ${infos.length} owner-gated INFO item(s))`);
-    }
+    if (summary.info && !go) console.log(`   (plus ${summary.info} owner-gated INFO item(s))`);
     console.log('\nActive verification (run separately): npm run smoke:launch-spine · npm run smoke:clinical-spine');
   }
   process.exit(go ? 0 : 1);

--- a/backend/services/launchReadiness.service.js
+++ b/backend/services/launchReadiness.service.js
@@ -1,0 +1,136 @@
+'use strict';
+
+/**
+ * launchReadiness.service.js — W1375 (shared launch-readiness evaluator).
+ *
+ * The check logic behind `scripts/launch-readiness.js` (W1286/W1287),
+ * extracted so BOTH the CLI and the read-only HTTP route
+ * (routes/launch-readiness.routes.js → web-admin /launch-readiness page)
+ * compute the SAME verdict from one source of truth.
+ *
+ * `evaluateLaunchReadiness({ db, env })` is PURE-ish: it only READS
+ * (countDocuments) the supplied mongoose `db` handle + reads `env` for
+ * mail config. No connect, no process.exit, no console. Returns
+ * `{ go, checks, summary }`.
+ *
+ * Each check: { status: 'PASS'|'NOT-YET'|'INFO', name, detail, fix }.
+ *   INFO (owner-gated: SMTP, demo-data) NEVER blocks — refuse to declare
+ *   someone else's decision "wrong". Verdict GO iff zero NOT-YET.
+ *
+ * Collection names are the MODEL-TRUE names (W1287 lesson: a guessed plural
+ * silently false-negatives — icfcodereferences not icfcodes; clinical_sessions
+ * not clinicalsessions).
+ */
+
+async function evaluateLaunchReadiness({ db, env = process.env } = {}) {
+  if (!db) throw new Error('evaluateLaunchReadiness requires a mongoose db handle');
+
+  const checks = [];
+  const add = (status, name, detail, fix) => checks.push({ status, name, detail, fix: fix || null });
+  const PASS = (n, d) => add('PASS', n, d);
+  const NOTYET = (n, d, fix) => add('NOT-YET', n, d, fix);
+  const INFO = (n, d, fix) => add('INFO', n, d, fix);
+
+  const countSafe = async (coll, query = {}) => {
+    try {
+      return await db.collection(coll).countDocuments(query);
+    } catch (_e) {
+      return null;
+    }
+  };
+
+  // ── 1. Reference/config data seeded ──────────────────────────────
+  const forms = await countSafe('formtemplates');
+  forms > 0
+    ? PASS('forms catalog seeded', `${forms} templates`)
+    : NOTYET('forms catalog seeded', `${forms} templates`, 'npm run seed:forms-catalog');
+
+  const measures = await countSafe('measures_library', { status: 'active' });
+  measures > 0
+    ? PASS('measures library seeded', `${measures} active instruments`)
+    : NOTYET('measures library seeded', `${measures} active`, 'npm run seed:measures');
+
+  const goalbank = await countSafe('goalbanks');
+  goalbank > 0
+    ? PASS('goal bank seeded (R4 pathway bundles need it)', `${goalbank} goals`)
+    : NOTYET('goal bank seeded', `${goalbank} goals`, 'npm run seed:goal-bank');
+
+  const icf = await countSafe('icfcodereferences');
+  icf > 0
+    ? PASS('ICF codes seeded', `${icf} codes`)
+    : INFO('ICF codes seeded', `${icf == null ? 'collection absent' : icf} codes`, 'npm run seed:icf-codes');
+
+  // ── 2. Real org + staff exist ────────────────────────────────────
+  const branches = await countSafe('branches');
+  branches > 0
+    ? PASS('≥1 branch exists', `${branches} branch(es)`)
+    : NOTYET('≥1 branch exists', `${branches}`, 'provision via UI/admin or npm run provision:branches');
+
+  const users = await countSafe('users');
+  users > 0
+    ? PASS('≥1 user exists', `${users} user(s)`)
+    : NOTYET('≥1 user exists', `${users}`, 'provision via UI/admin or npm run provision:staff');
+
+  // ── 3. A beneficiary registered ──────────────────────────────────
+  const bens = await countSafe('beneficiaries', { isDeleted: { $ne: true } });
+  bens > 0
+    ? PASS('≥1 beneficiary registered', `${bens}`)
+    : NOTYET('≥1 beneficiary registered', '0', 'register via the Arabic UI form');
+
+  // ── 4. Session write/read split (W1240) ──────────────────────────
+  const clinSessions = await countSafe('clinical_sessions');
+  if (!clinSessions) {
+    INFO('session projection (W1240)', 'no ClinicalSessions yet — nothing to project', null);
+  } else {
+    const projected = await countSafe('therapysessions', { sourceClinicalSessionId: { $exists: true } });
+    projected > 0
+      ? PASS('session write/read split resolved (W1240 projection live)', `${projected} projected`)
+      : NOTYET(
+          'session write/read split resolved (W1240 projection)',
+          `${clinSessions} ClinicalSessions, 0 projected → analytics blind`,
+          'verify the W1240 projection hook; run npm run smoke:launch-spine'
+        );
+  }
+
+  // ── 5. Mail provisioned (owner-gated) ────────────────────────────
+  const smtp = !!(env.SMTP_USER && env.SMTP_PASS) || !!env.SENDGRID_API_KEY;
+  smtp
+    ? PASS('mail transport configured', env.SENDGRID_API_KEY ? 'sendgrid' : 'smtp')
+    : INFO(
+        'mail transport configured',
+        'no SMTP_USER/PASS or SENDGRID_API_KEY → all mail no-ops (owner-gated)',
+        'set SMTP_USER + SMTP_PASS in .env + pm2 restart alawael-api --update-env'
+      );
+
+  // ── 6. Demo-data fate (owner decision) ───────────────────────────
+  const demo = await countSafe('beneficiaries', { nationalId: { $regex: '^11000000' } });
+  if (demo > 0) {
+    INFO(
+      'demo-data fate decided',
+      `${demo} demo beneficiary(ies) present (sequential 11000000xx)`,
+      'keep-and-tag for soft launch OR seed:demo --reset to clear (DESTRUCTIVE, owner-gated)'
+    );
+  } else {
+    PASS('demo-data fate decided', 'no demo-tagged beneficiaries present');
+  }
+
+  // ── verdict ──────────────────────────────────────────────────────
+  const blocking = checks.filter((c) => c.status === 'NOT-YET');
+  const infos = checks.filter((c) => c.status === 'INFO');
+  const passes = checks.filter((c) => c.status === 'PASS');
+  const go = blocking.length === 0;
+
+  return {
+    go,
+    generatedAt: new Date().toISOString(),
+    summary: {
+      total: checks.length,
+      pass: passes.length,
+      notYet: blocking.length,
+      info: infos.length,
+    },
+    checks,
+  };
+}
+
+module.exports = { evaluateLaunchReadiness };

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1046,3 +1046,4 @@ __tests__/smoke-clinical-spine-wave1285.test.js
 __tests__/launch-readiness-wave1286.test.js
 __tests__/whatsapp-bot-data-lookup-wave1372.test.js
 __tests__/whatsapp-bot-flow-menu-wave1372.test.js
+__tests__/launch-readiness-service-wave1375.test.js


### PR DESCRIPTION
Extracts W1286/W1287 check logic into `services/launchReadiness.service.js` (`evaluateLaunchReadiness({db,env})` — read-only, no connect/exit/console) so the CLI **and** a new `GET /api/v1/launch-readiness` route share one verdict.

- Route: admin-gated, read-only, registry-mounted.
- CLI refactored onto the service (output unchanged).
- W1286 guard repointed (logic moved to service) + W1375 guard: behavioral evaluator vs a fake db (GO-iff-zero-NOT-YET · INFO-never-blocks · model-true collection names · fix-per-gap · session-split) + static wiring. **26 green.**

Backs the web-admin /launch-readiness operator screen (next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)