### PR TITLE
feat(hr): W1385 — compa-ratio for pay-equity (job→band mapping, zero-migration)

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1881,6 +1881,11 @@ on:
       - 'backend/__tests__/therapy-sessions-documentation-branch-isolation-wave1409.test.js'
       - 'backend/__tests__/ai-recommendations-branch-isolation-wave1409.test.js'
       - 'backend/__tests__/alerts-workflow-branch-isolation-wave1409.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/compa-ratio-lib-wave1385.test.js'
+      - 'backend/__tests__/job-band-mapping-behavioral-wave1385.test.js'
+      - 'backend/__tests__/compa-ratio-service-behavioral-wave1385.test.js'
+      - 'backend/__tests__/pay-equity-compa-ratio-routes-wave1385.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3740,6 +3745,11 @@ on:
       - 'backend/__tests__/therapy-sessions-documentation-branch-isolation-wave1409.test.js'
       - 'backend/__tests__/ai-recommendations-branch-isolation-wave1409.test.js'
       - 'backend/__tests__/alerts-workflow-branch-isolation-wave1409.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/compa-ratio-lib-wave1385.test.js'
+      - 'backend/__tests__/job-band-mapping-behavioral-wave1385.test.js'
+      - 'backend/__tests__/compa-ratio-service-behavioral-wave1385.test.js'
+      - 'backend/__tests__/pay-equity-compa-ratio-routes-wave1385.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/compa-ratio-lib-wave1385.test.js
+++ b/backend/__tests__/compa-ratio-lib-wave1385.test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+/**
+ * W1385 — compa-ratio.lib unit tests (pure, no DB).
+ * Locks the math + the never-misleading contract (null when unmapped/no-mid).
+ */
+
+const L = require('../intelligence/compa-ratio.lib');
+
+describe('W1385 compa-ratio.lib — compaRatio()', () => {
+  test('salary / midpoint, rounded to 3dp', () => {
+    expect(L.compaRatio(8000, 10000)).toBe(0.8);
+    expect(L.compaRatio(10000, 10000)).toBe(1);
+    expect(L.compaRatio(12500, 10000)).toBe(1.25);
+    expect(L.compaRatio(9999, 10000)).toBe(1); // 0.9999 rounds to 1.000 at 3dp
+    expect(L.compaRatio(8500, 10000)).toBe(0.85);
+  });
+
+  test('null (NOT 0, NOT guessed) when either input is unusable', () => {
+    expect(L.compaRatio(8000, 0)).toBeNull(); // no midpoint
+    expect(L.compaRatio(8000, undefined)).toBeNull();
+    expect(L.compaRatio(8000, null)).toBeNull();
+    expect(L.compaRatio(0, 10000)).toBeNull(); // no salary
+    expect(L.compaRatio(null, 10000)).toBeNull();
+    expect(L.compaRatio(-5, 10000)).toBeNull();
+    expect(L.compaRatio('abc', 10000)).toBeNull();
+  });
+});
+
+describe('W1385 compa-ratio.lib — classifyCompaRatio()', () => {
+  test('below (<0.8) / within / above (>1.2), boundaries inclusive of within', () => {
+    expect(L.classifyCompaRatio(0.79).key).toBe('below');
+    expect(L.classifyCompaRatio(0.8).key).toBe('within'); // exactly at threshold = within
+    expect(L.classifyCompaRatio(1.0).key).toBe('within');
+    expect(L.classifyCompaRatio(1.2).key).toBe('within'); // exactly at threshold = within
+    expect(L.classifyCompaRatio(1.21).key).toBe('above');
+  });
+  test('custom thresholds honoured', () => {
+    expect(L.classifyCompaRatio(0.85, { belowThreshold: 0.9 }).key).toBe('below');
+    expect(L.classifyCompaRatio(1.05, { aboveThreshold: 1.0 }).key).toBe('above');
+  });
+  test('non-finite → null', () => {
+    expect(L.classifyCompaRatio(null)).toBeNull();
+    expect(L.classifyCompaRatio(undefined)).toBeNull();
+  });
+  test('every band carries an Arabic label', () => {
+    for (const k of ['below', 'within', 'above']) {
+      expect(typeof L.BANDS[k].ar).toBe('string');
+      expect(L.BANDS[k].ar.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('W1385 compa-ratio.lib — median()', () => {
+  test('odd / even / empty', () => {
+    expect(L.median([1, 3, 2])).toBe(2);
+    expect(L.median([1, 2, 3, 4])).toBe(2.5);
+    expect(L.median([])).toBeNull();
+    expect(L.median([5])).toBe(5);
+  });
+  test('ignores non-finite values', () => {
+    expect(L.median([1, null, 3, undefined, 2])).toBe(2);
+  });
+});
+
+describe('W1385 compa-ratio.lib — compaRatioStats()', () => {
+  test('counts below/within/above + median, excluding null compa-ratios', () => {
+    const s = L.compaRatioStats([
+      { compaRatio: 0.7 }, // below
+      { compaRatio: 0.75 }, // below
+      { compaRatio: 1.0 }, // within
+      { compaRatio: 1.3 }, // above
+      { compaRatio: null }, // EXCLUDED (unmapped)
+      {}, // EXCLUDED
+    ]);
+    expect(s.rated).toBe(4);
+    expect(s.belowCount).toBe(2);
+    expect(s.withinCount).toBe(1);
+    expect(s.aboveCount).toBe(1);
+    expect(s.belowPct).toBe(50);
+    expect(s.medianCompaRatio).toBe(0.875); // median of [0.7,0.75,1.0,1.3]
+  });
+  test('empty / all-null → zeroed, no divide-by-zero', () => {
+    const s = L.compaRatioStats([{ compaRatio: null }, {}]);
+    expect(s.rated).toBe(0);
+    expect(s.belowPct).toBe(0);
+    expect(s.medianCompaRatio).toBeNull();
+  });
+});

--- a/backend/__tests__/compa-ratio-service-behavioral-wave1385.test.js
+++ b/backend/__tests__/compa-ratio-service-behavioral-wave1385.test.js
@@ -1,0 +1,142 @@
+'use strict';
+
+/**
+ * W1385 — compa-ratio service behavioral (MongoMemoryServer).
+ *
+ * The integration test that catches the "wired-but-broken" class (W1227 lesson):
+ * seeds REAL Employee + JobBandMapping + CompensationBand and asserts the whole
+ * chain — role→band→midpoint→compa-ratio→classify→aggregate — plus the two
+ * invariants that matter: branch isolation (W269) and "unmapped is EXCLUDED, never
+ * salary-guessed".
+ *
+ * Employees are inserted at the collection level (bypassing the heavy Employee
+ * required-field validation) since this test exercises the pay-equity service, not
+ * Employee's schema.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let svc;
+let Employee;
+let JobBandMapping;
+let CompensationBand;
+let mongo;
+
+const B1 = new mongoose.Types.ObjectId();
+const B2 = new mongoose.Types.ObjectId();
+
+let empSeq = 0;
+function emp(branch_id, job_title_en, basic_salary, extra = {}) {
+  empSeq += 1;
+  // Employee carries unique indexes (employee_number, national_id) — give each a
+  // distinct value so collection-level inserts don't collide on null.
+  return {
+    status: 'active',
+    deleted_at: null,
+    branch_id,
+    job_title_en,
+    basic_salary,
+    full_name: job_title_en,
+    employee_number: `EMP-${empSeq}`,
+    national_id: `100000000${empSeq}`,
+    email: `emp${empSeq}@test.local`,
+    ...extra,
+  };
+}
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  Employee = require('../models/HR/Employee');
+  JobBandMapping = require('../models/HR/JobBandMapping');
+  CompensationBand = require('../models/HR/CompensationBand');
+  svc = require('../services/hr/payEquityService');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+});
+
+afterEach(async () => {
+  await Promise.all([
+    Employee.collection.deleteMany({}),
+    JobBandMapping.deleteMany({}),
+    CompensationBand.deleteMany({}),
+  ]);
+});
+
+async function seedBandAndMapping() {
+  await CompensationBand.create({
+    bandCode: 'L3', bandName: 'Level 3', level: 3, minSalary: 8000, midSalary: 10000, maxSalary: 12000, isActive: true,
+  });
+  await JobBandMapping.create({ jobTitle: 'Therapist', bandCode: 'L3', active: true });
+}
+
+describe('W1385 compaRatioAnalysis', () => {
+  test('computes + classifies + aggregates the full role→band→compa chain', async () => {
+    await seedBandAndMapping();
+    await Employee.collection.insertMany([
+      emp(B1, 'Therapist', 7000), // 0.7  → below
+      emp(B1, 'Therapist', 10000), // 1.0 → within
+      emp(B1, 'Therapist', 13000), // 1.3 → above
+      emp(B1, 'Receptionist', 9000), // no mapping → UNMAPPED (excluded)
+    ]);
+
+    const a = await svc.compaRatioAnalysis({ branchId: B1 });
+    expect(a.workforce).toBe(4);
+    expect(a.mapped).toBe(3);
+    expect(a.unmapped).toBe(1); // Receptionist excluded, NOT salary-guessed
+    expect(a.coveragePct).toBe(75);
+    expect(a.stats.belowCount).toBe(1);
+    expect(a.stats.withinCount).toBe(1);
+    expect(a.stats.aboveCount).toBe(1);
+    expect(a.stats.medianCompaRatio).toBe(1);
+  });
+
+  test('an inactive band yields no compa-ratio (graceful, never misleading)', async () => {
+    await CompensationBand.create({
+      bandCode: 'L3', bandName: 'L3', level: 3, minSalary: 8000, midSalary: 10000, maxSalary: 12000, isActive: false,
+    });
+    await JobBandMapping.create({ jobTitle: 'Therapist', bandCode: 'L3', active: true });
+    await Employee.collection.insertMany([emp(B1, 'Therapist', 7000)]);
+
+    const a = await svc.compaRatioAnalysis({ branchId: B1 });
+    expect(a.workforce).toBe(1);
+    expect(a.mapped).toBe(0);
+    expect(a.unmapped).toBe(1);
+  });
+
+  test('branch isolation (W269) — a foreign-branch employee is excluded', async () => {
+    await seedBandAndMapping();
+    await Employee.collection.insertMany([
+      emp(B1, 'Therapist', 10000),
+      emp(B2, 'Therapist', 5000), // branch B2 — must NOT appear in a B1 analysis
+    ]);
+
+    const a = await svc.compaRatioAnalysis({ branchId: B1 });
+    expect(a.workforce).toBe(1);
+    expect(a.mapped).toBe(1);
+    expect(a.stats.belowCount).toBe(0); // the B2 underpaid one is not counted
+  });
+});
+
+describe('W1385 belowBandEmployees', () => {
+  test('returns only below-band employees, most-underpaid first', async () => {
+    await seedBandAndMapping();
+    await Employee.collection.insertMany([
+      emp(B1, 'Therapist', 7800, { full_name: 'A' }), // 0.78 → below
+      emp(B1, 'Therapist', 7000, { full_name: 'B' }), // 0.70 → below (more)
+      emp(B1, 'Therapist', 10000, { full_name: 'C' }), // within → excluded
+    ]);
+
+    const list = await svc.belowBandEmployees({ branchId: B1 });
+    expect(list).toHaveLength(2);
+    expect(list.map((e) => e.name)).toEqual(['B', 'A']); // 0.70 before 0.78
+    expect(list.every((e) => e.compaRatio < 0.8)).toBe(true);
+  });
+});

--- a/backend/__tests__/job-band-mapping-behavioral-wave1385.test.js
+++ b/backend/__tests__/job-band-mapping-behavioral-wave1385.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * W1385 — JobBandMapping behavioral (MongoMemoryServer).
+ * Verifies the org-global job→band config: defaults, one-band-per-title unique
+ * index, and that the service upsert is idempotent per title.
+ */
+
+jest.unmock('mongoose');
+jest.setTimeout(90000);
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let JobBandMapping;
+let svc;
+let mongo;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  JobBandMapping = require('../models/HR/JobBandMapping');
+  await JobBandMapping.init(); // build indexes before the unique-constraint assertion
+  svc = require('../services/hr/payEquityService');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongo) await mongo.stop();
+});
+
+afterEach(async () => {
+  await JobBandMapping.deleteMany({});
+});
+
+describe('W1385 JobBandMapping model', () => {
+  test('requires jobTitle + bandCode', async () => {
+    await expect(JobBandMapping.create({ jobTitle: 'Senior Therapist' })).rejects.toThrow(/bandCode/);
+    await expect(JobBandMapping.create({ bandCode: 'L4' })).rejects.toThrow(/jobTitle/);
+  });
+
+  test('defaults active=true; is org-global (no branchId in schema)', async () => {
+    const m = await JobBandMapping.create({ jobTitle: 'Senior Therapist', bandCode: 'L4' });
+    expect(m.active).toBe(true);
+    expect(m.schema.path('branchId')).toBeUndefined(); // reference data, NOT branch-scoped
+  });
+
+  test('one band per job title (unique index)', async () => {
+    await JobBandMapping.create({ jobTitle: 'Therapist', bandCode: 'L3' });
+    await expect(JobBandMapping.create({ jobTitle: 'Therapist', bandCode: 'L4' })).rejects.toThrow(/E11000|duplicate/);
+  });
+});
+
+describe('W1385 payEquityService.upsertJobBandMapping', () => {
+  test('creates then UPDATES the same title (idempotent per title, not duplicated)', async () => {
+    const a = await svc.upsertJobBandMapping({ jobTitle: 'Manager', bandCode: 'L5' });
+    expect(a.bandCode).toBe('L5');
+    const b = await svc.upsertJobBandMapping({ jobTitle: 'Manager', bandCode: 'L6', note: 'regrade' });
+    expect(b.bandCode).toBe('L6');
+    expect(b.note).toBe('regrade');
+    expect(await JobBandMapping.countDocuments({ jobTitle: 'Manager' })).toBe(1);
+  });
+
+  test('rejects missing jobTitle/bandCode with a VALIDATION code', async () => {
+    await expect(svc.upsertJobBandMapping({ jobTitle: '', bandCode: 'L1' })).rejects.toMatchObject({ code: 'VALIDATION' });
+    await expect(svc.upsertJobBandMapping({ jobTitle: 'X', bandCode: '  ' })).rejects.toMatchObject({ code: 'VALIDATION' });
+  });
+
+  test('listJobBandMappings returns all, sorted by jobTitle', async () => {
+    await svc.upsertJobBandMapping({ jobTitle: 'Zed', bandCode: 'L1' });
+    await svc.upsertJobBandMapping({ jobTitle: 'Abe', bandCode: 'L2' });
+    const list = await svc.listJobBandMappings();
+    expect(list.map((m) => m.jobTitle)).toEqual(['Abe', 'Zed']);
+  });
+});

--- a/backend/__tests__/pay-equity-compa-ratio-routes-wave1385.test.js
+++ b/backend/__tests__/pay-equity-compa-ratio-routes-wave1385.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * W1385 — pay-equity compa-ratio route static drift guard.
+ * Reads the route source and asserts the 4 new endpoints exist with the right
+ * role gates + W269 branch scope + no `req.branchId` leak.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(path.join(__dirname, '..', 'routes', 'hr', 'pay-equity.routes.js'), 'utf8');
+
+describe('W1385 pay-equity compa-ratio routes — static drift guard', () => {
+  test('declares the 4 new endpoints', () => {
+    expect(SRC).toMatch(/router\.get\(\s*['"]\/compa-ratio['"]/);
+    expect(SRC).toMatch(/router\.get\(\s*['"]\/below-band['"]/);
+    expect(SRC).toMatch(/router\.get\(\s*['"]\/band-mappings['"]/);
+    expect(SRC).toMatch(/router\.post\(\s*['"]\/band-mappings['"]/);
+  });
+
+  test('aggregate read uses READ_ROLES; identity-bearing below-band uses the stricter FLAGGED_ROLES', () => {
+    expect(SRC).toMatch(/\/compa-ratio['"]\s*,\s*requireRole\(READ_ROLES\)/);
+    expect(SRC).toMatch(/\/below-band['"]\s*,\s*requireRole\(FLAGGED_ROLES\)/);
+  });
+
+  test('config write (POST band-mappings) is gated to CONFIG_ROLES', () => {
+    expect(SRC).toMatch(/CONFIG_ROLES\s*=\s*\[/);
+    expect(SRC).toMatch(/\.post\(\s*['"]\/band-mappings['"]\s*,\s*requireRole\(CONFIG_ROLES\)/);
+  });
+
+  test('branch scope via effectiveBranchScope (W269); never reads req.branchId', () => {
+    // both branch-scoped reads resolve the caller's own branch
+    const compaBlock = SRC.slice(SRC.indexOf("'/compa-ratio'"), SRC.indexOf("'/band-mappings'"));
+    expect(compaBlock).toMatch(/effectiveBranchScope\(req\)/);
+    expect(SRC).not.toMatch(/req\.branchId/); // W269h class — the fallback that silently leaks all branches
+  });
+
+  test('self-authenticated (router.use(authenticateToken) + requireBranchAccess)', () => {
+    expect(SRC).toMatch(/router\.use\(authenticateToken\)/);
+    expect(SRC).toMatch(/router\.use\(requireBranchAccess\)/);
+  });
+
+  test('errors mapped: MODEL_UNAVAILABLE→503, VALIDATION→400', () => {
+    expect(SRC).toMatch(/MODEL_UNAVAILABLE[\s\S]*?503/);
+    expect(SRC).toMatch(/VALIDATION[\s\S]*?400/);
+  });
+});

--- a/backend/intelligence/compa-ratio.lib.js
+++ b/backend/intelligence/compa-ratio.lib.js
@@ -1,0 +1,103 @@
+'use strict';
+
+/**
+ * compa-ratio.lib.js — pure compa-ratio math for pay-equity (W1385).
+ *
+ * compa-ratio = actual salary ÷ the MIDPOINT of the pay band the employee's ROLE
+ * maps to. <1 = paid below the band midpoint, 1 = at midpoint, >1 = above. It is
+ * the standard "is this person paid fairly for their grade" lens that the W1193
+ * pay-equity analysis lacked (it had only demographic gaps + cohort outliers).
+ *
+ * Deliberately role-based, never salary-inferred: the band must come from the
+ * employee's job→band mapping, NOT from "which band's range contains this salary"
+ * (that would put everyone inside their band by construction and could never
+ * reveal under-payment). When an employee has no mapping or the band has no
+ * midpoint, compa-ratio is null and the employee is simply excluded — never
+ * coerced, never guessed.
+ *
+ * No DB, no Date, no I/O — unit-testable in isolation.
+ */
+
+const DEFAULT_BELOW = 0.8; // < 80% of midpoint → underpaid for the band
+const DEFAULT_ABOVE = 1.2; // > 120% of midpoint → above the band
+
+const BANDS = Object.freeze({
+  below: { key: 'below', ar: 'أقل من النطاق' },
+  within: { key: 'within', ar: 'ضمن النطاق' },
+  above: { key: 'above', ar: 'أعلى من النطاق' },
+});
+
+function round(n, dp = 2) {
+  if (!Number.isFinite(n)) return null;
+  const f = 10 ** dp;
+  return Math.round(n * f) / f;
+}
+
+/** compa-ratio = salary / midSalary, or null when either input is unusable. */
+function compaRatio(salary, midSalary) {
+  const s = Number(salary);
+  const m = Number(midSalary);
+  if (!Number.isFinite(s) || s <= 0) return null;
+  if (!Number.isFinite(m) || m <= 0) return null;
+  return round(s / m, 3);
+}
+
+/** Classify a compa-ratio into below / within / above the band. */
+function classifyCompaRatio(ratio, { belowThreshold = DEFAULT_BELOW, aboveThreshold = DEFAULT_ABOVE } = {}) {
+  if (!Number.isFinite(ratio)) return null;
+  if (ratio < belowThreshold) return BANDS.below;
+  if (ratio > aboveThreshold) return BANDS.above;
+  return BANDS.within;
+}
+
+/** Median of a numeric array (sorted copy), or null when empty. */
+function median(values) {
+  const xs = (values || []).filter((v) => Number.isFinite(v)).sort((a, b) => a - b);
+  if (!xs.length) return null;
+  const mid = Math.floor(xs.length / 2);
+  return xs.length % 2 ? xs[mid] : round((xs[mid - 1] + xs[mid]) / 2, 3);
+}
+
+/**
+ * Aggregate compa-ratio stats over entries that HAVE a numeric compaRatio.
+ * @param {Array<{compaRatio:number}>} entries
+ * Returns counts/percentages + median; `belowPct` is the equity-risk signal
+ * (share of mapped employees paid below their band midpoint threshold).
+ */
+function compaRatioStats(entries, opts = {}) {
+  const belowThreshold = opts.belowThreshold ?? DEFAULT_BELOW;
+  const aboveThreshold = opts.aboveThreshold ?? DEFAULT_ABOVE;
+  const rated = (entries || []).filter((e) => e && Number.isFinite(e.compaRatio));
+  let below = 0;
+  let within = 0;
+  let above = 0;
+  for (const e of rated) {
+    const c = classifyCompaRatio(e.compaRatio, { belowThreshold, aboveThreshold });
+    if (c === BANDS.below) below += 1;
+    else if (c === BANDS.above) above += 1;
+    else within += 1;
+  }
+  const n = rated.length;
+  return {
+    rated: n,
+    belowCount: below,
+    withinCount: within,
+    aboveCount: above,
+    belowPct: n ? round((below / n) * 100, 1) : 0,
+    withinPct: n ? round((within / n) * 100, 1) : 0,
+    abovePct: n ? round((above / n) * 100, 1) : 0,
+    medianCompaRatio: median(rated.map((e) => e.compaRatio)),
+    thresholds: { below: belowThreshold, above: aboveThreshold },
+  };
+}
+
+module.exports = {
+  DEFAULT_BELOW,
+  DEFAULT_ABOVE,
+  BANDS,
+  round,
+  compaRatio,
+  classifyCompaRatio,
+  median,
+  compaRatioStats,
+};

--- a/backend/models/HR/JobBandMapping.js
+++ b/backend/models/HR/JobBandMapping.js
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * JobBandMapping.js — maps a job title to a compensation band (W1385).
+ *
+ * Org-global REFERENCE data (a "Senior Therapist" sits in the same pay band in
+ * every branch), like CompensationBand + RoleCompetencyRequirement — so NO
+ * branchId / no branch isolation. One row per jobTitle. Drives the compa-ratio
+ * lens of pay-equity: an employee's role → this mapping → CompensationBand →
+ * band midpoint → compa-ratio = salary / midpoint.
+ *
+ * `bandCode` is a soft reference to CompensationBand.bandCode (a string key, not
+ * an ObjectId) — bands are themselves keyed by a human code like "L4". An unknown
+ * or inactive bandCode simply yields no compa-ratio (graceful, never misleading).
+ */
+
+const mongoose = require('mongoose');
+
+const JobBandMappingSchema = new mongoose.Schema(
+  {
+    // matches Employee.job_title_en / job_title_ar (HR keys mappings on the title
+    // exactly as RoleCompetencyRequirement does).
+    // unique index declared below (one band per title) — that covers indexing too,
+    // so NO `index: true` here (it would collide with the unique jobTitle_1 index).
+    jobTitle: { type: String, required: true, trim: true, maxlength: 120 },
+    bandCode: { type: String, required: true, trim: true, maxlength: 20 }, // → CompensationBand.bandCode
+    active: { type: Boolean, default: true },
+    note: { type: String, maxlength: 500 },
+    createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  },
+  { timestamps: true, collection: 'hr_job_band_mappings' }
+);
+
+// one band per job title
+JobBandMappingSchema.index({ jobTitle: 1 }, { unique: true });
+
+module.exports =
+  mongoose.models.JobBandMapping || mongoose.model('JobBandMapping', JobBandMappingSchema);

--- a/backend/routes/hr/pay-equity.routes.js
+++ b/backend/routes/hr/pay-equity.routes.js
@@ -51,6 +51,8 @@ const FLAGGED_ROLES = [
   'compliance_officer',
   'cfo',
 ];
+// Editing the job→band config (org-global reference data) — HR/admin only.
+const CONFIG_ROLES = ['admin', 'superadmin', 'super_admin', 'hr_director', 'hr_manager'];
 
 router.use(authenticateToken);
 router.use(requireBranchAccess);
@@ -65,6 +67,9 @@ function parseOpts(req) {
 function mapErr(res, err, ctx) {
   if (err && err.code === 'MODEL_UNAVAILABLE') {
     return res.status(503).json({ success: false, error: err.message });
+  }
+  if (err && err.code === 'VALIDATION') {
+    return res.status(400).json({ success: false, error: err.message });
   }
   return safeError(res, err, ctx);
 }
@@ -148,6 +153,61 @@ router.get('/trends', requireRole(READ_ROLES), async (req, res) => {
     res.json({ success: true, data: { count: series.length, series } });
   } catch (err) {
     mapErr(res, err, 'pay-equity:trends');
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// compa-ratio (W1385) — salary vs the midpoint of the band the ROLE maps to.
+// ──────────────────────────────────────────────────────────────────────────
+
+/** GET /compa-ratio — aggregate compa-ratio distribution (no identities). */
+router.get('/compa-ratio', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const department = req.query.department ? String(req.query.department) : null;
+    const branchId = effectiveBranchScope(req); // W269 — own branch, or null for HQ
+    const data = await svc.compaRatioAnalysis({ branchId, department });
+    res.json({ success: true, data });
+  } catch (err) {
+    mapErr(res, err, 'pay-equity:compa-ratio');
+  }
+});
+
+/** GET /below-band — employees paid below their band (identities) — stricter role. */
+router.get('/below-band', requireRole(FLAGGED_ROLES), async (req, res) => {
+  try {
+    const department = req.query.department ? String(req.query.department) : null;
+    const branchId = effectiveBranchScope(req);
+    const items = await svc.belowBandEmployees({ branchId, department, belowThreshold: req.query.belowThreshold });
+    res.json({ success: true, data: { count: items.length, items } });
+  } catch (err) {
+    mapErr(res, err, 'pay-equity:below-band');
+  }
+});
+
+/** GET /band-mappings — list the job→band config (org-global reference). */
+router.get('/band-mappings', requireRole(READ_ROLES), async (req, res) => {
+  try {
+    const items = await svc.listJobBandMappings();
+    res.json({ success: true, data: { count: items.length, items } });
+  } catch (err) {
+    mapErr(res, err, 'pay-equity:band-mappings:list');
+  }
+});
+
+/** POST /band-mappings — create/update a job→band mapping (HR/admin config). */
+router.post('/band-mappings', requireRole(CONFIG_ROLES), async (req, res) => {
+  try {
+    const actor = req.user || {};
+    const doc = await svc.upsertJobBandMapping({
+      jobTitle: req.body && req.body.jobTitle,
+      bandCode: req.body && req.body.bandCode,
+      active: req.body && req.body.active !== undefined ? !!req.body.active : true,
+      note: req.body && req.body.note ? String(req.body.note) : null,
+      createdBy: actor.id || actor._id || actor.userId || null,
+    });
+    res.status(201).json({ success: true, data: doc });
+  } catch (err) {
+    mapErr(res, err, 'pay-equity:band-mappings:upsert');
   }
 });
 

--- a/backend/services/hr/payEquityService.js
+++ b/backend/services/hr/payEquityService.js
@@ -14,6 +14,7 @@
  */
 
 const lib = require('../../intelligence/pay-equity.lib');
+const compaLib = require('../../intelligence/compa-ratio.lib');
 
 function getModel(name) {
   const mongoose = require('mongoose');
@@ -24,6 +25,8 @@ function getModel(name) {
     try {
       if (name === 'Employee') require('../../models/HR/Employee');
       if (name === 'PayEquitySnapshot') require('../../models/HR/PayEquitySnapshot');
+      if (name === 'JobBandMapping') require('../../models/HR/JobBandMapping');
+      if (name === 'CompensationBand') require('../../models/HR/CompensationBand');
       return mongoose.model(name);
     } catch {
       return null;
@@ -175,6 +178,115 @@ async function flaggedEmployees({
   return a.flagged;
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// compa-ratio (W1385) — salary vs the midpoint of the band the ROLE maps to.
+// ──────────────────────────────────────────────────────────────────────────
+
+/** active jobTitle→bandCode + bandCode→midSalary lookups (org-global config). */
+async function loadBandLookup() {
+  const JobBandMapping = getModel('JobBandMapping');
+  const CompensationBand = getModel('CompensationBand');
+  const titleToBand = new Map();
+  const bandToMid = new Map();
+  if (JobBandMapping) {
+    const maps = await JobBandMapping.find({ active: true }).select('jobTitle bandCode').lean();
+    for (const m of maps) titleToBand.set(m.jobTitle, m.bandCode);
+  }
+  if (CompensationBand) {
+    const bands = await CompensationBand.find({ isActive: true }).select('bandCode midSalary').lean();
+    for (const b of bands) bandToMid.set(b.bandCode, Number(b.midSalary));
+  }
+  return { titleToBand, bandToMid };
+}
+
+/**
+ * Per-employee compa-ratio entries (branch-scoped). Only employees whose role
+ * maps to an ACTIVE band WITH a midpoint get a compaRatio; everyone else is
+ * counted as `unmapped` and excluded — never salary-inferred (that would put
+ * everyone inside their band by construction; see compa-ratio.lib header).
+ */
+async function computeCompaEntries({ branchId, department }) {
+  const rows = await loadWorkforce({ branchId, department });
+  const { titleToBand, bandToMid } = await loadBandLookup();
+  const entries = [];
+  let unmapped = 0;
+  for (const r of rows) {
+    const bandCode = r.jobTitle ? titleToBand.get(r.jobTitle) : undefined;
+    const mid = bandCode != null ? bandToMid.get(bandCode) : undefined;
+    const ratio = compaLib.compaRatio(r.salary, mid);
+    if (ratio == null) {
+      unmapped += 1;
+      continue;
+    }
+    entries.push({
+      employeeId: r.employeeId,
+      name: r.name,
+      department: r.department,
+      jobTitle: r.jobTitle,
+      bandCode,
+      midSalary: mid,
+      salary: r.salary,
+      compaRatio: ratio,
+      band: compaLib.classifyCompaRatio(ratio),
+    });
+  }
+  return { entries, unmapped, total: rows.length };
+}
+
+/** Aggregate compa-ratio stats (NO individual identities) — for READ_ROLES. */
+async function compaRatioAnalysis({ branchId, department = null } = {}) {
+  const { entries, unmapped, total } = await computeCompaEntries({ branchId, department });
+  const stats = compaLib.compaRatioStats(entries);
+  return {
+    scope: { branchId: branchId || null, department: department || null },
+    workforce: total,
+    mapped: entries.length,
+    unmapped,
+    coveragePct: total ? compaLib.round((entries.length / total) * 100, 1) : 0,
+    stats,
+  };
+}
+
+/** Identity-bearing list of employees paid BELOW their band — stricter role. */
+async function belowBandEmployees({ branchId, department = null, belowThreshold } = {}) {
+  const { entries } = await computeCompaEntries({ branchId, department });
+  const t = Number.isFinite(Number(belowThreshold)) ? Number(belowThreshold) : compaLib.DEFAULT_BELOW;
+  return entries.filter((e) => e.compaRatio < t).sort((a, b) => a.compaRatio - b.compaRatio);
+}
+
+/** List the job→band mappings (org-global config). */
+async function listJobBandMappings() {
+  const JobBandMapping = getModel('JobBandMapping');
+  if (!JobBandMapping) {
+    const e = new Error('JobBandMapping model unavailable');
+    e.code = 'MODEL_UNAVAILABLE';
+    throw e;
+  }
+  return JobBandMapping.find({}).sort({ jobTitle: 1 }).lean();
+}
+
+/** Create or update a job→band mapping (admin/HR config; one band per title). */
+async function upsertJobBandMapping({ jobTitle, bandCode, active = true, note = null, createdBy = null } = {}) {
+  const JobBandMapping = getModel('JobBandMapping');
+  if (!JobBandMapping) {
+    const e = new Error('JobBandMapping model unavailable');
+    e.code = 'MODEL_UNAVAILABLE';
+    throw e;
+  }
+  const title = String(jobTitle || '').trim();
+  const code = String(bandCode || '').trim();
+  if (!title || !code) {
+    const e = new Error('jobTitle and bandCode are required');
+    e.code = 'VALIDATION';
+    throw e;
+  }
+  return JobBandMapping.findOneAndUpdate(
+    { jobTitle: title },
+    { $set: { bandCode: code, active: !!active, note: note || null, createdBy: createdBy || null } },
+    { new: true, upsert: true, setDefaultsOnInsert: true }
+  ).lean();
+}
+
 module.exports = {
   totalSalaryOf,
   toRow,
@@ -185,4 +297,11 @@ module.exports = {
   listSnapshots,
   trends,
   flaggedEmployees,
+  // compa-ratio (W1385)
+  loadBandLookup,
+  computeCompaEntries,
+  compaRatioAnalysis,
+  belowBandEmployees,
+  listJobBandMappings,
+  upsertJobBandMapping,
 };

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -927,3 +927,7 @@ __tests__/whatsapp-bot-core-linkage-wave1408.test.js
 __tests__/clinical-session-path-wave1379.test.js
 __tests__/session-completed-bus-wave1381.test.js
 __tests__/phantom-imports-fixes-wave1384.test.js
+__tests__/compa-ratio-lib-wave1385.test.js
+__tests__/job-band-mapping-behavioral-wave1385.test.js
+__tests__/compa-ratio-service-behavioral-wave1385.test.js
+__tests__/pay-equity-compa-ratio-routes-wave1385.test.js


### PR DESCRIPTION
## Closes the last HR-intelligence gap

pay-equity had demographic gaps + cohort outliers but **no compa-ratio** (salary vs the midpoint of the band the employee's ROLE maps to) because Employee carries no band/grade field.

**Solved without an Employee schema change or migration:** a new org-global config model `JobBandMapping` (jobTitle→bandCode, exactly like `RoleCompetencyRequirement`) that HR fills in once. compa-ratio is computed role→band→midpoint, and is **null (employee excluded, counted `unmapped`)** whenever there's no mapping or no active band — **never salary-inferred** (that would put everyone inside their band by construction and could never reveal under-payment).

### Surface
- `intelligence/compa-ratio.lib.js` — pure math (compaRatio / classify / stats), null-safe
- `models/HR/JobBandMapping.js` — org-global config, one band per title (unique)
- `services/hr/payEquityService.js` — `compaRatioAnalysis` (aggregate) + `belowBandEmployees` (identity-bearing) + list/upsert mapping config
- `routes/hr/pay-equity.routes.js` — `GET /compa-ratio` (READ_ROLES), `GET /below-band` (stricter FLAGGED_ROLES), `GET/POST /band-mappings` (POST→CONFIG_ROLES); all branch-scoped via `effectiveBranchScope` (W269)
- **4 drift guards** (lib + model behavioral + service behavioral + route static), **26 assertions**. The service behavioral seeds real Employee+band+mapping and asserts the whole chain + branch isolation + unmapped-excluded.

All 7 pre-push gates pass; sprint-enumerated. Renumbered W1384→W1385 to avoid an in-repo wave collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)