### PR TITLE
fix(sessions): W1382 — correct the bus event key for session completion (360 timeline)

### DIFF
--- a/backend/__tests__/clinical-session-path-wave1379.test.js
+++ b/backend/__tests__/clinical-session-path-wave1379.test.js
@@ -87,7 +87,7 @@ describe('W1379 ClinicalSession → sessions.session.completed producer', () => 
     const events = await captureBus(async () => {
       await ClinicalSession.create(baseSession());
     });
-    expect(events.filter((e) => e.eventType === 'sessions.session.completed')).toHaveLength(0);
+    expect(events.filter((e) => e.eventType === 'session.completed')).toHaveLength(0);
   });
 
   test('completing a session emits exactly once with the subscriber contract', async () => {
@@ -98,7 +98,7 @@ describe('W1379 ClinicalSession → sessions.session.completed producer', () => 
       s.status = 'completed';
       await s.save();
     });
-    const emitted = events.filter((e) => e.eventType === 'sessions.session.completed');
+    const emitted = events.filter((e) => e.eventType === 'session.completed');
     expect(emitted).toHaveLength(1);
     const p = emitted[0].payload;
     expect(emitted[0].domain).toBe('sessions');
@@ -114,14 +114,14 @@ describe('W1379 ClinicalSession → sessions.session.completed producer', () => 
       s.notes = 'addendum';
       await s.save();
     });
-    expect(events.filter((e) => e.eventType === 'sessions.session.completed')).toHaveLength(0);
+    expect(events.filter((e) => e.eventType === 'session.completed')).toHaveLength(0);
   });
 
   test('creating directly as completed emits once', async () => {
     const events = await captureBus(async () => {
       await ClinicalSession.create(baseSession({ status: 'completed' }));
     });
-    expect(events.filter((e) => e.eventType === 'sessions.session.completed')).toHaveLength(1);
+    expect(events.filter((e) => e.eventType === 'session.completed')).toHaveLength(1);
   });
 });
 

--- a/backend/__tests__/session-completed-bus-wave1381.test.js
+++ b/backend/__tests__/session-completed-bus-wave1381.test.js
@@ -79,7 +79,7 @@ describe('W1381 completeSession → integrationBus', () => {
       await sessionsService.completeSession(String(session._id), { duration: 45 });
     });
 
-    const emitted = events.filter((e) => e.eventType === 'sessions.session.completed');
+    const emitted = events.filter((e) => e.eventType === 'session.completed');
     expect(emitted).toHaveLength(1);
     expect(emitted[0].domain).toBe('sessions');
     const p = emitted[0].payload;

--- a/backend/domains/sessions/models/ClinicalSession.js
+++ b/backend/domains/sessions/models/ClinicalSession.js
@@ -345,7 +345,7 @@ clinicalSessionSchema.post('save', function emitSessionCompleted(doc) {
   if (!doc.$__sessionCompleted || !doc.beneficiaryId) return;
   try {
     const { integrationBus } = require('../../../integration/systemIntegrationBus');
-    integrationBus.publish('sessions', 'sessions.session.completed', {
+    integrationBus.publish('sessions', 'session.completed', {
       sessionId: String(doc._id),
       beneficiaryId: String(doc.beneficiaryId),
       ...(doc.episodeId ? { episodeId: String(doc.episodeId) } : {}),

--- a/backend/domains/sessions/services/SessionsService.js
+++ b/backend/domains/sessions/services/SessionsService.js
@@ -247,7 +247,7 @@ class SessionsService extends BaseService {
     // ClinicalSession W1379 model hook does not fire here — no double-emit.
     try {
       const { integrationBus } = require('../../../integration/systemIntegrationBus');
-      integrationBus.publish('sessions', 'sessions.session.completed', {
+      integrationBus.publish('sessions', 'session.completed', {
         sessionId: String(session._id),
         beneficiaryId: session.beneficiaryId ? String(session.beneficiaryId) : null,
         ...(session.episodeId ? { episodeId: String(session.episodeId) } : {}),


### PR DESCRIPTION
Verified live after W1381: a completed session **still** produced 0 CareTimeline rows.

**Root:** the bus routing key is `${domain}.${eventType}` (systemIntegrationBus.js:251); the subscriber listens on `sessions.session.completed`. W1379/W1381 published `publish('sessions', 'sessions.session.completed', …)` → routing key `sessions.sessions.session.completed` → **never matched**.

**Fix:** eventType = `session.completed` (so `sessions` + `.` + `session.completed` = the subscriber pattern), matching the CouponUsage W1105 convention. Both producers corrected; tests updated. 8 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)