### PR TITLE
feat(alerts): W1244 — email channel for high/critical alert raises (notification loop closed)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1760,6 +1760,8 @@ on:
       - 'backend/__tests__/whatsapp-bot-flow-menu-wave1372.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/launch-readiness-service-wave1375.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/alerts-email-notify-wave1244.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3498,6 +3500,8 @@ on:
       - 'backend/__tests__/whatsapp-bot-flow-menu-wave1372.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/launch-readiness-service-wave1375.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/alerts-email-notify-wave1244.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/alerts-email-notify-wave1244.test.js
+++ b/backend/__tests__/alerts-email-notify-wave1244.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+/**
+ * alerts-email-notify-wave1244.test.js — severity-gated email channel for
+ * the smart-alerts engine.
+ *
+ * The dispatcher's `_notify` plumbing existed since Wave 9 but app.js never
+ * injected channels/recipients — the notification half was dormant. W1244
+ * wires it. These tests lock:
+ *   1. buildEmailNotify contract (null without inbox; severity gate; the
+ *      EmailManager.sendAlert mapping incl. error paths);
+ *   2. END-TO-END through the REAL dispatcher: a critical raise produces
+ *      exactly one email send, a warning produces none, and a re-detected
+ *      alert on the next tick does NOT re-email (the dedup that makes the
+ *      channel inbox-safe);
+ *   3. static guard: app.js injects the channel under ALERTS_EMAIL_ENABLED.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { buildEmailNotify, SEVERITY_RANK } = require('../alerts/email-notify');
+
+// EmailManager is lazy-required inside the channel — mock the module.
+jest.mock('../services/email', () => ({
+  emailManager: { sendAlert: jest.fn(async () => ({ success: true })) },
+}));
+// eslint-disable-next-line node/no-missing-require
+const { emailManager } = require('../services/email');
+
+afterEach(() => jest.clearAllMocks());
+
+describe('W1244 buildEmailNotify — contract', () => {
+  test('returns null without a valid inbox', () => {
+    expect(buildEmailNotify({})).toBeNull();
+    expect(buildEmailNotify({ opsEmail: 'not-an-email' })).toBeNull();
+  });
+
+  test('severity gate: below minSeverity resolves to no recipients', async () => {
+    const n = buildEmailNotify({ opsEmail: 'ops@x.test', minSeverity: 'high' });
+    expect(await n.recipients.resolve({ severity: 'warning' })).toEqual([]);
+    expect(await n.recipients.resolve({ severity: 'info' })).toEqual([]);
+    expect(await n.recipients.resolve({ severity: 'high' })).toHaveLength(1);
+    expect(await n.recipients.resolve({ severity: 'critical' })).toHaveLength(1);
+  });
+
+  test('rank table covers the Alert model severity enum', () => {
+    expect(Object.keys(SEVERITY_RANK).sort()).toEqual(['critical', 'high', 'info', 'warning']);
+  });
+
+  test('send maps alert → EmailManager.sendAlert and reports success', async () => {
+    const n = buildEmailNotify({ opsEmail: 'ops@x.test' });
+    const alert = {
+      severity: 'critical',
+      message: 'فاتورة متأخرة 90 يوماً',
+      description: 'تفاصيل…',
+      ruleId: 'invoice-overdue',
+      category: 'finance',
+    };
+    const res = await n.channels.email.send(alert, [{ id: 'ops-inbox', email: 'ops@x.test' }]);
+    expect(res.success).toBe(true);
+    expect(emailManager.sendAlert).toHaveBeenCalledTimes(1);
+    const [payload, to] = emailManager.sendAlert.mock.calls[0];
+    expect(to).toBe('ops@x.test');
+    expect(payload.title).toBe('فاتورة متأخرة 90 يوماً');
+    expect(payload.source).toBe('invoice-overdue');
+    expect(payload.severity).toBe('critical');
+  });
+
+  test('send failure is reported, never thrown', async () => {
+    emailManager.sendAlert.mockResolvedValueOnce({ success: false, error: 'SMTP down' });
+    const n = buildEmailNotify({ opsEmail: 'ops@x.test' });
+    const res = await n.channels.email.send({ severity: 'high', message: 'x' }, [
+      { email: 'ops@x.test' },
+    ]);
+    expect(res.success).toBe(false);
+    expect(res.error).toBe('SMTP down');
+  });
+});
+
+describe('W1244 end-to-end through the real dispatcher', () => {
+  const { AlertDispatcher } = require('../alerts/dispatcher');
+  const { AlertsEngine } = require('../alerts/engine');
+
+  function makeDispatcher(findingsByTick) {
+    let tickNo = -1;
+    const engine = new AlertsEngine({ logger: { info() {}, warn() {}, error() {} } });
+    engine.register({
+      id: 'test-rule',
+      severity: 'critical',
+      evaluate: async () => {
+        tickNo += 1;
+        return findingsByTick[Math.min(tickNo, findingsByTick.length - 1)];
+      },
+    });
+    const notify = buildEmailNotify({ opsEmail: 'ops@x.test' });
+    const fakeModel = {
+      model: {
+        updateOne: jest.fn(async () => ({ acknowledged: true })),
+      },
+    };
+    return new AlertDispatcher({
+      engine,
+      AlertModel: fakeModel,
+      channels: notify.channels,
+      recipients: notify.recipients,
+      logger: { info() {}, warn() {}, error() {} },
+    });
+  }
+
+  test('critical raise emails ONCE; re-detection on next tick does NOT re-email', async () => {
+    const finding = {
+      key: 'inv-1',
+      severity: 'critical',
+      category: 'finance',
+      description: 'd',
+      message: 'm',
+    };
+    const d = makeDispatcher([[finding], [finding]]);
+
+    const t1 = await d.tick({});
+    expect(t1.raised).toBe(1);
+    expect(t1.notified).toBe(1);
+    expect(emailManager.sendAlert).toHaveBeenCalledTimes(1);
+
+    const t2 = await d.tick({});
+    expect(t2.raised).toBe(0); // dedup: still-firing bumps lastSeenAt only
+    expect(emailManager.sendAlert).toHaveBeenCalledTimes(1); // no second email
+  });
+
+  test('warning-severity raise persists but does not email', async () => {
+    const d = makeDispatcher([
+      [{ key: 'w-1', severity: 'warning', category: 'ops', description: 'd', message: 'm' }],
+    ]);
+    const t1 = await d.tick({});
+    expect(t1.raised).toBe(1);
+    expect(t1.notified).toBe(0);
+    expect(emailManager.sendAlert).not.toHaveBeenCalled();
+  });
+});
+
+describe('W1244 static guard — app.js wiring', () => {
+  const appSrc = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+
+  test('engine block injects the email channel under ALERTS_EMAIL_ENABLED', () => {
+    expect(appSrc).toMatch(/ALERTS_EMAIL_ENABLED/);
+    expect(appSrc).toMatch(/require\('\.\/alerts\/email-notify'\)/);
+    expect(appSrc).toMatch(
+      /channels: emailNotify\.channels, recipients: emailNotify\.recipients/
+    );
+  });
+
+  test('boot log reports the email channel state', () => {
+    expect(appSrc).toMatch(/email=\$\{emailNotify \? /);
+  });
+});

--- a/backend/alerts/email-notify.js
+++ b/backend/alerts/email-notify.js
@@ -1,0 +1,83 @@
+'use strict';
+
+/**
+ * email-notify.js — severity-gated email channel for the smart-alerts
+ * engine (W1244).
+ *
+ * The dispatcher has carried full channel/recipient plumbing since Wave 9
+ * (`_notify` → recipients.resolve → channels[name].send) but app.js never
+ * injected either, so the notification half of the engine was dormant —
+ * alerts persisted, nobody was told. With prod SMTP activated (W1242 +
+ * Hostinger creds, 2026-06-12) this wires the missing half:
+ *
+ *   raise (first detection only — the engine's in-memory dedup means NO
+ *   re-notify on every 5-min tick) → severity ≥ minSeverity → ONE email
+ *   to the ops inbox via EmailManager.sendAlert (ALERT_NOTIFICATION
+ *   bilingual template, priority 10 for critical).
+ *
+ * Config (read by app.js, not here):
+ *   ALERTS_EMAIL_ENABLED=true        master switch (default OFF)
+ *   OPS_ALERT_EMAIL=<inbox>          recipient (already set on prod)
+ *   ALERTS_EMAIL_MIN_SEVERITY=high   info|warning|high|critical
+ *
+ * Failure is best-effort by design: a send error is recorded in the tick
+ * report's `errors` and never blocks alert persistence.
+ */
+
+const SEVERITY_RANK = Object.freeze({ info: 0, warning: 1, high: 2, critical: 3 });
+
+/**
+ * @param {object} opts
+ * @param {string} opts.opsEmail        destination inbox (required)
+ * @param {string} [opts.minSeverity]   minimum severity to email (default 'high')
+ * @param {object} [opts.logger]
+ * @returns {{recipients: object, channels: object}|null} null when no inbox configured
+ */
+function buildEmailNotify({ opsEmail, minSeverity = 'high', logger = console } = {}) {
+  if (!opsEmail || typeof opsEmail !== 'string' || !opsEmail.includes('@')) {
+    return null;
+  }
+  const min = SEVERITY_RANK[minSeverity] !== undefined ? SEVERITY_RANK[minSeverity] : 2;
+
+  return {
+    recipients: {
+      async resolve(alert) {
+        const rank = SEVERITY_RANK[alert && alert.severity];
+        if (rank === undefined || rank < min) return [];
+        return [{ id: 'ops-inbox', email: opsEmail, channels: ['email'] }];
+      },
+    },
+    channels: {
+      email: {
+        async send(alert, recipients) {
+          const to = recipients && recipients[0] && recipients[0].email;
+          if (!to) return { success: false, error: 'NO_EMAIL' };
+          try {
+            // Lazy require — the email stack must never be a load-time
+            // dependency of the alerts engine.
+            const { emailManager } = require('../services/email');
+            const res = await emailManager.sendAlert(
+              {
+                severity: alert.severity,
+                title: alert.message,
+                message: alert.description || alert.message,
+                source: alert.ruleId,
+                type: alert.category || 'alert',
+              },
+              to
+            );
+            return {
+              success: !!(res && res.success !== false && !res.error),
+              error: (res && res.error) || undefined,
+            };
+          } catch (err) {
+            logger.warn && logger.warn(`[SmartAlerts] email notify failed: ${err.message}`);
+            return { success: false, error: err.message };
+          }
+        },
+      },
+    },
+  };
+}
+
+module.exports = { buildEmailNotify, SEVERITY_RANK };

