### PR TITLE
feat(sessions): W1379+W1380 — complete the clinical session path (timeline + SOAP)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1867,6 +1867,8 @@ on:
       - 'backend/__tests__/whatsapp-bot-records-wave1384.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/whatsapp-bot-core-linkage-wave1408.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/clinical-session-path-wave1379.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3712,6 +3714,8 @@ on:
       - 'backend/__tests__/whatsapp-bot-records-wave1384.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/whatsapp-bot-core-linkage-wave1408.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/clinical-session-path-wave1379.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/clinical-session-path-wave1379.test.js
+++ b/backend/__tests__/clinical-session-path-wave1379.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+/**
+ * clinical-session-path-wave1379.test.js
+ *
+ * Completes the GO-LIVE clinical daily path (after W1378 unblocked
+ * episode/session creation). Two fixes, both found by walking the path live:
+ *
+ *   W1379 — ClinicalSession → CareTimeline producer. The
+ *     `sessions:completed → timeline:record` subscriber (pattern
+ *     `sessions.session.completed`) has been wired since W1240, but
+ *     ClinicalSession never EMITTED — so /care/360 stayed empty even with
+ *     real sessions. Native pre-compile post('save') hook now publishes on
+ *     a status→completed transition (best-effort, beneficiary-gated, no
+ *     re-emit on later saves).
+ *
+ *   W1380 — SOAP documentation contract. The schema stores SOAP as four
+ *     top-level String fields; the route used to `$set` the whole request
+ *     OBJECT into the String `soapNotes` → CastError (400). Asserting the
+ *     post-save emit + the field-mapping shape here.
+ *
+ * Producer is verified by capturing integrationBus publishes (the subscriber
+ * itself is already covered by the W1240-era suites). Poll-free: the emit is
+ * synchronous within save().
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const { integrationBus } = require('../integration/systemIntegrationBus');
+
+let mongo;
+let ClinicalSession;
+
+const oid = () => new mongoose.Types.ObjectId();
+
+function baseSession(over = {}) {
+  return {
+    beneficiaryId: oid(),
+    episodeId: oid(),
+    therapistId: oid(),
+    branchId: oid(),
+    scheduledDate: new Date('2026-06-18T09:00:00Z'),
+    type: 'individual',
+    status: 'scheduled',
+    ...over,
+  };
+}
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  ({ ClinicalSession } = require('../domains/sessions/models/ClinicalSession'));
+  await ClinicalSession.init();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+});
+
+afterEach(async () => {
+  await ClinicalSession.deleteMany({});
+});
+
+/** Capture every publish on the integration bus for the duration of `fn`. */
+async function captureBus(fn) {
+  const events = [];
+  const orig = integrationBus.publish.bind(integrationBus);
+  integrationBus.publish = (domain, eventType, payload) => {
+    events.push({ domain, eventType, payload });
+    return orig(domain, eventType, payload);
+  };
+  try {
+    await fn();
+  } finally {
+    integrationBus.publish = orig;
+  }
+  return events;
+}
+
+describe('W1379 ClinicalSession → sessions.session.completed producer', () => {
+  test('scheduled session does NOT emit', async () => {
+    const events = await captureBus(async () => {
+      await ClinicalSession.create(baseSession());
+    });
+    expect(events.filter((e) => e.eventType === 'sessions.session.completed')).toHaveLength(0);
+  });
+
+  test('completing a session emits exactly once with the subscriber contract', async () => {
+    const benId = oid();
+    const epId = oid();
+    const s = await ClinicalSession.create(baseSession({ beneficiaryId: benId, episodeId: epId }));
+    const events = await captureBus(async () => {
+      s.status = 'completed';
+      await s.save();
+    });
+    const emitted = events.filter((e) => e.eventType === 'sessions.session.completed');
+    expect(emitted).toHaveLength(1);
+    const p = emitted[0].payload;
+    expect(emitted[0].domain).toBe('sessions');
+    expect(String(p.beneficiaryId)).toBe(String(benId));
+    expect(String(p.episodeId)).toBe(String(epId));
+    expect(p.sessionId).toBe(String(s._id));
+    expect(p.sessionType).toBe('individual');
+  });
+
+  test('a later unrelated save of an already-completed session does NOT re-emit', async () => {
+    const s = await ClinicalSession.create(baseSession({ status: 'completed' }));
+    const events = await captureBus(async () => {
+      s.notes = 'addendum';
+      await s.save();
+    });
+    expect(events.filter((e) => e.eventType === 'sessions.session.completed')).toHaveLength(0);
+  });
+
+  test('creating directly as completed emits once', async () => {
+    const events = await captureBus(async () => {
+      await ClinicalSession.create(baseSession({ status: 'completed' }));
+    });
+    expect(events.filter((e) => e.eventType === 'sessions.session.completed')).toHaveLength(1);
+  });
+});
+
+describe('W1380 SOAP documentation stores four fields (not the object in a String)', () => {
+  test('subjective/objective/assessment/plan persist as their own String fields', async () => {
+    const s = await ClinicalSession.create(baseSession());
+    s.subjective = 'المريض متعاون';
+    s.objective = 'أكمل التمارين';
+    s.assessment = 'تحسن ملحوظ';
+    s.plan = 'الاستمرار';
+    s.documentedAt = new Date();
+    await s.save();
+
+    const row = await ClinicalSession.findById(s._id).lean();
+    expect(row.subjective).toBe('المريض متعاون');
+    expect(row.assessment).toBe('تحسن ملحوظ');
+    expect(row.documentedAt).toBeInstanceOf(Date);
+    // soapNotes (the combined String) is independent and was never set to an object
+    expect(typeof (row.soapNotes ?? '')).toBe('string');
+  });
+
+  test('the route source maps fields explicitly and never dumps req.body into soapNotes', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(
+      path.join(__dirname, '..', 'routes', 'therapy-sessions.routes.js'),
+      'utf8'
+    );
+    expect(src).not.toMatch(/soapNotes:\s*req\.body/);
+    expect(src).toMatch(/for \(const f of \['subjective', 'objective', 'assessment', 'plan', 'soapNotes'\]\)/);
+  });
+});

