### PR TITLE
fix(security): W1378 — export missing assertBeneficiaryInScope (20 write routes threw 500; LAUNCH BLOCKER)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1770,6 +1770,8 @@ on:
       - 'backend/__tests__/whatsapp-bot-intelligence-wave1382.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/whatsapp-bot-bilingual-wave1383.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/assert-beneficiary-in-scope-wave1378.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3518,6 +3520,8 @@ on:
       - 'backend/__tests__/whatsapp-bot-intelligence-wave1382.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/whatsapp-bot-bilingual-wave1383.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/assert-beneficiary-in-scope-wave1378.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/assert-beneficiary-in-scope-wave1378.test.js
+++ b/backend/__tests__/assert-beneficiary-in-scope-wave1378.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+/**
+ * assert-beneficiary-in-scope-wave1378.test.js
+ *
+ * W1378 — 20 route files import `assertBeneficiaryInScope` from
+ * middleware/assertBranchMatch.js, but it was never exported → every guarded
+ * write path threw `assertBeneficiaryInScope is not a function` (HTTP 500),
+ * silently dead until a write was exercised (pre-adoption prod hid it;
+ * surfaced on the GO-LIVE episode-create walk). This locks:
+ *   1. the function exists + honours the callers' (req, benId, res) → denied
+ *      contract (allowed=false, cross-branch=true+writes 403, missing-res=throw);
+ *   2. a DRIFT GUARD — every name destructured from assertBranchMatch in
+ *      routes/ resolves to a real export (catches the next phantom import).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const assertBranchMatch = require('../middleware/assertBranchMatch');
+const { assertBeneficiaryInScope } = assertBranchMatch;
+
+function mockRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(c) {
+      this.statusCode = c;
+      return this;
+    },
+    json(b) {
+      this.body = b;
+      return this;
+    },
+  };
+}
+
+describe('W1378 assertBeneficiaryInScope — contract', () => {
+  test('is exported as a function', () => {
+    expect(typeof assertBeneficiaryInScope).toBe('function');
+  });
+
+  test('unrestricted / unscoped caller → allowed (false), no response written', async () => {
+    const res = mockRes();
+    const denied = await assertBeneficiaryInScope({}, 'anything', res);
+    expect(denied).toBe(false);
+    expect(res.statusCode).toBeNull();
+  });
+
+  test('restricted caller + missing beneficiaryId → denied (true) + 400 written', async () => {
+    const req = { branchScope: { restricted: true } };
+    const res = mockRes();
+    const denied = await assertBeneficiaryInScope(req, null, res);
+    expect(denied).toBe(true);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('without res, a denial RE-THROWS (2-arg call sites keep their try/catch)', async () => {
+    const req = { branchScope: { restricted: true } };
+    await expect(assertBeneficiaryInScope(req, null)).rejects.toThrow();
+  });
+});
+
+describe('W1378 drift guard — every assertBranchMatch import resolves to a real export', () => {
+  const exported = new Set(Object.keys(assertBranchMatch));
+  const routesDir = path.join(__dirname, '..', 'routes');
+
+  // Collect (file, names[]) for every `require('.../assertBranchMatch')` destructure.
+  const offenders = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(p);
+      } else if (entry.name.endsWith('.js')) {
+        const src = fs.readFileSync(p, 'utf8');
+        const m = src.match(/const\s*\{([^}]*)\}\s*=\s*require\(\s*['"][^'"]*assertBranchMatch['"]\s*\)/);
+        if (!m) continue;
+        const names = m[1]
+          .split(',')
+          .map((s) => s.trim().split(':')[0].trim())
+          .filter(Boolean);
+        for (const n of names) {
+          if (!exported.has(n)) offenders.push(`${path.relative(routesDir, p)} → ${n}`);
+        }
+      }
+    }
+  };
+  walk(routesDir);
+
+  test('no route destructures a name assertBranchMatch does not export', () => {
+    expect(offenders).toEqual([]);
+  });
+});

--- a/backend/middleware/assertBranchMatch.js
+++ b/backend/middleware/assertBranchMatch.js
@@ -174,6 +174,40 @@ async function enforceBeneficiaryBranch(req, beneficiaryId) {
 }
 
 /**
+ * Denied-flag wrapper around `enforceBeneficiaryBranch` for routes written in the
+ * `const denied = await assertBeneficiaryInScope(req, benId, res); if (denied) return;`
+ * style (vs. a throw). Returns `true` (after writing the appropriate status to
+ * `res`) when the caller may NOT touch this beneficiary; returns `false` when
+ * allowed. When `res` is omitted it re-throws, so a try/catch caller still works.
+ *
+ * W1378: 20 route files imported this exact name from this module before it was
+ * ever exported — every guarded write threw `assertBeneficiaryInScope is not a
+ * function` (HTTP 500). It stayed silent in pre-adoption prod because no write
+ * path (open-episode, schedule-session, care-plan, EMR, referral, …) had been
+ * exercised; surfaced during the GO-LIVE daily-workflow walk (episode create →
+ * 500). Adding the function with the callers' contract fixes all 20 at once.
+ *
+ * @param {object} req
+ * @param {string|ObjectId} beneficiaryId
+ * @param {object} [res] Express response — written to on denial when present.
+ * @returns {Promise<boolean>} true = denied (caller should return), false = allowed
+ */
+async function assertBeneficiaryInScope(req, beneficiaryId, res) {
+  try {
+    await enforceBeneficiaryBranch(req, beneficiaryId);
+    return false; // allowed
+  } catch (err) {
+    if (!res || typeof res.status !== 'function') throw err;
+    const status = err.status || 403;
+    res.status(status).json({
+      success: false,
+      message: err.message || 'الوصول غير مسموح لهذا المستفيد',
+    });
+    return true; // denied — caller returns
+  }
+}
+
+/**
  * Enforce cross-branch isolation on an EMPLOYEE-keyed route (the HR analogue of
  * `enforceBeneficiaryBranch`). HR transactional records (attendance, payroll,
  * loans, …) are keyed by `employeeId`, and `Employee` carries `branch_id`, so a
@@ -498,6 +532,7 @@ module.exports = {
   assertBranchMatch,
   effectiveBranchScope,
   enforceBeneficiaryBranch,
+  assertBeneficiaryInScope,
   enforceEmployeeBranch,
   loadBeneficiaryAndAssertBranch,
   assertBranchIdsAllowed,

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1052,3 +1052,4 @@ __tests__/whatsapp-bot-new-units-wave1380.test.js
 __tests__/whatsapp-bot-interactive-menu-wave1381.test.js
 __tests__/whatsapp-bot-intelligence-wave1382.test.js
 __tests__/whatsapp-bot-bilingual-wave1383.test.js
+__tests__/assert-beneficiary-in-scope-wave1378.test.js


### PR DESCRIPTION
## The blocker (found on the GO-LIVE daily-workflow walk on prod)

Opening an episode of care returned **500 `assertBeneficiaryInScope is not a function`** → no episode → no session → **the entire clinical daily workflow is blocked**.

**20 route files** destructure `assertBeneficiaryInScope` from `middleware/assertBranchMatch.js`, which **never exported it** — every guarded write threw. Pre-adoption prod hid it (0 episodes / 0 appointments / 0 caretimelines — no write path had ever been exercised). Affected: episodes, therapy-sessions-admin, care-plans-admin, emr, clinical-docs, clinical-pathway, referrals, medicalReferrals, insuranceClaims, guardians, tasks, students, subsidies, outcomes-admin, caseload-assignment, beneficiary-consents, ai-analytics, family-home-program, smart-assessment-engine, therapist-extended.

## Fix

Add `assertBeneficiaryInScope(req, beneficiaryId, res)` to `assertBranchMatch` — a denied-flag wrapper over the existing `enforceBeneficiaryBranch` (returns `true` + writes the status on denial, `false` when allowed, re-throws when `res` is omitted). Matches all 20 callers' contract; **one export unblocks all of them**.

## Tests (5)

Contract (allowed / denied+400 / missing-res throw) + a **drift guard** that scans every `assertBranchMatch` destructure in `routes/` and fails on any name the module doesn't export — catches the next phantom import. `check:routes-load` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)