--- a/backend/app.js
+++ b/backend/app.js
@@ -1492,10 +1492,36 @@ try {
 
     const intervalMs = Number(process.env['ALERTS_ENGINE_INTERVAL_MS']) || undefined;
 
+    // W1244 — email channel for high/critical raises. The dispatcher has
+    // carried channel/recipient plumbing since Wave 9 but nothing was ever
+    // injected, so the notification half of the engine was dormant. With
+    // prod SMTP live (W1242) this closes the loop. Master switch
+    // ALERTS_EMAIL_ENABLED (default OFF) + OPS_ALERT_EMAIL recipient;
+    // engine dedup guarantees ONE email per raise, not per 5-min tick.
+    let emailNotify = null;
+    const alertsEmailEnabled =
+      String(process.env['ALERTS_EMAIL_ENABLED'] || '').toLowerCase() === 'true';
+    if (alertsEmailEnabled) {
+      const { buildEmailNotify } = require('./alerts/email-notify');
+      emailNotify = buildEmailNotify({
+        opsEmail: process.env['OPS_ALERT_EMAIL'],
+        minSeverity: process.env['ALERTS_EMAIL_MIN_SEVERITY'] || 'high',
+        logger,
+      });
+      if (!emailNotify) {
+        logger.warn(
+          '[SmartAlerts] ALERTS_EMAIL_ENABLED=true but OPS_ALERT_EMAIL is not a valid inbox — email channel skipped'
+        );
+      }
+    }
+
     const stack = buildAlertsStack({
       models: liveModels,
       kpiHistoryStore: sharedHistoryStore,
       ...(intervalMs ? { intervalMs } : {}),
+      ...(emailNotify
+        ? { channels: emailNotify.channels, recipients: emailNotify.recipients }
+        : {}),
       logger,
     });
     stack.scheduler.start(stack.ctxFactory);
@@ -1503,7 +1529,8 @@ try {
     logger.info(
       `[SmartAlerts] ✓ engine started — ${stack.rules.length} rules, ` +
         `kpiHistoryStore=${sharedHistoryStore ? 'on' : 'off'}, ` +
-        `interval=${intervalMs || '5min'}`
+        `interval=${intervalMs || '5min'}, ` +
+        `email=${emailNotify ? `on→${process.env['OPS_ALERT_EMAIL']}` : 'off'}`
     );
   } else if (!alertsEnabled) {
     logger.info('[SmartAlerts] engine disabled — set ALERTS_ENGINE_ENABLED=true to activate');

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1047,3 +1047,4 @@ __tests__/launch-readiness-wave1286.test.js
 __tests__/whatsapp-bot-data-lookup-wave1372.test.js
 __tests__/whatsapp-bot-flow-menu-wave1372.test.js
 __tests__/launch-readiness-service-wave1375.test.js
+__tests__/alerts-email-notify-wave1244.test.js


### PR DESCRIPTION
## What

The smart-alerts dispatcher has carried channel/recipient plumbing since Wave 9, but `app.js` never injected either — the engine's **notification half was dormant**: alerts persisted to the `alerts` collection, but nobody was told. With prod SMTP live (W1242 + Hostinger creds, 2026-06-12) this closes the loop.

- **`alerts/email-notify.js`** — severity-gated recipient resolver (`info<warning<high<critical`, default min `high`) + an email channel mapping `Alert → EmailManager.sendAlert` (the existing `ALERT_NOTIFICATION` bilingual template, priority 10 for critical). `EmailManager` is **lazy-required** — never a load-time dependency of the engine. Returns `null` without a valid `OPS_ALERT_EMAIL`.
- **`app.js`** — injects `channels`/`recipients` into `buildAlertsStack` **only when `ALERTS_EMAIL_ENABLED=true`** (default OFF — ships INERT until the owner flips it). Boot log reports `email=on→inbox` / `off`.

## Inbox-safe by design

The engine's existing dedup means a still-firing alert bumps `lastSeenAt` only (`raised:0`) on every 5-min tick → **exactly one email per raise**, not per tick. Send failures land in the tick report's `errors`, never block persistence.

## Tests (9)

`buildEmailNotify` contract (null-without-inbox, severity gate, `sendAlert` mapping, error path) + **end-to-end through the real `AlertDispatcher`** (critical emails once, re-detection does NOT re-email, warning persists-but-no-email) + static `app.js` wiring guard. 23 existing alert tests green; `check:routes-load` clean.

## Activation (post-merge, owner's call)

`ALERTS_EMAIL_ENABLED=true` + `OPS_ALERT_EMAIL=<inbox>` (already set on prod) + optional `ALERTS_EMAIL_MIN_SEVERITY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)