### PR TITLE
fix(test): W1377 — deflake two core-linkage suites (unblocks deploy shard 2/4)

### DIFF
--- a/backend/__tests__/caregiver-support-completed-core-linkage-wave1104.test.js
+++ b/backend/__tests__/caregiver-support-completed-core-linkage-wave1104.test.js
@@ -61,6 +61,17 @@ afterEach(async () => {
   await CaregiverSupportProgram.deleteMany({});
 });
 
+/** Poll until `expected` rows exist (or timeout) — W1227 deflake pattern. */
+async function waitForRows(filter, expected, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  let rows = [];
+  for (;;) {
+    rows = await CareTimeline.find(filter);
+    if (rows.length >= expected || Date.now() > deadline) return rows;
+    await new Promise(r => setTimeout(r, 25));
+  }
+}
+
 describe('W1104 CaregiverSupportProgram → CareTimeline (caregiver_support.completed)', () => {
   it('records a family/success timeline row when a program completes', async () => {
     const beneficiaryId = new mongoose.Types.ObjectId();
@@ -75,9 +86,8 @@ describe('W1104 CaregiverSupportProgram → CareTimeline (caregiver_support.comp
     doc.status = 'completed';
     doc.completedAt = new Date();
     await doc.save();
-    await new Promise(r => setTimeout(r, 30));
 
-    rows = await CareTimeline.find({ beneficiaryId });
+    rows = await waitForRows({ beneficiaryId }, 1);
     expect(rows).toHaveLength(1);
     const row = rows[0];
     expect(row.eventType).toBe('caregiver_support_completed');
@@ -95,7 +105,7 @@ describe('W1104 CaregiverSupportProgram → CareTimeline (caregiver_support.comp
     const doc = await CaregiverSupportProgram.create(program(beneficiaryId));
     doc.status = 'in_progress';
     await doc.save();
-    await new Promise(r => setTimeout(r, 30));
+    await new Promise(r => setTimeout(r, 150));
 
     const rows = await CareTimeline.find({ beneficiaryId });
     expect(rows).toHaveLength(0);
@@ -108,7 +118,7 @@ describe('W1104 CaregiverSupportProgram → CareTimeline (caregiver_support.comp
     doc.discontinuedAt = new Date();
     doc.discontinuationReason = 'انتقال الأسرة لمدينة أخرى';
     await doc.save();
-    await new Promise(r => setTimeout(r, 30));
+    await new Promise(r => setTimeout(r, 150));
 
     const rows = await CareTimeline.find({ beneficiaryId });
     expect(rows).toHaveLength(0);
@@ -120,12 +130,12 @@ describe('W1104 CaregiverSupportProgram → CareTimeline (caregiver_support.comp
     doc.status = 'completed';
     doc.completedAt = new Date();
     await doc.save();
-    await new Promise(r => setTimeout(r, 30));
+    await new Promise(r => setTimeout(r, 150));
 
     // Unrelated mutation — status stays 'completed', not re-modified.
     doc.notes = 'ملاحظة ختامية';
     await doc.save();
-    await new Promise(r => setTimeout(r, 30));
+    await new Promise(r => setTimeout(r, 150));
 
     const rows = await CareTimeline.find({ beneficiaryId });
     expect(rows).toHaveLength(1);

--- a/backend/__tests__/workflow-transition-recorded-core-linkage-wave1118.test.js
+++ b/backend/__tests__/workflow-transition-recorded-core-linkage-wave1118.test.js
@@ -44,9 +44,19 @@ function transition(beneficiaryId, overrides = {}) {
   };
 }
 
-async function settle() {
-  await new Promise(r => setTimeout(r, 60));
+// W1227 deflake pattern — poll until the async bus → subscriber → create
+// chain materialises `expected` rows, instead of a fixed sleep that loses
+// the race under CI load.
+async function waitForRows(filter, expected, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  let rows = [];
+  for (;;) {
+    rows = await CareTimeline.find(filter).lean();
+    if (rows.length >= expected || Date.now() > deadline) return rows;
+    await new Promise(r => setTimeout(r, 25));
+  }
 }
+
 
 describe('W1118 — WorkflowTransitionLog recorded → unified-core CareTimeline linkage', () => {
   test('records an administrative row when a workflow transition is logged', async () => {
@@ -55,9 +65,7 @@ describe('W1118 — WorkflowTransitionLog recorded → unified-core CareTimeline
     const doc = await WorkflowTransitionLog.create(
       transition(beneficiaryId, { branchId, fromPhase: 'referral', toPhase: 'intake' })
     );
-    await settle();
-
-    const rows = await CareTimeline.find({ beneficiaryId }).lean();
+    const rows = await waitForRows({ beneficiaryId }, 1);
     expect(rows).toHaveLength(1);
     const row = rows[0];
     expect(row.eventType).toBe('workflow_transition_recorded');
@@ -73,9 +81,7 @@ describe('W1118 — WorkflowTransitionLog recorded → unified-core CareTimeline
   test('maps a failed transition to a warning row', async () => {
     const beneficiaryId = new mongoose.Types.ObjectId();
     await WorkflowTransitionLog.create(transition(beneficiaryId, { status: 'failed' }));
-    await settle();
-
-    const rows = await CareTimeline.find({ beneficiaryId }).lean();
+    const rows = await waitForRows({ beneficiaryId }, 1);
     expect(rows).toHaveLength(1);
     expect(rows[0].severity).toBe('warning');
   });
@@ -88,9 +94,8 @@ describe('W1118 — WorkflowTransitionLog recorded → unified-core CareTimeline
     await WorkflowTransitionLog.create(
       transition(beneficiaryId, { fromPhase: 'triage', toPhase: 'initial_assessment' })
     );
-    await settle();
-
-    expect(await CareTimeline.countDocuments({ beneficiaryId })).toBe(2);
+    const rows = await waitForRows({ beneficiaryId }, 2);
+    expect(rows).toHaveLength(2);
   });
 
   test('records distinct transitions for distinct beneficiaries', async () => {
@@ -98,9 +103,7 @@ describe('W1118 — WorkflowTransitionLog recorded → unified-core CareTimeline
     const b2 = new mongoose.Types.ObjectId();
     await WorkflowTransitionLog.create(transition(b1));
     await WorkflowTransitionLog.create(transition(b2));
-    await settle();
-
-    expect(await CareTimeline.countDocuments({ beneficiaryId: b1 })).toBe(1);
-    expect(await CareTimeline.countDocuments({ beneficiaryId: b2 })).toBe(1);
+    expect(await waitForRows({ beneficiaryId: b1 }, 1)).toHaveLength(1);
+    expect(await waitForRows({ beneficiaryId: b2 }, 1)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
After W1376 unblocked shard 4/4, shard 2/4 flaked on two more CareTimeline core-linkage suites:

- `caregiver-support-completed-wave1104` (5× `setTimeout 30ms`)
- `workflow-transition-recorded-wave1118` (`settle 60ms`)

Both assert timeline rows after a **fixed sleep**, but the post-save → bus → DDD-subscriber → create chain is fire-and-forget and exceeds the sleep under CI load (passing locally on a warm binary). Same **W1227 flake class**.

Fix: poll-until helper (25ms/5s) for presence assertions; 150ms settle for negative/no-op assertions; removed the now-unused `settle()`. 8/8 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)