### PR TITLE
fix(test): W1376 — ratchet untenanted-aggregations 68→69 (unblocks the deploy pipeline)

### DIFF
--- a/backend/__tests__/untenanted-aggregations-ratchet-wave944.test.js
+++ b/backend/__tests__/untenanted-aggregations-ratchet-wave944.test.js
@@ -34,7 +34,12 @@ const BACKEND_ROOT = path.resolve(__dirname, '..');
 const AUDIT = path.join(BACKEND_ROOT, 'scripts', 'audit-untenanted-aggregations.js');
 
 // Baseline captured 2026-06-05: { rawCollectionSites: 68, untenantedCandidateSites: 765 }.
-const MAX_RAW_COLLECTION_SITES = 68; // tight — fail on any NEW raw-driver aggregate
+// W1376 ratchet 68→69 (2026-06-16): the new site is services/launchReadiness.service.js's
+// `countSafe(coll)` — a deliberately PLATFORM-WIDE ops readiness probe (W1375). It answers
+// "is the system's seed/reference data ready to launch?" and MUST see all branches; tenant-
+// scoping it would be semantically wrong. Verified not a tenant-data-leak vector before
+// ratcheting (it counts config/reference collections, returns counts only, never rows).
+const MAX_RAW_COLLECTION_SITES = 69; // tight — fail on any NEW raw-driver aggregate
 const MAX_UNTENANTED_CANDIDATES = 820; // buffered flood-cap (765 + headroom for churn)
 
 function runAudit() {
@@ -59,7 +64,7 @@ describe('C3 — untenanted-aggregations surface does not grow (ratchet)', () =>
     expect(typeof report.untenantedCandidateSites).toBe('number');
   });
 
-  it('NO new raw db.collection() aggregate leaks (tenantScope-blind) — pinned at 68', () => {
+  it('NO new raw db.collection() aggregate leaks (tenantScope-blind) — pinned at 69', () => {
     expect(report.rawCollectionSites).toBeLessThanOrEqual(MAX_RAW_COLLECTION_SITES);
   });
 


### PR DESCRIPTION
## Why the deploy pipeline has been red for 3 merges

W1375's `launchReadiness.service.js` added one raw `db.collection().countSafe()` — a **deliberately platform-wide ops readiness probe** ("is the system's seed/reference data ready to launch?"). It must see all branches; tenant-scoping it would be semantically wrong. It returns **counts only** over config/reference collections, never rows — **not a tenant-data-leak vector**.

The `untenanted-aggregations-ratchet-wave944` guard pins raw sites at 68 → the new site pushed it to 69 → shard 4/4 fails → **Deploy-to-VPS skipped on W1375, the dompurify bump, and W1244**.

## Fix

Ratchet the baseline 68 → 69 with a justification comment (the established ratchet-bump pattern for a verified-legitimate new site). 3/3 green locally. Unblocks the pipeline for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)