### PR TITLE
security(W1411): close W1407 cross-tenant PII leak in WhatsApp conversations

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1871,6 +1871,8 @@ on:
       - 'backend/__tests__/clinical-session-path-wave1379.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/session-completed-bus-wave1381.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/whatsapp-conversation-branch-isolation-wave1411.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3720,6 +3722,8 @@ on:
       - 'backend/__tests__/clinical-session-path-wave1379.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/session-completed-bus-wave1381.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/whatsapp-conversation-branch-isolation-wave1411.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/whatsapp-byid-org-scope-wave744.test.js
+++ b/backend/__tests__/whatsapp-byid-org-scope-wave744.test.js
@@ -1,30 +1,38 @@
 /**
- * W744 — org-scoped by-ID filter for WhatsApp conversation routes.
+ * W744 / W1407 — BRANCH-scoped by-ID filter for WhatsApp conversation routes.
  *
  * The path-based `/conversations/:id` (read), `/resolve`, `/assign`,
- * `/mark-read` and `/ai/insights/:conversationId` endpoints used
- * `findById` / `findByIdAndUpdate`, which ignore organization boundaries — a
- * foreign-org staff member could read/mutate another tenant's conversation by
- * id (W269 cross-tenant isolation doctrine). The filter now carries the org so
- * a cross-org id yields a clean 404 (no existence leak).
+ * `/mark-read` and `/ai/insights/:conversationId` endpoints scope by id only.
+ * Originally the filter carried `organizationId` — but this branch-scoped
+ * platform never sets `req.user.organizationId`, so the scope was always
+ * undefined → the filter fell back to id-only → ANY authenticated user could
+ * read/mutate another branch's conversation (W1407 cross-tenant PII leak).
+ * The filter now carries `branchId` (from effectiveBranchScope), so a
+ * foreign-branch id yields a clean 404 (no existence leak). Cross-branch roles
+ * pass null/undefined scope → id-only (intended).
  */
 'use strict';
 
 const { byIdScopedFilter } = require('../models/WhatsAppConversation');
 