--- a/backend/domains/sessions/models/ClinicalSession.js
+++ b/backend/domains/sessions/models/ClinicalSession.js
@@ -185,6 +185,7 @@ const clinicalSessionSchema = new mongoose.Schema(
     assessment: String, // A — تحليل الأخصائي
     plan: String, // P — الخطة التالية
     soapNotes: String, // Combined SOAP
+    documentedAt: Date, // W1380 — when SOAP documentation was last saved
 
     // ── Clinical Observations ──────────────────────────────────────────
     observations: {
@@ -324,6 +325,36 @@ clinicalSessionSchema.pre('save', function () {
     this.actualDurationMinutes = Math.round(
       (this.actualEndTime - this.actualStartTime) / (1000 * 60)
     );
+  }
+});
+
+// ── W1379 core-linkage: emit when a session is COMPLETED so it surfaces on
+// the unified CareTimeline. The subscriber `sessions:completed → timeline:record`
+// (pattern `sessions.session.completed`) has been wired since W1240, but the
+// PRODUCER side never existed — ClinicalSession emitted nothing, so the /care/360
+// timeline stayed empty even with real sessions (the W349/W1240 "subscriber wired
+// but never fired" class). Native pre-compile hooks (W933 lesson); best-effort —
+// never blocks the save. Gated on a status→completed TRANSITION so re-saves of an
+// already-completed session never re-emit.
+clinicalSessionSchema.pre('save', function flagSessionCompleted() {
+  this.$__sessionCompleted =
+    this.status === 'completed' && (this.isNew || this.isModified('status'));
+});
+
+clinicalSessionSchema.post('save', function emitSessionCompleted(doc) {
+  if (!doc.$__sessionCompleted || !doc.beneficiaryId) return;
+  try {
+    const { integrationBus } = require('../../../integration/systemIntegrationBus');
+    integrationBus.publish('sessions', 'sessions.session.completed', {
+      sessionId: String(doc._id),
+      beneficiaryId: String(doc.beneficiaryId),
+      ...(doc.episodeId ? { episodeId: String(doc.episodeId) } : {}),
+      ...(doc.branchId ? { branchId: String(doc.branchId) } : {}),
+      sessionType: doc.type || doc.specialty || null,
+      completedAt: doc.actualEndTime || new Date(),
+    });
+  } catch (_err) {
+    /* best-effort: never block the save on bus failure */
   }
 });
 

--- a/backend/routes/therapy-sessions.routes.js
+++ b/backend/routes/therapy-sessions.routes.js
@@ -275,29 +275,56 @@ router.get(
     const S = Session();
     if (!S) return res.json({ success: true, data: null });
     const session = await S.findById(req.params.sessionId)
-      .select('notes soapNotes documentation')
+      .select('subjective objective assessment plan soapNotes notes documentation documentedAt')
       .lean();
     if (!session) return res.status(404).json({ success: false, message: 'Session not found' });
     res.json({
       success: true,
-      data: session.soapNotes || session.documentation || session.notes || null,
+      data: {
+        subjective: session.subjective ?? null,
+        objective: session.objective ?? null,
+        assessment: session.assessment ?? null,
+        plan: session.plan ?? null,
+        soapNotes: session.soapNotes ?? session.documentation ?? session.notes ?? null,
+        documentedAt: session.documentedAt ?? null,
+      },
     });
   })
 );
 
 // POST /therapy-sessions/:sessionId/documentation — save SOAP notes
