### PR TITLE
fix(sessions): W1381 — completeSession publishes on the integration bus (360 timeline was empty)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1869,6 +1869,8 @@ on:
       - 'backend/__tests__/whatsapp-bot-core-linkage-wave1408.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/clinical-session-path-wave1379.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/session-completed-bus-wave1381.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3716,6 +3718,8 @@ on:
       - 'backend/__tests__/whatsapp-bot-core-linkage-wave1408.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/clinical-session-path-wave1379.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/session-completed-bus-wave1381.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/session-completed-bus-wave1381.test.js
+++ b/backend/__tests__/session-completed-bus-wave1381.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+/**
+ * session-completed-bus-wave1381.test.js
+ *
+ * W1381 — SessionsService.completeSession must publish
+ * `sessions.session.completed` on the INTEGRATION BUS, not only via the
+ * local BaseService EventEmitter. The CareTimeline subscriber
+ * (`sessions:completed → timeline:record`, wired since W1240) listens on
+ * the integrationBus, and the two were never bridged for SessionsService —
+ * so completing a session left /care/360 empty (verified live on prod:
+ * PATCH /:id/status → completed produced 0 timeline rows).
+ *
+ * Verifies the bus publish fires with the subscriber's payload contract,
+ * by capturing integrationBus.publish around a real completeSession call.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const { integrationBus } = require('../integration/systemIntegrationBus');
+
+let mongo;
+let ClinicalSession;
+let sessionsService;
+
+const oid = () => new mongoose.Types.ObjectId();
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  ({ ClinicalSession } = require('../domains/sessions/models/ClinicalSession'));
+  await ClinicalSession.init();
+  ({ sessionsService } = require('../domains/sessions/services/SessionsService'));
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+});
+
+afterEach(async () => {
+  await ClinicalSession.deleteMany({});
+});
+
+async function captureBus(fn) {
+  const events = [];
+  const orig = integrationBus.publish.bind(integrationBus);
+  integrationBus.publish = (domain, eventType, payload) => {
+    events.push({ domain, eventType, payload });
+    return orig(domain, eventType, payload);
+  };
+  try {
+    await fn();
+  } finally {
+    integrationBus.publish = orig;
+  }
+  return events;
+}
+
+describe('W1381 completeSession → integrationBus', () => {
+  test('publishes sessions.session.completed with the subscriber contract', async () => {
+    const benId = oid();
+    const epId = oid();
+    const session = await ClinicalSession.create({
+      beneficiaryId: benId,
+      episodeId: epId,
+      therapistId: oid(),
+      branchId: oid(),
+      scheduledDate: new Date(),
+      type: 'individual',
+      status: 'scheduled',
+    });
+
+    const events = await captureBus(async () => {
+      await sessionsService.completeSession(String(session._id), { duration: 45 });
+    });
+
+    const emitted = events.filter((e) => e.eventType === 'sessions.session.completed');
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].domain).toBe('sessions');
+    const p = emitted[0].payload;
+    expect(String(p.beneficiaryId)).toBe(String(benId));
+    expect(String(p.episodeId)).toBe(String(epId));
+    expect(p.sessionId).toBe(String(session._id));
+    expect(p.sessionType).toBe('individual');
+    expect(p.duration).toBe(45);
+  });
+
+  test('the persisted session reaches status completed', async () => {
+    const session = await ClinicalSession.create({
+      beneficiaryId: oid(),
+      episodeId: oid(),
+      therapistId: oid(),
+      scheduledDate: new Date(),
+      type: 'individual',
+      status: 'scheduled',
+    });
+    await sessionsService.completeSession(String(session._id), { duration: 30 });
+    const row = await ClinicalSession.findById(session._id).lean();
+    expect(row.status).toBe('completed');
+  });
+});

--- a/backend/domains/sessions/services/SessionsService.js
+++ b/backend/domains/sessions/services/SessionsService.js
@@ -237,6 +237,28 @@ class SessionsService extends BaseService {
       duration: duration || session.duration,
     });
 
+    // W1381 — also publish on the INTEGRATION BUS. The line above is a local
+    // BaseService EventEmitter emit; the `sessions:completed → timeline:record`
+    // subscriber (CareTimeline, since W1240) listens on the integrationBus, and
+    // the two are NOT bridged for SessionsService — so completing a session left
+    // /care/360 empty (verified live on prod: PATCH /:id/status completed → 0
+    // timeline rows). This direct publish closes the W387 cross-bus gap.
+    // completeSession persists via findByIdAndUpdate (no doc .save()), so the
+    // ClinicalSession W1379 model hook does not fire here — no double-emit.
+    try {
+      const { integrationBus } = require('../../../integration/systemIntegrationBus');
+      integrationBus.publish('sessions', 'sessions.session.completed', {
+        sessionId: String(session._id),
+        beneficiaryId: session.beneficiaryId ? String(session.beneficiaryId) : null,
+        ...(session.episodeId ? { episodeId: String(session.episodeId) } : {}),
+        ...(session.branchId ? { branchId: String(session.branchId) } : {}),
+        sessionType: session.type || null,
+        duration: duration || session.duration || null,
+      });
+    } catch (_err) {
+      /* best-effort: never fail the completion on bus failure */
+    }
+
     await projectClinicalSession(session, { logger: this.logger });
     return session;
   }

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -920,3 +920,4 @@ __tests__/monitoring-infrastructure-wave1405.test.js
 __tests__/whatsapp-bot-records-wave1384.test.js
 __tests__/whatsapp-bot-core-linkage-wave1408.test.js
 __tests__/clinical-session-path-wave1379.test.js
+__tests__/session-completed-bus-wave1381.test.js


### PR DESCRIPTION
Verified live on prod after W1379/W1380: `PATCH /:id/status → completed` produced **0 CareTimeline rows**.

**Root:** `completeSession` only did `this.emit('session.completed', …)` — a **local** BaseService EventEmitter emit — while the `sessions:completed → timeline:record` subscriber (CareTimeline, since W1240) listens on the **integrationBus**, and the two aren't bridged for SessionsService (the W387 cross-bus class). So `/care/360` stayed empty even for properly-completed sessions.

**Fix:** `completeSession` now also `integrationBus.publish('sessions', 'sessions.session.completed', {beneficiaryId, episodeId, sessionId, sessionType, duration, branchId})`. best-effort. Uses findByIdAndUpdate (no `.save()`), so the W1379 model hook doesn't fire here → no double-emit.

**Test:** captures the bus publish around a real `completeSession` + asserts the subscriber payload + status reaches completed. 2 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)