### PR TITLE
W1390: post-deploy mount probes for blueprint-43 + launch surfaces

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1772,6 +1772,8 @@ on:
       - 'backend/__tests__/whatsapp-bot-bilingual-wave1383.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/assert-beneficiary-in-scope-wave1378.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/post-deploy-probes-blueprint43-wave1390.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3522,6 +3524,8 @@ on:
       - 'backend/__tests__/whatsapp-bot-bilingual-wave1383.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/assert-beneficiary-in-scope-wave1378.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/post-deploy-probes-blueprint43-wave1390.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/post-deploy-probes-blueprint43-wave1390.test.js
+++ b/backend/__tests__/post-deploy-probes-blueprint43-wave1390.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/**
+ * W1390 — lock the post-deploy smoke probes for the blueprint-43 +
+ * launch-readiness surfaces.
+ *
+ * post-deploy-smoke.js catches "route registered in code but unmounted in the
+ * registry" (its documented purpose). This session shipped 5 auth-gated read
+ * surfaces that back LIVE web-admin screens — a silent 404 on any = a blank
+ * operator page. This guard ensures their probes stay in the smoke list (a
+ * future probe-list refactor can't silently drop them).
+ *
+ * Static: reads the script source (the script's main() hits the network, so
+ * we assert on the PROBES declaration text, not by running it).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'scripts', 'post-deploy-smoke.js'),
+  'utf8'
+);
+
+const REQUIRED_PROBES = [
+  '/api/v1/next-best-action/catalogue', // W1206
+  '/api/v1/pathway-bundles', // W1205
+  '/api/v1/outcomes-rollup/center', // W1214
+  '/api/v1/email-templates', // W1242
+  '/api/v1/launch-readiness', // W1375
+];
+
+describe('W1390 — blueprint-43 / launch surfaces have post-deploy mount probes', () => {
+  test.each(REQUIRED_PROBES)('probes %s via mountedRoute', (probePath) => {
+    // mountedRoute(name, path) → critical mount probe (accepts 401/403, rejects 404/5xx)
+    const re = new RegExp(`mountedRoute\\([^)]*'${probePath.replace(/[/]/g, '\\/')}'`);
+    expect(SRC).toMatch(re);
+  });
+
+  test('all five are declared inside the PROBES array (before its close)', () => {
+    const probesStart = SRC.indexOf('const PROBES = [');
+    const probesEnd = SRC.indexOf('];', probesStart);
+    expect(probesStart).toBeGreaterThan(-1);
+    const block = SRC.slice(probesStart, probesEnd);
+    for (const p of REQUIRED_PROBES) expect(block).toContain(p);
+  });
+
+  test('they use the critical mount predicate (not a bespoke weaker check)', () => {
+    // mountedRoute sets critical:true + expect r.status!==404 && <500 — assert
+    // we reused the helper rather than hand-rolling a probe that could pass on 404.
+    for (const p of REQUIRED_PROBES) {
+      expect(SRC).toMatch(new RegExp(`mountedRoute\\('[^']+',\\s*'${p.replace(/[/]/g, '\\/')}'\\)`));
+    }
+  });
+});

--- a/backend/scripts/post-deploy-smoke.js
+++ b/backend/scripts/post-deploy-smoke.js
@@ -154,6 +154,17 @@ const PROBES = [
   mountedRoute('phase30-hr-workflow-config', '/api/v1/hr/workflow/config'),
   mountedRoute('phase30-hr-scheduler-status', '/api/v1/hr/workflow/scheduler/status'),
 
+  // ── Blueprint-43 + launch-readiness surfaces (shipped 2026-06-11→16) ──
+  // The session's golden-thread / intelligence / launch-enablement routes.
+  // Each is one _registry.js entry away from a silent 404 — and unlike most,
+  // these back live web-admin screens (a 404 here = a blank operator page).
+  // All are auth-gated read surfaces → 401/403 unauth is mounted-evidence.
+  mountedRoute('w1206-next-best-action', '/api/v1/next-best-action/catalogue'),
+  mountedRoute('w1205-pathway-bundles', '/api/v1/pathway-bundles'),
+  mountedRoute('w1214-outcomes-rollup', '/api/v1/outcomes-rollup/center'),
+  mountedRoute('w1242-email-templates', '/api/v1/email-templates'),
+  mountedRoute('w1375-launch-readiness', '/api/v1/launch-readiness'),
+
   // ── Auth-gated diagnostics (non-critical without a token) ────────
   {
     name: 'integration-health-aggregator',

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1053,3 +1053,4 @@ __tests__/whatsapp-bot-interactive-menu-wave1381.test.js
 __tests__/whatsapp-bot-intelligence-wave1382.test.js
 __tests__/whatsapp-bot-bilingual-wave1383.test.js
 __tests__/assert-beneficiary-in-scope-wave1378.test.js
+__tests__/post-deploy-probes-blueprint43-wave1390.test.js


### PR DESCRIPTION
`post-deploy-smoke.js` catches 'route in code but unmounted' (its purpose). This session shipped 5 auth-gated read surfaces backing **live web-admin screens** — a silent 404 = a blank operator page. Adds a critical mount probe for each (next-best-action / pathway-bundles / outcomes-rollup / email-templates / launch-readiness).

All 5 verified returning 401 (mounted) on prod now. +7-assertion guard. Sprint-enumerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)