-describe('W744 — byIdScopedFilter', () => {
-  test('adds organizationId to the filter when an org is given', () => {
-    expect(byIdScopedFilter('abc', 'org-1')).toEqual({ _id: 'abc', organizationId: 'org-1' });
+describe('W744/W1407 — byIdScopedFilter (branch-scoped)', () => {
+  test('adds branchId to the filter when a branch scope is given', () => {
+    expect(byIdScopedFilter('abc', 'branch-1')).toEqual({ _id: 'abc', branchId: 'branch-1' });
   });
 
-  test('omits organizationId for single-tenant / system callers', () => {
+  test('omits branchId for cross-branch / system callers (null/undefined scope)', () => {
     const f = byIdScopedFilter('abc', undefined);
     expect(f).toEqual({ _id: 'abc' });
-    expect(f).not.toHaveProperty('organizationId');
+    expect(f).not.toHaveProperty('branchId');
+    expect(byIdScopedFilter('abc', null)).toEqual({ _id: 'abc' });
+  });
+
+  test('never scopes by the never-set organizationId field', () => {
+    expect(byIdScopedFilter('abc', 'branch-1')).not.toHaveProperty('organizationId');
   });
 
   test('always targets the requested id', () => {
-    expect(byIdScopedFilter('xyz', 'org-9')._id).toBe('xyz');
+    expect(byIdScopedFilter('xyz', 'branch-9')._id).toBe('xyz');
     expect(byIdScopedFilter('xyz', null)._id).toBe('xyz');
   });
 });

--- a/backend/__tests__/whatsapp-conversation-branch-isolation-wave1411.test.js
+++ b/backend/__tests__/whatsapp-conversation-branch-isolation-wave1411.test.js
@@ -1,0 +1,85 @@
+/**
+ * W1411 — WhatsApp conversation BRANCH isolation (closes the W1407 leak).
+ *
+ * W1407 finding: `/conversations` (+ pending-review, byId read/resolve/assign/
+ * mark-read, insights, analytics) scoped by `req.user.organizationId` — a field
+ * this branch-scoped platform NEVER sets. So the scope was always undefined →
+ * the filters fell back to unscoped → ANY authenticated user could read every
+ * branch's WhatsApp conversations + message PII (fails OPEN).
+ *
+ * Fix: scope by `branchId` via `effectiveBranchScope(req)`; the webhook derives
+ * the conversation's `branchId` from the matched beneficiary; unmatched inbound
+ * → branchId null (visible only to cross-branch roles = fail-closed).
+ *
+ * This guard pairs the pure-helper behavior with a source drift check so the
+ * never-set-organizationId scoping cannot silently return.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { byIdScopedFilter, queueCountFilters } = require('../models/WhatsAppConversation');
+
+const ROUTES_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'routes', 'whatsapp.routes.js'),
+  'utf8'
+);
+const WEBHOOK_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'services', 'whatsapp', 'whatsappWebhook.service.js'),
+  'utf8'
+);
+const MODEL_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'models', 'WhatsAppConversation.js'),
+  'utf8'
+);
+
+describe('W1411 — pure helpers scope by branchId (not the never-set organizationId)', () => {
+  test('byIdScopedFilter scopes by branchId', () => {
+    expect(byIdScopedFilter('id1', 'branch-1')).toEqual({ _id: 'id1', branchId: 'branch-1' });
+    expect(byIdScopedFilter('id1', null)).toEqual({ _id: 'id1' });
+    expect(byIdScopedFilter('id1', 'branch-1')).not.toHaveProperty('organizationId');
+  });
+
+  test('queueCountFilters scopes by branchId', () => {
+    const f = queueCountFilters('branch-2');
+    expect(f.pendingReview.branchId).toBe('branch-2');
+    expect(f.critical.branchId).toBe('branch-2');
+    expect(f.pendingReview).not.toHaveProperty('organizationId');
+  });
+
+  // NOTE: findPendingReview + getAnalytics are mongoose schema STATICS. Under
+  // jest.setup.js the mongoose model is mocked, so statics aren't attached and
+  // can't be invoked here — their branchId scoping is asserted via the source
+  // drift guard below (q.branchId / match.branchId in the model source).
+});
+
+describe('W1411 — source drift guard (the org-scoped leak cannot return)', () => {
+  test('routes import + use effectiveBranchScope for conversation scoping', () => {
+    expect(ROUTES_SRC).toContain('effectiveBranchScope');
+    // list endpoint scopes by branchId from effectiveBranchScope
+    expect(ROUTES_SRC).toMatch(/filter\.branchId\s*=\s*branchScope/);
+    // by-id routes pass the branch scope, not the never-set org
+    expect(ROUTES_SRC).toContain('byIdScopedFilter(req.params.id, effectiveBranchScope(req))');
+  });
+
+  test('routes no longer scope conversations by req.user.organizationId', () => {
+    expect(ROUTES_SRC).not.toContain('byIdScopedFilter(req.params.id, req.user?.organizationId)');
+    expect(ROUTES_SRC).not.toContain('findPendingReview(req.user?.organizationId)');
+    expect(ROUTES_SRC).not.toMatch(/filter\.organizationId\s*=\s*req\.user/);
+  });
+
+  test('webhook derives + persists branchId from the matched beneficiary', () => {
+    expect(WEBHOOK_SRC).toContain('getBeneficiaryModel');
+    expect(WEBHOOK_SRC).toMatch(/branchId,\s*\/\/ W1407/);
+  });
+
+  test('all 4 model scoping helpers filter by branchId (not organizationId)', () => {
+    expect(MODEL_SRC).toMatch(/filter\.branchId\s*=\s*branchScope/); // byIdScopedFilter
+    expect(MODEL_SRC).toMatch(/q\.branchId\s*=\s*branchScope/); // findPendingReview
+    expect(MODEL_SRC).toMatch(/base\.branchId\s*=\s*branchScope/); // queueCountFilters
+    expect(MODEL_SRC).toMatch(/match\.branchId\s*=\s*new mongoose\.Types\.ObjectId/); // getAnalytics
+    // the never-set organizationId must no longer be a scoping key in any helper
+    expect(MODEL_SRC).not.toMatch(/\.organizationId\s*=\s*(orgId|branchScope)\b/);
+  });
+});

--- a/backend/__tests__/whatsapp-queue-count-filters-wave743.test.js
+++ b/backend/__tests__/whatsapp-queue-count-filters-wave743.test.js
@@ -1,37 +1,44 @@
 /**
- * W743 — org-scoped queue-count filters for the WhatsApp /analytics tiles.
+ * W743 / W1407 — BRANCH-scoped queue-count filters for the WhatsApp /analytics tiles.
  *
- * `getAnalytics` and `findPendingReview` both scope by `organizationId`, but the
- * sibling `pendingReview` / `critical` countDocuments in the /analytics route
- * did NOT — so a multi-tenant deployment over-counted across organizations. The
- * filters are now built by one pure helper that scopes by org when present.
+ * `getAnalytics`, `findPendingReview`, and these `pendingReview` / `critical`
+ * countDocuments filters all scope by the same tenant key so the tiles match.
+ * Originally that key was `organizationId` — never set on this branch-scoped
+ * platform, so the tiles counted ALL branches (W1407). Now scoped by `branchId`
+ * (from effectiveBranchScope) when a branch scope is present.
  */
 'use strict';
 
 const { queueCountFilters } = require('../models/WhatsAppConversation');
 
-describe('W743 — queueCountFilters', () => {
-  test('scopes both counts by organizationId when an org is given', () => {
-    const f = queueCountFilters('org-1');
-    expect(f.pendingReview.organizationId).toBe('org-1');
-    expect(f.critical.organizationId).toBe('org-1');
+describe('W743/W1407 — queueCountFilters (branch-scoped)', () => {
+  test('scopes both counts by branchId when a branch scope is given', () => {
+    const f = queueCountFilters('branch-1');
+    expect(f.pendingReview.branchId).toBe('branch-1');
+    expect(f.critical.branchId).toBe('branch-1');
   });
 
-  test('omits organizationId when no org is given (single-tenant)', () => {
+  test('omits branchId when no scope is given (cross-branch role)', () => {
     const f = queueCountFilters(undefined);
+    expect(f.pendingReview).not.toHaveProperty('branchId');
+    expect(f.critical).not.toHaveProperty('branchId');
+  });
+
+  test('never scopes by the never-set organizationId field', () => {
+    const f = queueCountFilters('branch-1');
     expect(f.pendingReview).not.toHaveProperty('organizationId');
     expect(f.critical).not.toHaveProperty('organizationId');
   });
 
   test('pendingReview filter targets the unresolved human-review queue', () => {
-    const f = queueCountFilters('org-1');
+    const f = queueCountFilters('branch-1');
     expect(f.pendingReview.requiresHumanReview).toBe(true);
     expect(f.pendingReview.status).toEqual({ $ne: 'resolved' });
     expect(f.pendingReview.isDeleted).toBe(false);
   });
 
   test('critical filter targets unresolved critical conversations', () => {
-    const f = queueCountFilters('org-1');
+    const f = queueCountFilters('branch-1');
     expect(f.critical.urgencyLevel).toBe('critical');
     expect(f.critical.status).toEqual({ $ne: 'resolved' });
     expect(f.critical.isDeleted).toBe(false);

--- a/backend/models/WhatsAppConversation.js
+++ b/backend/models/WhatsAppConversation.js
@@ -139,6 +139,7 @@ const whatsappConversationSchema = new mongoose.Schema(
     branchId: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'Branch',
+      index: true, // W1407: tenant-isolation scoping field (see byIdScopedFilter)
     },
 
     // Conversation state
@@ -215,6 +216,7 @@ whatsappConversationSchema.index({ requiresHumanReview: 1, status: 1, lastMessag
 whatsappConversationSchema.index({ urgencyLevel: 1, status: 1 });
 whatsappConversationSchema.index({ urgencyRank: -1, lastMessageAt: -1 });
 whatsappConversationSchema.index({ organizationId: 1, lastMessageAt: -1 });
+whatsappConversationSchema.index({ branchId: 1, lastMessageAt: -1 }); // W1407 branch-scoped list
 whatsappConversationSchema.index({ assignedTo: 1, status: 1 });
 
 // ─── Virtuals ─────────────────────────────────────────────────────────────────
@@ -249,26 +251,29 @@ function sortPendingReview(rows) {
   });
 }
 
-// Filters for the dashboard queue-count tiles. Org-scoped so multi-tenant
-// deployments don't over-count across organizations (the sibling analytics
-// aggregation is already org-scoped — these must match). Pure + unit-testable.
-function queueCountFilters(orgId) {
+// Filters for the dashboard queue-count tiles. BRANCH-scoped (W1407) so a
+// branch-restricted user's tiles don't count other branches' conversations
+// (the sibling analytics aggregation is branch-scoped too — these must match).
+// `branchScope` = effectiveBranchScope(req): a branchId for restricted users,
+// null/undefined for cross-branch roles (→ no filter = see all). Pure + testable.
+function queueCountFilters(branchScope) {
   const base = { status: { $ne: 'resolved' }, isDeleted: false };
-  if (orgId) base.organizationId = orgId;
+  if (branchScope) base.branchId = branchScope;
   return {
     pendingReview: { ...base, requiresHumanReview: true },
     critical: { ...base, urgencyLevel: 'critical' },
   };
 }
 
-// Query filter for a by-ID lookup that also enforces org isolation. Path-based
-// `/conversations/:id` routes would otherwise let a foreign-org staff member
-// read/resolve/assign another tenant's conversation (W269 doctrine). Returning
-// the org in the filter means a cross-org id simply yields a clean 404 (no
-// existence leak). Pure + unit-testable.
-function byIdScopedFilter(id, orgId) {
+// Query filter for a by-ID lookup that also enforces BRANCH isolation (W1407).
+// Path-based `/conversations/:id` routes would otherwise let a branch-restricted
+// staff member read/resolve/assign another branch's conversation (W269 doctrine).
+// Putting branchId in the filter means a foreign-branch id simply yields a clean
+// 404 (no existence leak). `branchScope` null/undefined → no constraint (cross-
+// branch role). Pure + unit-testable.
+function byIdScopedFilter(id, branchScope) {
   const filter = { _id: id };
-  if (orgId) filter.organizationId = orgId;
+  if (branchScope) filter.branchId = branchScope;
   return filter;
 }
 
@@ -290,9 +295,9 @@ whatsappConversationSchema.statics.findByPhone = function (phone) {
   return this.findOne({ phone, isDeleted: false });
 };
 
-whatsappConversationSchema.statics.findPendingReview = function (orgId) {
+whatsappConversationSchema.statics.findPendingReview = function (branchScope) {
   const q = { requiresHumanReview: true, status: { $ne: 'resolved' }, isDeleted: false };
-  if (orgId) q.organizationId = orgId;
+  if (branchScope) q.branchId = branchScope;
   return this.find(q)
     .populate('beneficiaryId', 'personalInfo.firstName personalInfo.lastName fileNumber')
     .populate('familyMemberId', 'firstName lastName relationship')
@@ -300,9 +305,9 @@ whatsappConversationSchema.statics.findPendingReview = function (orgId) {
     .then(sortPendingReview);
 };
 
-whatsappConversationSchema.statics.getAnalytics = function (orgId, startDate, endDate) {
+whatsappConversationSchema.statics.getAnalytics = function (branchScope, startDate, endDate) {
   const match = { isDeleted: false };
-  if (orgId) match.organizationId = new mongoose.Types.ObjectId(orgId);
+  if (branchScope) match.branchId = new mongoose.Types.ObjectId(branchScope);
   if (startDate || endDate) {
     match.lastMessageAt = {};
     if (startDate) match.lastMessageAt.$gte = new Date(startDate);

--- a/backend/package.json
+++ b/backend/package.json
@@ -90,6 +90,7 @@
     "verify:supply-chain-staging": "node scripts/verify-supply-chain-staging.js",
     "verify:supply-chain-staging:json": "node scripts/verify-supply-chain-staging.js --json",
     "backfill:complaint-branchid": "node scripts/backfill-complaint-branchid.js",
+    "backfill:whatsapp-conversation-branchid": "node scripts/backfill-whatsapp-conversation-branchid.js",
     "backfill:referral-branchid": "node scripts/backfill-referral-branchid.js",
     "backfill:rehabplan-branchid": "node scripts/backfill-rehabplan-branchid.js",
     "backfill:referralticket-branchid": "node scripts/backfill-referralticket-branchid.js",

--- a/backend/routes/whatsapp.routes.js
+++ b/backend/routes/whatsapp.routes.js
@@ -44,7 +44,10 @@
 'use strict';
 
 const express = require('express');
-const { bodyScopedBeneficiaryGuard } = require('../middleware/assertBranchMatch');
+const {
+  bodyScopedBeneficiaryGuard,
+  effectiveBranchScope,
+} = require('../middleware/assertBranchMatch');
 
 const router = express.Router();
 router.use(bodyScopedBeneficiaryGuard); // W441: enforce branch on req.body.beneficiaryId
@@ -218,7 +221,8 @@ router.get(
     if (requiresReview === 'true') filter.requiresHumanReview = true;
     if (beneficiaryId) filter.beneficiaryId = beneficiaryId;
     if (assignedTo) filter.assignedTo = assignedTo;
-    if (req.user?.organizationId) filter.organizationId = req.user.organizationId;
+    const branchScope = effectiveBranchScope(req); // W1407: branch isolation (was never-set organizationId)
+    if (branchScope) filter.branchId = branchScope;
 
     const skip = (parseInt(page) - 1) * parseInt(limit);
     const [data, total] = await Promise.all([
@@ -243,7 +247,7 @@ router.get(
   '/conversations/pending-review',
   asyncHandler(async (req, res) => {
     const Conversation = getConversationModel();
-    const data = await Conversation.findPendingReview(req.user?.organizationId);
+    const data = await Conversation.findPendingReview(effectiveBranchScope(req));
     res.json({ success: true, data, total: data.length });
   })
 );
@@ -254,7 +258,7 @@ router.get(
   asyncHandler(async (req, res) => {
     const Conversation = getConversationModel();
     const conv = await Conversation.findOne(
-      Conversation.byIdScopedFilter(req.params.id, req.user?.organizationId)
+      Conversation.byIdScopedFilter(req.params.id, effectiveBranchScope(req))
     )
       .populate('beneficiaryId', 'personalInfo fileNumber')
       .populate('familyMemberId', 'firstName lastName relationship contactInfo')
@@ -290,7 +294,7 @@ router.post(
     const Conversation = getConversationModel();
     const staffId = req.user?._id || req.user?.id;
     const data = await Conversation.findOneAndUpdate(
-      Conversation.byIdScopedFilter(req.params.id, req.user?.organizationId),
+      Conversation.byIdScopedFilter(req.params.id, effectiveBranchScope(req)),
       {
         status: 'resolved',
         requiresHumanReview: false,
@@ -312,7 +316,7 @@ router.post(
     const Conversation = getConversationModel();
     validate(['staffId'], req.body);
     const data = await Conversation.findOneAndUpdate(
-      Conversation.byIdScopedFilter(req.params.id, req.user?.organizationId),
+      Conversation.byIdScopedFilter(req.params.id, effectiveBranchScope(req)),
       { assignedTo: req.body.staffId, status: 'pending_review' },
       { returnDocument: 'after' }
     ).lean();
@@ -327,7 +331,7 @@ router.post(
   asyncHandler(async (req, res) => {
     const Conversation = getConversationModel();
     await Conversation.updateOne(
-      Conversation.byIdScopedFilter(req.params.id, req.user?.organizationId),
+      Conversation.byIdScopedFilter(req.params.id, effectiveBranchScope(req)),
       { unreadCount: 0 }
     );
     res.json({ success: true });
@@ -689,7 +693,7 @@ router.get(
   asyncHandler(async (req, res) => {
     const Conversation = getConversationModel();
     const conv = await Conversation.findOne(
-      Conversation.byIdScopedFilter(req.params.conversationId, req.user?.organizationId)
+      Conversation.byIdScopedFilter(req.params.conversationId, effectiveBranchScope(req))
     )
       .select('messages')
       .lean();
@@ -852,11 +856,11 @@ router.get(
   asyncHandler(async (req, res) => {
     const Conversation = getConversationModel();
     const { startDate, endDate } = req.query;
-    const orgId = req.user?.organizationId;
+    const branchScope = effectiveBranchScope(req); // W1407: branch isolation
 
-    const filters = Conversation.queueCountFilters(orgId);
+    const filters = Conversation.queueCountFilters(branchScope);
     const [analytics, pendingReview, critical] = await Promise.all([
-      Conversation.getAnalytics(orgId, startDate, endDate),
+      Conversation.getAnalytics(branchScope, startDate, endDate),
       Conversation.countDocuments(filters.pendingReview),
       Conversation.countDocuments(filters.critical),
     ]);

--- a/backend/scripts/backfill-whatsapp-conversation-branchid.js
+++ b/backend/scripts/backfill-whatsapp-conversation-branchid.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * backfill-whatsapp-conversation-branchid.js — W1407 (tenant isolation).
+ * ════════════════════════════════════════════════════════════════════
+ * Backfills `branchId` on existing WhatsAppConversation docs that predate the
+ * W1407 tenancy fix (conversations were scoped by a never-set `organizationId`,
+ * leaking across branches; scoping is now by `branchId`).
+ *
+ * Source of truth: beneficiaryId → Beneficiary.branchId (the only branch anchor
+ * a conversation has). Conversations with no matched beneficiary are left unset
+ * (reported "skipped") — they remain visible only to cross-branch roles
+ * (fail-closed), never leaked to a branch-restricted user.
+ *
+ * SAFE BY DEFAULT: dry-run unless `--commit` is passed. Only ever SETS branchId
+ * on docs where it is currently missing — never overwrites.
+ *
+ * Usage:
+ *   MONGODB_URI=mongodb://... node scripts/backfill-whatsapp-conversation-branchid.js            # dry-run
+ *   MONGODB_URI=mongodb://... node scripts/backfill-whatsapp-conversation-branchid.js --commit   # apply
+ *   ... --json
+ *
+ * Exit: 0 ok · 2 usage/connection error.
+ */
+
+const COMMIT = process.argv.includes('--commit');
+const JSON_OUT = process.argv.includes('--json');
+
+function log(...a) {
+  if (!JSON_OUT) console.log(...a);
+}
+
+(async () => {
+  if (!process.env.MONGODB_URI) {
+    console.error('Error: MONGODB_URI environment variable required.');
+    process.exit(2);
+  }
+
+  const mongoose = require('mongoose');
+  await mongoose.connect(process.env.MONGODB_URI);
+
+  const Conversation = require('../models/WhatsAppConversation');
+  let Beneficiary = null;
+  try {
+    Beneficiary = require('../models/Beneficiary');
+  } catch {
+    Beneficiary = null;
+  }
+
+  const missing = await Conversation.find({
+    $or: [{ branchId: { $exists: false } }, { branchId: null }],
+  })
+    .select('_id beneficiaryId')
+    .lean();
+
+  let fromBeneficiary = 0;
+  let skipped = 0;
+
+  for (const c of missing) {
+    let branchId = null;
+    if (Beneficiary && c.beneficiaryId) {
+      const b = await Beneficiary.findById(c.beneficiaryId).select('branchId').lean();
+      if (b && b.branchId) {
+        branchId = b.branchId;
+        fromBeneficiary++;
+      }
+    }
+    if (!branchId) {
+      skipped++;
+      continue;
+    }
+    if (COMMIT) {
+      await Conversation.updateOne({ _id: c._id }, { $set: { branchId } });
+    }
+  }
+
+  const summary = {
+    mode: COMMIT ? 'commit' : 'dry-run',
+    missingBranchId: missing.length,
+    resolvedFromBeneficiary: fromBeneficiary,
+    skippedNoAnchor: skipped,
+    wouldUpdate: fromBeneficiary,
+  };
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    log('');
+    log(`W1407 WhatsAppConversation.branchId backfill — ${summary.mode}`);
+    log('──────────────────────────────────────────────');
+    log(`Missing branchId:          ${summary.missingBranchId}`);
+    log(`  → from beneficiary:      ${summary.resolvedFromBeneficiary}`);
+    log(`  → skipped (no anchor):   ${summary.skippedNoAnchor}`);
+    log(`${COMMIT ? 'Updated' : 'Would update'}: ${summary.wouldUpdate}`);
+    if (!COMMIT && summary.wouldUpdate > 0) log('Re-run with --commit to apply.');
+    log('');
+  }
+
+  await mongoose.disconnect();
+  process.exit(0);
+})().catch(err => {
+  console.error('backfill-whatsapp-conversation-branchid failed:', err.message);
+  process.exit(2);
+});

--- a/backend/services/whatsapp/whatsappWebhook.service.js
+++ b/backend/services/whatsapp/whatsappWebhook.service.js
@@ -41,6 +41,14 @@ function getFamilyMemberModel() {
   }
 }
 
+function getBeneficiaryModel() {
+  try {
+    return mongoose.model('Beneficiary');
+  } catch {
+    return null;
+  }
+}
+
 function getConsentModel() {
   try {
     return require('../../models/WhatsAppConsent');
@@ -258,6 +266,23 @@ async function handleIncomingMessage(msg, contact, _phoneNumberId) {
     beneficiaryId = familyMember?.beneficiaryId || null;
   }
 
+  // W1407: derive the conversation's branchId from the matched beneficiary so it
+  // is tenant-scoped. Unmatched inbound (no beneficiary) leaves branchId null —
+  // such conversations are visible only to cross-branch roles (fail-closed for
+  // branch-restricted users), never leaked across branches.
+  let branchId = null;
+  if (beneficiaryId) {
+    const Beneficiary = getBeneficiaryModel();
+    if (Beneficiary) {
+      try {
+        const ben = await Beneficiary.findById(beneficiaryId).select('branchId').lean();
+        branchId = ben?.branchId || null;
+      } catch (err) {
+        logger.warn(`[WhatsApp] branch derivation failed: ${err.message}`);
+      }
+    }
+  }
+
   // Record consent — first-time inbound = implicit opt-in, every inbound
   // extends the 24-hour customer-service window. Never throws.
   const Consent = getConsentModel();
@@ -292,6 +317,7 @@ async function handleIncomingMessage(msg, contact, _phoneNumberId) {
           phone: fromPhone,
           senderName,
           beneficiaryId,
+          branchId, // W1407: tenant scope derived from the matched beneficiary
           familyMemberId: familyMember?._id || null,
           createdAt: new Date(),
         },

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -873,6 +873,7 @@ __tests__/whatsapp-autoreply-template-gate-wave738.test.js
 __tests__/whatsapp-broadcast-preview-wave747.test.js
 __tests__/whatsapp-byid-org-scope-wave744.test.js
 __tests__/whatsapp-canonical-consolidation-wave725.test.js
+__tests__/whatsapp-conversation-branch-isolation-wave1411.test.js
 __tests__/whatsapp-contact-group-add-wave756.test.js
 __tests__/whatsapp-contact-group-csv-import-wave751.test.js
 __tests__/whatsapp-contact-group-csv-wave750.test.js


### PR DESCRIPTION
Closes the verified W1407 finding (#526).

## The leak (confirmed in live code)

`whatsapp.routes.js` scoped `/conversations` (list, pending-review, byId read/resolve/assign/mark-read, AI insights, analytics, queue tiles) by `req.user.organizationId` — a field this **branch-scoped** platform never sets (no middleware populates it; `User` has `branchId`, not `organizationId`). So:

```js
if (req.user?.organizationId) filter.organizationId = ...  // never true → filter unscoped
Conversation.byIdScopedFilter(id, req.user?.organizationId) // scope = undefined → id-only
```

→ **any authenticated user could read every branch's WhatsApp conversations + message PII (fails OPEN).** Verified: 24 org-scoped sites, 0 middleware setting `organizationId`. Now live on prod after the W1410 deploy unblock, so closing promptly.

## Fix — W269 doctrine (scope by `branchId`, fail-closed)

| Layer | Change |
|---|---|
| Model | 4 scoping helpers (`byIdScopedFilter`, `queueCountFilters`, `findPendingReview`, `getAnalytics`) filter by `branchId`; added `branchId` index |
| Routes | pass `effectiveBranchScope(req)` everywhere — restricted user → their `branchId`; cross-branch role → `null` (sees all, intended) |
| Webhook | derive conversation `branchId` from the matched beneficiary on insert; unmatched inbound → `branchId=null` (visible only to cross-branch roles = **fail-closed**) |
| Backfill | `scripts/backfill-whatsapp-conversation-branchid.js` (+npm alias) sets `branchId` from `beneficiaryId` on existing rows (dry-run by default) |
| Tests | `wave743`/`wave744` retargeted to `branchId`; new `wave1411` isolation + source-drift guard so the never-set-org scoping can't silently return |

**Unmatched-inbound handling:** chosen fail-closed default (null branchId → cross-branch-admin-only) — no extra config, closes the leak immediately. Routing unmatched inbound to a configurable default branch is an optional future enhancement, not required for the security fix.

## Out of scope (fast-follow)

`WhatsAppContactGroup` shares the same `organizationId`-fail-open pattern but has **no `branchId` field** — fixing it needs a schema field + backfill (a distinct unit). Conversations carry the message PII and are the W1407 core, so they're fixed here; Groups tracked as a follow-up.

## Verification

- 42 WhatsApp suites / 348 tests + 7 model/webhook suites / 56 tests green.
- Pre-push gates pass (sprint-paths, routes-load, hook-style, phantom-writes — `branchId` is a declared schema field, no phantom write).
- `effectiveBranchScope` is the canonical W269 helper already used across the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)