+// W1380: ClinicalSession stores SOAP as four top-level String fields
+// (subjective/objective/assessment/plan) + a combined `soapNotes`. The route
+// previously assigned the WHOLE request object to the String soapNotes field
+// → Mongoose CastError (400 INVALID_ID) → SOAP could never be saved. Map each
+// field explicitly instead.
 router.post(
   '/:sessionId/documentation',
   asyncHandler(async (req, res) => {
     const S = Session();
     if (!S) return res.status(503).json({ success: false, message: 'Model unavailable' });
+    const body = req.body || {};
+    const $set = { documentedAt: new Date() };
+    for (const f of ['subjective', 'objective', 'assessment', 'plan', 'soapNotes']) {
+      if (body[f] !== undefined && body[f] !== null) $set[f] = String(body[f]);
+    }
     const session = await S.findByIdAndUpdate(
       req.params.sessionId,
-      { $set: { soapNotes: req.body, documentedAt: new Date() } },
+      { $set },
       { returnDocument: 'after' }
     ).lean();
     if (!session) return res.status(404).json({ success: false, message: 'Session not found' });
-    res.json({ success: true, data: session.soapNotes });
+    res.json({
+      success: true,
+      data: {
+        subjective: session.subjective ?? null,
+        objective: session.objective ?? null,
+        assessment: session.assessment ?? null,
+        plan: session.plan ?? null,
+        soapNotes: session.soapNotes ?? null,
+        documentedAt: session.documentedAt ?? null,
+      },
+    });
   })
 );
 

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -919,3 +919,4 @@ __tests__/go-live-deployment-readiness-wave1404.test.js
 __tests__/monitoring-infrastructure-wave1405.test.js
 __tests__/whatsapp-bot-records-wave1384.test.js
 __tests__/whatsapp-bot-core-linkage-wave1408.test.js
+__tests__/clinical-session-path-wave1379.test.js


### PR DESCRIPTION
Two fixes found by the GO-LIVE daily-workflow walk on prod, after W1378 (#519) unblocked episode/session creation.

### W1379 — ClinicalSession → CareTimeline producer
The `sessions:completed → timeline:record` subscriber (pattern `sessions.session.completed`) has been wired since W1240, but **ClinicalSession never emitted** — so `/care/360` stayed empty even with real sessions (the W349/W1240 *subscriber-wired-but-never-fired* class). Native pre-compile `post('save')` hook now publishes on a **status→completed transition** (best-effort, beneficiary-gated, no re-emit on later saves).

### W1380 — SOAP documentation contract
ClinicalSession stores SOAP as four top-level String fields + a combined `soapNotes`; the `/:sessionId/documentation` route assigned the **whole request object** to the String `soapNotes` → Mongoose CastError (**400 INVALID_ID**) → SOAP could never be saved. Route now maps each field explicitly + `documentedAt:Date` added to the schema; GET returns the structured shape.

### Tests (6)
Producer emits once on completion / not when scheduled / no re-emit on unrelated save / emits on create-as-completed (bus capture) + SOAP fields persist independently + source guard. `hook-style` + `routes-load` + `phantom-writes` clean; existing session-timeline-subscriber suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)