### PR TITLE
feat(authz): W1420 — read-only IAM / access-control console

### DIFF
--- a/.github/workflows/sprint-tests.yml
+++ b/.github/workflows/sprint-tests.yml
@@ -1888,6 +1888,8 @@ on:
       - 'backend/__tests__/pay-equity-compa-ratio-routes-wave1385.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/dead-scope-axis-read-filter-wave1408.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/access-console-wave1420.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   pull_request:
@@ -3754,6 +3756,8 @@ on:
       - 'backend/__tests__/pay-equity-compa-ratio-routes-wave1385.test.js'
       # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
       - 'backend/__tests__/dead-scope-axis-read-filter-wave1408.test.js'
+      # Auto-synced from sprint-tests.txt by scripts/sync-sprint-tests-paths.js
+      - 'backend/__tests__/access-console-wave1420.test.js'
       - 'backend/package.json'
       - '.github/workflows/sprint-tests.yml'
   workflow_dispatch:

--- a/backend/__tests__/access-console-wave1420.test.js
+++ b/backend/__tests__/access-console-wave1420.test.js
@@ -1,0 +1,192 @@
+'use strict';
+/**
+ * access-console-wave1420.test.js
+ *
+ * Drift guard for the READ-ONLY IAM console (W1420). The console MUST be a pure
+ * projection of the canonical authority — it adds no second decision path. The
+ * headline assertion (§4) proves that lib.simulate() agrees with can.js for the
+ * FULL role × permission cross-product: if anyone ever forks the decision here,
+ * this fails.
+ */
+
+const lib = require('../authorization/access-console/access-console.lib');
+const reg = require('../authorization/permissions.registry');
+const { can } = require('../authorization/can');
+const archetypeMap = require('../authorization/role-archetype.map.json');
+
+const ALL_PERMS = reg.ALL;
+const ALL_ROLES = (archetypeMap.map || []).map(e => e.live);
+
+describe('access-console — overview()', () => {
+  const ov = lib.overview();
+  it('reports dynamic, non-hardcoded counts', () => {
+    expect(ov.permissions).toBe(ALL_PERMS.length);
+    expect(ov.roles).toBe(ALL_ROLES.length);
+    expect(ov.archetypes).toBe(Object.keys(reg.ARCHETYPES).length);
+    expect(ov.domains).toBeGreaterThan(0);
+  });
+  it('points at can.js as THE decision engine', () => {
+    expect(ov.decisionEngine).toBe('backend/authorization/can.js');
+  });
+  it('counts PHI permissions from META (never 0 in this codebase)', () => {
+    const phi = ALL_PERMS.filter(k => reg.META[k] && reg.META[k].phi).length;
+    expect(ov.phiPermissions).toBe(phi);
+    expect(ov.phiPermissions).toBeGreaterThan(0);
+  });
+});
+
+describe('access-console — listArchetypes()', () => {
+  const items = lib.listArchetypes();
+  it('lists exactly the 9 registry archetypes', () => {
+    expect(items.length).toBe(Object.keys(reg.ARCHETYPES).length);
+    items.forEach(a => {
+      expect(reg.ARCHETYPES[a.code]).toBe(a.name);
+      expect(typeof a.labelAr).toBe('string');
+      expect(a.grantCount).toBe(Object.keys(reg.ROLE_GRANTS[a.code] || {}).length);
+      expect(a.denyCount).toBe((reg.ROLE_DENY[a.code] || []).length);
+    });
+  });
+});
+
+describe('access-console — listRoles()', () => {
+  const roles = lib.listRoles();
+  it('covers every live role in the archetype map', () => {
+    expect(roles.length).toBe(ALL_ROLES.length);
+    const names = roles.map(r => r.role).sort();
+    expect(names).toEqual([...ALL_ROLES].sort());
+  });
+  it('enriches each role with archetype, level, scope and a permission count', () => {
+    roles.forEach(r => {
+      expect(typeof r.labelAr).toBe('string');
+      expect(typeof r.archetype).toBe('string');
+      expect(typeof r.level).toBe('number');
+      expect(r.permissionCount).toBeGreaterThanOrEqual(0);
+      expect(r.permissionCount).toBeLessThanOrEqual(ALL_PERMS.length);
+    });
+  });
+  it('permissionCount equals the can.js-derived effective grant count', () => {
+    roles.forEach(r => {
+      const expected = ALL_PERMS.reduce((n, k) => (can({ role: r.role }, k).allow ? n + 1 : n), 0);
+      expect(r.permissionCount).toBe(expected);
+    });
+  });
+});
+
+describe('access-console — listPermissions() / permissionDetail()', () => {
+  const perms = lib.listPermissions();
+  it('lists every canonical permission with META', () => {
+    expect(perms.length).toBe(ALL_PERMS.length);
+    perms.forEach(p => {
+      const m = reg.META[p.key];
+      expect(m).toBeTruthy();
+      expect(p.tier).toBe(m.tier);
+      expect(p.phi).toBe(!!m.phi);
+      expect(p.domain).toBe(p.key.split(':')[0]);
+    });
+  });
+  it('grantedByArchetypes matches reg.can per archetype', () => {
+    perms.forEach(p => {
+      const expected = Object.keys(reg.ARCHETYPES).filter(c => reg.can(c, p.key).allow);
+      expect(p.grantedByArchetypes.sort()).toEqual(expected.sort());
+    });
+  });
+  it('permissionDetail returns null for an unknown key', () => {
+    expect(lib.permissionDetail('totally:fake:permission')).toBeNull();
+  });
+  it('permissionDetail surfaces granting + denying archetypes for a known key', () => {
+    const d = lib.permissionDetail('beneficiary:clinical:read');
+    expect(d).toBeTruthy();
+    expect(Array.isArray(d.grantingArchetypes)).toBe(true);
+    // HQ_ADMIN is explicitly denied clinical read in the registry.
+    expect(d.denyingArchetypes.map(a => a.code)).toContain('HQA');
+  });
+});
+
+describe('access-console — roleDetail()', () => {
+  it('groups effective permissions by domain and routes every item through can.js', () => {
+    const d = lib.roleDetail('therapist');
+    expect(d.mapped).toBe(true);
+    expect(d.archetype).toBe('THERAPIST');
+    expect(d.summary.total).toBe(ALL_PERMS.length);
+    expect(d.summary.granted + d.summary.denied).toBe(ALL_PERMS.length);
+
+    const flat = d.domains.flatMap(g => g.items);
+    expect(flat.length).toBe(ALL_PERMS.length);
+    flat.forEach(item => {
+      const v = can({ role: 'therapist' }, item.key);
+      expect(item.allow).toBe(v.allow);
+      expect(item.reason).toBe(v.reason);
+    });
+  });
+  it('returns mapped:false for an unmapped role', () => {
+    const d = lib.roleDetail('not_a_real_role_xyz');
+    expect(d.mapped).toBe(false);
+  });
+});
+
+describe('access-console — buildMatrix()', () => {
+  const m = lib.buildMatrix();
+  it('is an archetype × permission grid whose cells equal reg.can', () => {
+    expect(m.archetypes.length).toBe(Object.keys(reg.ARCHETYPES).length);
+    expect(m.permissions.length).toBe(ALL_PERMS.length);
+    m.archetypes.forEach(a => {
+      ALL_PERMS.forEach(key => {
+        const cell = m.cells[a.code][key];
+        const v = reg.can(a.code, key);
+        expect(cell.allow).toBe(v.allow);
+      });
+    });
+  });
+});
+
+describe('access-console — simulate() PARITY with can.js (the drift guard)', () => {
+  it('agrees with can.js for the FULL role × permission cross-product', () => {
+    let checked = 0;
+    ALL_ROLES.forEach(role => {
+      ALL_PERMS.forEach(permission => {
+        const sim = lib.simulate(role, permission);
+        const truth = can({ role }, permission);
+        expect(sim.allow).toBe(truth.allow);
+        expect(sim.reason).toBe(truth.reason);
+        checked += 1;
+      });
+    });
+    expect(checked).toBe(ALL_ROLES.length * ALL_PERMS.length);
+  });
+
+  it('surfaces explicit deny (receptionist cannot read clinical PHI)', () => {
+    const sim = lib.simulate('receptionist', 'beneficiary:clinical:read');
+    expect(sim.allow).toBe(false);
+    expect(sim.reason).toBe('explicit-deny');
+  });
+
+  it('honours the approver gate (a non-approver line role cannot approve)', () => {
+    // doctor is a THERAPIST-archetype line role (approver:false).
+    const sim = lib.simulate('doctor', 'treatment_plan:plan:approve');
+    expect(sim.allow).toBe(false);
+    expect(['not-approver', 'ungranted', 'explicit-deny']).toContain(sim.reason);
+  });
+
+  it('flags an unknown permission rather than silently allowing', () => {
+    const sim = lib.simulate('super_admin', 'made:up:permission');
+    expect(sim.permissionKnown).toBe(false);
+    expect(sim.allow).toBe(false);
+  });
+});
+
+describe('access-console — routes contract', () => {
+  const routesMod = require('../authorization/access-console/access-console.routes');
+  it('exports buildRouter + the two role allow-lists', () => {
+    expect(typeof routesMod.buildRouter).toBe('function');
+    expect(Array.isArray(routesMod.VIEW_ROLES)).toBe(true);
+    expect(routesMod.VIEW_ROLES.length).toBeGreaterThan(0);
+    expect(Array.isArray(routesMod.USER_INSPECT_ROLES)).toBe(true);
+    // user-inspection is a STRICTER subset of view roles.
+    routesMod.USER_INSPECT_ROLES.forEach(r => expect(routesMod.VIEW_ROLES).toContain(r));
+  });
+  it('builds an Express router with a non-empty middleware stack', () => {
+    const r = routesMod.buildRouter({});
+    expect(r && Array.isArray(r.stack)).toBe(true);
+    expect(r.stack.length).toBeGreaterThan(5);
+  });
+});

--- a/backend/authorization/access-console/access-console.lib.js
+++ b/backend/authorization/access-console/access-console.lib.js
@@ -1,0 +1,424 @@
+'use strict';
+/**
+ * access-console.lib.js — W1420
+ *
+ * PURE, read-only serializers over the canonical authorization authority. This
+ * is the presentation layer for the IAM console (web-admin /admin/access-control):
+ * it makes the EXISTING decision authority VISIBLE; it does NOT add a second one
+ * (ADR-035 §4 / ADR-036 — `can.js` stays the one PDP).
+ *
+ * Sources (single source of truth — never duplicated here):
+ *   - permissions.registry.js  → P / META / ROLE_GRANTS / ROLE_DENY / ARCHETYPES
+ *   - role-archetype.map.json   → the 46 live roles → 9 archetypes bridge
+ *   - can.js                    → THE decision (every allow/deny below routes
+ *                                 through it, so the console can never drift
+ *                                 from the real PDP)
+ *   - roles.constants.js        → ROLE_LEVELS / CROSS_BRANCH_ROLES / region scope
+ *
+ * No I/O, no Mongoose, deny-biased. Trivially unit-testable.
+ */
+
+const reg = require('../permissions.registry');
+const archetypeMap = require('../role-archetype.map.json');
+const { can, archetypeOf } = require('../can');
+const {
+  ROLE_LEVELS,
+  levelOf,
+  CROSS_BRANCH_ROLES,
+  REGION_SCOPED_ROLES,
+} = require('../../config/constants/roles.constants');
+
+// ── Display metadata (Arabic-first; the live UI is RTL) ────────────────────
+
+/** permission domain (1st segment of `domain:resource:action`) → Arabic label. */
+const DOMAIN_LABELS_AR = Object.freeze({
+  dashboard: 'لوحات المعلومات',
+  branch: 'الفروع والتنظيم',
+  beneficiary: 'المستفيدون',
+  assessment: 'التقييمات',
+  treatment_plan: 'الخطط العلاجية',
+  session: 'الجلسات',
+  appointment: 'المواعيد',
+  attendance: 'الحضور',
+  employee: 'الموظفون',
+  hr: 'الموارد البشرية',
+  report: 'التقارير',
+  approval: 'الموافقات',
+  user: 'المستخدمون والحسابات',
+  rbac: 'سياسات الصلاحيات',
+  audit: 'سجل التدقيق',
+});
+
+/** archetype NAME → Arabic label. */
+const ARCHETYPE_LABELS_AR = Object.freeze({
+  HQ_ADMIN: 'مدير المركز الرئيسي (تقني)',
+  EXECUTIVE_DIRECTOR: 'الإدارة التنفيذية',
+  BRANCH_MANAGER: 'مدير الفرع',
+  UNIT_SUPERVISOR: 'مشرف وحدة / قسم',
+  THERAPIST: 'أخصائي / مُمارس سريري',
+  RECEPTIONIST: 'الاستقبال / إدخال البيانات',
+  HR_OFFICER: 'الموارد البشرية',
+  FINANCE_OFFICER: 'الشؤون المالية',
+  AUDITOR: 'التدقيق / الالتزام (قراءة فقط)',
+  NON_MATRIX: 'خارج مصفوفة الموظفين (خارجي / نقل)',
+});
+
+/** live role → Arabic label (covers all 46 mapped roles). */
+const ROLE_LABELS_AR = Object.freeze({
+  super_admin: 'مدير النظام الأعلى',
+  head_office_admin: 'مدير الإدارة العامة',
+  it_admin: 'مدير تقنية المعلومات',
+  ceo: 'الرئيس التنفيذي',
+  group_gm: 'المدير العام للمجموعة',
+  regional_director: 'المدير الإقليمي',
+  admin: 'مدير',
+  manager: 'مدير عام (فرع)',
+  branch_manager: 'مدير الفرع',
+  clinical_director: 'المدير السريري',
+  supervisor: 'مشرف',
+  therapy_supervisor: 'مشرف العلاج',
+  special_ed_supervisor: 'مشرف التربية الخاصة',
+  doctor: 'طبيب',
+  therapist: 'أخصائي علاجي',
+  therapist_slp: 'أخصائي تخاطب',
+  therapist_ot: 'أخصائي علاج وظيفي',
+  therapist_pt: 'أخصائي علاج طبيعي',
+  therapist_psych: 'أخصائي نفسي',
+  teacher: 'معلم تربية خاصة',
+  special_ed_teacher: 'معلم تربية خاصة',
+  therapy_assistant: 'مساعد علاجي',
+  receptionist: 'موظف استقبال',
+  data_entry: 'مُدخل بيانات',
+  group_chro: 'مدير الموارد البشرية للمجموعة',
+  hr_manager: 'مدير الموارد البشرية',
+  hr_supervisor: 'مشرف الموارد البشرية',
+  hr_officer: 'موظف موارد بشرية',
+  hr: 'موارد بشرية',
+  group_cfo: 'المدير المالي للمجموعة',
+  finance_supervisor: 'مشرف مالي',
+  finance: 'موظف مالي',
+  accountant: 'محاسب',
+  internal_auditor: 'مدقق داخلي',
+  compliance_officer: 'مسؤول الالتزام',
+  group_quality_officer: 'مسؤول الجودة للمجموعة',
+  regional_quality: 'مسؤول الجودة الإقليمي',
+  quality_coordinator: 'منسق الجودة',
+  parent: 'ولي أمر',
+  guardian: 'وصي',
+  student: 'طالب',
+  viewer: 'مُشاهد',
+  user: 'مستخدم',
+  guest: 'زائر',
+  driver: 'سائق',
+  bus_assistant: 'مرافق حافلة',
+  nurse: 'ممرض',
+  head_nurse: 'رئيس التمريض',
+  nursing_supervisor: 'مشرف التمريض',
+  dpo: 'مسؤول حماية البيانات',
+  family_counsellor: 'مستشار أسري',
+  independent_advocate: 'مُناصر مستقل',
+  cultural_officer: 'مسؤول التكيّف الثقافي',
+  patient_relations_officer: 'موظف علاقات المستفيدين',
+  crm_supervisor: 'مشرف علاقات العملاء',
+});
+
+/** assurance tier (ADR-019) → Arabic label. */
+const TIER_LABELS_AR = Object.freeze({
+  1: 'أساسي',
+  2: 'حساس (تحقق ثنائي)',
+  3: 'حرج (تحقق مشدّد)',
+});
+
+/** scope code (role-archetype.map.json) → Arabic label. */
+const SCOPE_LABELS_AR = Object.freeze({
+  G: 'كل الفروع',
+  regional: 'إقليمي',
+  B: 'الفرع',
+  U: 'الوحدة / القسم',
+  S: 'الحالات المُسندة',
+  self: 'سجلاته فقط',
+  none: 'بدون نطاق',
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const ALL_PERMISSIONS = reg.ALL; // Object.values(P) — never hardcode a count
+const MAP_ENTRIES = (archetypeMap.map || []).slice();
+
+/** first `:`-segment of a permission key. */
+function domainOf(key) {
+  return String(key).split(':')[0];
+}
+
+/** structured `{ domain, resource, action }` for a permission key. */
+function partsOf(key) {
+  const [domain, resource, action] = String(key).split(':');
+  return { domain, resource: resource || '', action: action || '' };
+}
+
+/** META + display sugar for one permission key. */
+function permissionMeta(key) {
+  const m = reg.META[key] || { tier: null, phi: false, hqOnly: false, sod: null };
+  const { domain, resource, action } = partsOf(key);
+  return {
+    key,
+    domain,
+    domainLabelAr: DOMAIN_LABELS_AR[domain] || domain,
+    resource,
+    action,
+    tier: m.tier,
+    tierLabelAr: m.tier ? TIER_LABELS_AR[m.tier] || null : null,
+    phi: !!m.phi,
+    hqOnly: !!m.hqOnly,
+    sod: m.sod || null,
+  };
+}
+
+/** archetype codes that GRANT a permission key (deny-aware). */
+function archetypesGranting(key) {
+  return Object.keys(reg.ARCHETYPES).filter(code => reg.can(code, key).allow);
+}
+
+// ── Public serializers ─────────────────────────────────────────────────────
+
+/** counts for the console landing page. */
+function overview() {
+  const phiCount = ALL_PERMISSIONS.filter(k => reg.META[k] && reg.META[k].phi).length;
+  const tierCounts = { 1: 0, 2: 0, 3: 0, none: 0 };
+  ALL_PERMISSIONS.forEach(k => {
+    const t = reg.META[k] && reg.META[k].tier;
+    if (t === 1 || t === 2 || t === 3) tierCounts[t] += 1;
+    else tierCounts.none += 1;
+  });
+  return {
+    roles: MAP_ENTRIES.length,
+    archetypes: Object.keys(reg.ARCHETYPES).length,
+    permissions: ALL_PERMISSIONS.length,
+    domains: Object.keys(DOMAIN_LABELS_AR).length,
+    phiPermissions: phiCount,
+    crossBranchRoles: CROSS_BRANCH_ROLES.length,
+    tierCounts,
+    decisionEngine: 'backend/authorization/can.js',
+  };
+}
+
+/** the 9 archetypes with grant / deny counts. */
+function listArchetypes() {
+  return Object.entries(reg.ARCHETYPES).map(([code, name]) => ({
+    code,
+    name,
+    labelAr: ARCHETYPE_LABELS_AR[name] || name,
+    grantCount: Object.keys(reg.ROLE_GRANTS[code] || {}).length,
+    denyCount: (reg.ROLE_DENY[code] || []).length,
+  }));
+}
+
+/** count of permissions a live role effectively holds (via can.js). */
+function effectiveGrantCount(role) {
+  return ALL_PERMISSIONS.reduce((n, k) => (can({ role }, k).allow ? n + 1 : n), 0);
+}
+
+/** the 46 live roles, each enriched with archetype + scope + level + count. */
+function listRoles() {
+  return MAP_ENTRIES.map(e => {
+    const role = e.live;
+    const a = archetypeOf(role);
+    return {
+      role,
+      labelAr: ROLE_LABELS_AR[role] || role,
+      archetype: e.archetype,
+      archetypeCode: a ? a.code : null,
+      archetypeLabelAr: ARCHETYPE_LABELS_AR[e.archetype] || e.archetype,
+      scope: e.scope,
+      scopeLabelAr: SCOPE_LABELS_AR[e.scope] || e.scope,
+      seniority: e.seniority || null,
+      approver: !!e.approver,
+      level: ROLE_LEVELS[role] != null ? ROLE_LEVELS[role] : levelOf(role),
+      crossBranch: CROSS_BRANCH_ROLES.includes(role),
+      regionScoped: REGION_SCOPED_ROLES.includes(role),
+      note: e.note || null,
+      permissionCount: effectiveGrantCount(role),
+    };
+  });
+}
+
+/**
+ * full effective-permission breakdown for one live role, grouped by domain.
+ * Every item's allow/reason/scope comes straight from can.js.
+ */
+function roleDetail(role) {
+  const entry = MAP_ENTRIES.find(e => String(e.live).toLowerCase() === String(role).toLowerCase());
+  const a = archetypeOf(role);
+
+  const byDomain = {};
+  let granted = 0;
+  let phiGranted = 0;
+  let tier3Granted = 0;
+
+  ALL_PERMISSIONS.forEach(key => {
+    const verdict = can({ role }, key);
+    const meta = permissionMeta(key);
+    const item = {
+      ...meta,
+      allow: verdict.allow,
+      reason: verdict.reason,
+      scope: verdict.allow ? verdict.scope || null : null,
+    };
+    if (verdict.allow) {
+      granted += 1;
+      if (meta.phi) phiGranted += 1;
+      if (meta.tier === 3) tier3Granted += 1;
+    }
+    const d = meta.domain;
+    if (!byDomain[d]) {
+      byDomain[d] = { domain: d, domainLabelAr: DOMAIN_LABELS_AR[d] || d, items: [] };
+    }
+    byDomain[d].items.push(item);
+  });
+
+  // Order domains by DOMAIN_LABELS_AR declaration order, then any extras.
+  const order = Object.keys(DOMAIN_LABELS_AR);
+  const domains = Object.values(byDomain).sort(
+    (x, y) => (order.indexOf(x.domain) + 1 || 999) - (order.indexOf(y.domain) + 1 || 999)
+  );
+
+  return {
+    role,
+    labelAr: ROLE_LABELS_AR[role] || role,
+    mapped: !!entry,
+    archetype: a ? a.name : null,
+    archetypeCode: a ? a.code : null,
+    archetypeLabelAr: a ? ARCHETYPE_LABELS_AR[a.name] || a.name : null,
+    scope: entry ? entry.scope : a ? a.scope : null,
+    scopeLabelAr: entry ? SCOPE_LABELS_AR[entry.scope] || entry.scope : null,
+    seniority: entry ? entry.seniority || null : null,
+    approver: a ? !!a.approver : false,
+    level: ROLE_LEVELS[role] != null ? ROLE_LEVELS[role] : levelOf(role),
+    crossBranch: CROSS_BRANCH_ROLES.includes(role),
+    regionScoped: REGION_SCOPED_ROLES.includes(role),
+    note: entry ? entry.note || null : null,
+    summary: {
+      total: ALL_PERMISSIONS.length,
+      granted,
+      denied: ALL_PERMISSIONS.length - granted,
+      phiGranted,
+      tier3Granted,
+    },
+    domains,
+  };
+}
+
+/** the full permission catalog with META + which archetypes/roles grant each. */
+function listPermissions() {
+  const rolesByArchetype = {};
+  MAP_ENTRIES.forEach(e => {
+    const a = archetypeOf(e.live);
+    if (!a || !a.code) return;
+    (rolesByArchetype[a.code] = rolesByArchetype[a.code] || []).push(e.live);
+  });
+  return ALL_PERMISSIONS.map(key => {
+    const codes = archetypesGranting(key);
+    return {
+      ...permissionMeta(key),
+      grantedByArchetypes: codes,
+      grantedByRoleCount: codes.reduce((n, c) => n + (rolesByArchetype[c] || []).length, 0),
+    };
+  });
+}
+
+/** detail for one permission: who grants it, who is explicitly denied. */
+function permissionDetail(key) {
+  if (!reg.META[key]) return null;
+  const granting = Object.entries(reg.ARCHETYPES)
+    .map(([code, name]) => {
+      const v = reg.can(code, key);
+      return v.allow ? { code, name, labelAr: ARCHETYPE_LABELS_AR[name] || name, scope: v.scope } : null;
+    })
+    .filter(Boolean);
+  const denying = Object.entries(reg.ARCHETYPES)
+    .filter(([code]) => (reg.ROLE_DENY[code] || []).includes(key))
+    .map(([code, name]) => ({ code, name, labelAr: ARCHETYPE_LABELS_AR[name] || name }));
+  return { ...permissionMeta(key), grantingArchetypes: granting, denyingArchetypes: denying };
+}
+
+/** archetype × permission grid for the matrix view. */
+function buildMatrix() {
+  const archetypes = Object.entries(reg.ARCHETYPES).map(([code, name]) => ({
+    code,
+    name,
+    labelAr: ARCHETYPE_LABELS_AR[name] || name,
+  }));
+  const permissions = ALL_PERMISSIONS.map(permissionMeta);
+  const cells = {};
+  archetypes.forEach(({ code }) => {
+    cells[code] = {};
+    ALL_PERMISSIONS.forEach(key => {
+      const v = reg.can(code, key);
+      cells[code][key] = v.allow
+        ? { allow: true, scope: v.scope || null }
+        : { allow: false, reason: v.reason };
+    });
+  });
+  return { archetypes, permissions, cells };
+}
+
+/**
+ * Access simulator — answers "can this role do X, and why?" THROUGH can.js.
+ * @param {string} role        a live role name
+ * @param {string} permission  a canonical permission key
+ */
+function simulate(role, permission) {
+  const verdict = can({ role }, permission);
+  const a = archetypeOf(role);
+  return {
+    role,
+    roleLabelAr: ROLE_LABELS_AR[role] || role,
+    permission,
+    permissionKnown: !!reg.META[permission],
+    meta: reg.META[permission] ? permissionMeta(permission) : null,
+    archetype: a ? a.name : null,
+    archetypeLabelAr: a ? ARCHETYPE_LABELS_AR[a.name] || a.name : null,
+    allow: verdict.allow,
+    reason: verdict.reason,
+    reasonLabelAr: REASON_LABELS_AR[verdict.reason] || verdict.reason,
+    tier: verdict.tier != null ? verdict.tier : null,
+    scope: verdict.allow ? verdict.scope || verdict.archetypeScope || null : null,
+  };
+}
+
+/** decision reason code → Arabic explanation (mirrors can.js return reasons). */
+const REASON_LABELS_AR = Object.freeze({
+  granted: 'مسموح',
+  'explicit-deny': 'ممنوع صراحةً (Deny يتجاوز المنح)',
+  ungranted: 'غير ممنوح لهذا النوع',
+  'unknown-permission': 'صلاحية غير معروفة',
+  'unmapped-role': 'دور غير مُعرَّف في المصفوفة',
+  'non-matrix': 'دور خارج مصفوفة الموظفين',
+  'not-approver': 'يتطلب صلاحية اعتماد (Approver)',
+});
+
+module.exports = {
+  // serializers
+  overview,
+  listArchetypes,
+  listRoles,
+  roleDetail,
+  listPermissions,
+  permissionDetail,
+  buildMatrix,
+  simulate,
+  // pure helpers (exported for tests + the routes layer)
+  domainOf,
+  partsOf,
+  permissionMeta,
+  archetypesGranting,
+  effectiveGrantCount,
+  // label maps (exported so the user-effective route can reuse them)
+  DOMAIN_LABELS_AR,
+  ARCHETYPE_LABELS_AR,
+  ROLE_LABELS_AR,
+  TIER_LABELS_AR,
+  SCOPE_LABELS_AR,
+  REASON_LABELS_AR,
+  ALL_PERMISSIONS,
+};

--- a/backend/authorization/access-console/access-console.routes.js
+++ b/backend/authorization/access-console/access-console.routes.js
@@ -1,0 +1,184 @@
+'use strict';
+/**
+ * access-console.routes.js — W1420
+ *
+ * READ-ONLY IAM console surface for web-admin /admin/access-control. Serializes
+ * the canonical authorization authority (permissions.registry.js + can.js +
+ * role-archetype.map.json) so an administrator can finally SEE the policy that
+ * the live PDP already enforces — what each role can do, the full role ×
+ * permission matrix, and a "can this role do X, and why?" simulator.
+ *
+ * This adds NO new decision path: every allow/deny is computed through
+ * backend/authorization/can.js (ADR-035 §4 / ADR-036). There are NO mutating
+ * endpoints here — role↔permission grants are config (seed → generated registry),
+ * not runtime-mutable, by deliberate design.
+ *
+ * Mounted in features.registry.js:
+ *   dualMountAuth(app, 'access-control', buildRouter({ UserModel }))
+ *   → /api/access-control + /api/v1/access-control  (authenticated)
+ */
+
+const express = require('express');
+const mongoose = require('mongoose');
+const lib = require('./access-console.lib');
+const { requireRole } = require('../../middleware/auth');
+const { requireBranchAccess } = require('../../middleware/branchScope.middleware');
+const { assertBranchMatch } = require('../../middleware/assertBranchMatch');
+
+// Who may VIEW the policy console (read-only; no PHI, no secrets — just the
+// access policy itself). Admin / HQ / governance roles.
+const VIEW_ROLES = Object.freeze([
+  'super_admin',
+  'head_office_admin',
+  'it_admin',
+  'admin',
+  'manager',
+  'branch_manager',
+  'regional_director',
+  'ceo',
+  'group_gm',
+  'compliance_officer',
+  'internal_auditor',
+  'group_quality_officer',
+  'dpo',
+]);
+
+// Inspecting a SPECIFIC user's effective access is narrower (touches a person's
+// account) → HQ / cross-branch / governance only, plus per-branch enforcement.
+const USER_INSPECT_ROLES = Object.freeze([
+  'super_admin',
+  'head_office_admin',
+  'it_admin',
+  'admin',
+  'ceo',
+  'group_gm',
+  'compliance_officer',
+  'internal_auditor',
+  'dpo',
+]);
+
+const ok = (res, data) => res.json({ success: true, data });
+
+/**
+ * @param {{ UserModel?: import('mongoose').Model<any> }} [deps]
+ */
+function buildRouter(deps = {}) {
+  const router = express.Router();
+
+  const resolveUserModel = () => {
+    if (deps.UserModel) return deps.UserModel;
+    try {
+      return mongoose.model('User');
+    } catch {
+      return null;
+    }
+  };
+
+  // Whole console is admin/governance-gated (read-only).
+  router.use(requireRole(...VIEW_ROLES));
+
+  // ── Landing / counts ──────────────────────────────────────────────────
+  router.get('/overview', (_req, res) => ok(res, lib.overview()));
+
+  // ── Archetypes (the 9 permission families) ────────────────────────────
+  router.get('/archetypes', (_req, res) => ok(res, { items: lib.listArchetypes() }));
+
+  // ── Roles (the 46 live roles) ─────────────────────────────────────────
+  router.get('/roles', (_req, res) => ok(res, { items: lib.listRoles() }));
+
+  router.get('/roles/:role', (req, res) => {
+    const detail = lib.roleDetail(req.params.role);
+    if (!detail.mapped) {
+      return res.status(404).json({ success: false, error: 'role_not_mapped', role: req.params.role });
+    }
+    return ok(res, detail);
+  });
+
+  // ── Permission catalog ────────────────────────────────────────────────
+  router.get('/permissions', (_req, res) => ok(res, { items: lib.listPermissions() }));
+
+  // Keys are colon-delimited (`beneficiary:clinical:read`) — colons stay within
+  // one path segment, so `:key` captures the whole key.
+  router.get('/permissions/:key', (req, res) => {
+    const detail = lib.permissionDetail(req.params.key);
+    if (!detail) {
+      return res.status(404).json({ success: false, error: 'unknown_permission', key: req.params.key });
+    }
+    return ok(res, detail);
+  });
+
+  // ── Full archetype × permission matrix ────────────────────────────────
+  router.get('/matrix', (_req, res) => ok(res, lib.buildMatrix()));
+
+  // ── Access simulator (can this role do X, and why?) ───────────────────
+  router.post('/simulate', (req, res) => {
+    const { role, permission } = req.body || {};
+    if (!role || !permission) {
+      return res.status(400).json({ success: false, error: 'role_and_permission_required' });
+    }
+    return ok(res, lib.simulate(String(role), String(permission)));
+  });
+
+  // ── Effective access for a specific user (branch-scoped) ──────────────
+  router.get(
+    '/users/:id/effective',
+    requireRole(...USER_INSPECT_ROLES),
+    requireBranchAccess,
+    async (req, res) => {
+      const Model = resolveUserModel();
+      if (!Model) return res.status(503).json({ success: false, error: 'user_model_unavailable' });
+      if (!mongoose.isValidObjectId(req.params.id)) {
+        return res.status(400).json({ success: false, error: 'invalid_user_id' });
+      }
+      let user;
+      try {
+        user = await Model.findById(req.params.id)
+          .select('name fullName email role roles branchId branch_id permissions customPermissions deniedPermissions')
+          .lean();
+      } catch (e) {
+        return res.status(500).json({ success: false, error: 'user_lookup_failed', message: e.message });
+      }
+      if (!user) return res.status(404).json({ success: false, error: 'user_not_found' });
+
+      // Branch isolation (W269 doctrine) — a restricted caller cannot inspect a
+      // user outside their branch. assertBranchMatch is a no-op for cross-branch
+      // roles; requireBranchAccess above populated req.branchScope.
+      const userBranch = user.branchId || user.branch_id || null;
+      if (userBranch) {
+        try {
+          assertBranchMatch(req, userBranch, 'user');
+        } catch (e) {
+          return res.status(e.statusCode || 403).json({ success: false, error: 'cross_branch_denied' });
+        }
+      }
+
+      const role = user.role || (Array.isArray(user.roles) && user.roles[0]) || 'guest';
+      const detail = lib.roleDetail(role);
+
+      // Per-user overrides are surfaced for transparency ONLY — can.js resolves
+      // capability at the role/archetype layer; these fields (if present on the
+      // User doc) are informational, not re-evaluated here.
+      const overrides = {
+        custom: Array.isArray(user.customPermissions) ? user.customPermissions : [],
+        denied: Array.isArray(user.deniedPermissions) ? user.deniedPermissions : [],
+      };
+
+      return ok(res, {
+        user: {
+          id: String(user._id || req.params.id),
+          name: user.fullName || user.name || null,
+          email: user.email || null,
+          role,
+          roles: Array.isArray(user.roles) ? user.roles : role ? [role] : [],
+          branchId: userBranch ? String(userBranch) : null,
+        },
+        effective: detail,
+        overrides,
+      });
+    }
+  );
+
+  return router;
+}
+
+module.exports = { buildRouter, VIEW_ROLES, USER_INSPECT_ROLES };

--- a/backend/routes/registries/features.registry.js
+++ b/backend/routes/registries/features.registry.js
@@ -615,5 +615,23 @@ module.exports = function registerFeatureRoutes(
     logger.warn(`Break-glass routes not mounted: ${e.message}`);
   }
 
+  // ── Access-control console — READ-ONLY IAM surface (W1420) ───────────
+  // Serializes the canonical authority (permissions.registry + can.js +
+  // role-archetype.map) for web-admin /admin/access-control: role explorer,
+  // permission catalog, full archetype×permission matrix, and a "can this role
+  // do X, and why?" simulator. NO mutating endpoints — grants are config, not
+  // runtime-mutable by design. Every allow/deny routes through can.js (one PDP).
+  try {
+    const {
+      buildRouter: buildAccessConsoleRouter,
+    } = require('../../authorization/access-console/access-console.routes');
+    // UserModel is resolved lazily inside the router via mongoose.model('User')
+    // (registered at boot) — avoids a brittle cross-base safeRequire path.
+    dualMountAuth(app, 'access-control', buildAccessConsoleRouter({}));
+    logger.info('✅ Access-control console mounted (read-only IAM): /api/(v1/)access-control');
+  } catch (e) {
+    logger.warn(`Access-control console not mounted: ${e.message}`);
+  }
+
   logger.info('[Features] All prompt feature modules mounted successfully');
 };

--- a/backend/sprint-tests.txt
+++ b/backend/sprint-tests.txt
@@ -1,6 +1,7 @@
 __tests__/aac-foundation-wave263.test.js
 __tests__/aac-pecs-phase-advanced-core-linkage-wave1063.test.js
 __tests__/absence-detection-sweeper-wave402.test.js
+__tests__/access-console-wave1420.test.js
 __tests__/access-grant-model-canonical-wave599.test.js
 __tests__/access-review-attestation-behavioral-wave38.test.js
 __tests__/access-review-wave38.test.js


### PR DESCRIPTION
## ما هذا
لوحة **IAM للقراءة فقط** تكشف نظام الصلاحيات القوي الموجود في الـ backend (`backend/authorization/can.js` — محرك القرار الوحيد) دون اختراع مسار قرار ثانٍ.

## لماذا
الـ RBAC ناضج (9 نماذج وظيفية × 75 صلاحية، 55 دوراً حيّاً) لكنه كان **غير مرئي**: لا طريقة لرؤية ماذا يستطيع دورٌ فعله، ولا المصفوفة الكاملة، ولا لماذا مُنع مستخدم. هذا يسدّ تلك الفجوة.

## التغييرات (backend، للقراءة فقط، `dualMountAuth` → `/api/(v1/)access-control`)
- `authorization/access-console/access-console.lib.js` — مُسلسِلات نقية فوق `permissions.registry` + `can.js` + `role-archetype.map` + `roles.constants` (تسميات عربية).
- `authorization/access-console/access-console.routes.js` — `buildRouter`، محروس بـ `requireRole(VIEW_ROLES)`؛ مسار «الوصول الفعلي لمستخدم» أشد + معزول بالفرع (W269). `UserModel` يُحَلّ كسولاً عبر `mongoose.model`. **لا نقاط تعديل** — المنح config بالتصميم.
- `__tests__/access-console-wave1420.test.js` — 20 اختباراً؛ أبرزها **تطابق `simulate()` مع `can.js` عبر كل الأدوار × كل الصلاحيات** (حارس انحراف). مُسجَّل في sprint.

## التحقق
- ✅ 20/20 drift test · lint نظيف · HTTP smoke (admin 200 / غير مصرّح 403 / 400 / 404 / مفتاح بنقطتين) أخضر
- ✅ `check:routes-load` (576 ملف) · `check:wave-collision` (W1420 حر)

يقترن مع PR واجهة web-admin (`feat/w1420-access-control-console` على repo الـ rehab-platform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)