### PR TITLE
chore(security): W1422 — override frontend form-data >=4.0.6 (green Security Scanning)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5122,16 +5122,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.12",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
@@ -9302,16 +9292,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -9867,9 +9857,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -97,6 +97,7 @@
     ]
   },
   "overrides": {
+    "form-data": ">=4.0.6",
     "uuid": ">=14.0.0",
     "nth-check": ">=2.1.1",
     "serialize-javascript": ">=7.0.5",


### PR DESCRIPTION
## المشكلة
بوابة `Security Scanning` تفشل على خطوة **«Frontend audit (high)»** بثغرة عالية وحيدة في شجرة تبعيات الواجهة:
- **form-data** `4.0.0-4.0.5` (تبعية غير مباشرة) — CRLF injection عبر أسماء حقول/ملفات multipart غير مهرَّبة (GHSA-hmw2-7cc7-3qxx)

## الإصلاح
form-data غير مباشرة (dependabot لا يرقّيها مباشرةً) → تُثبَّت عبر بلوك `overrides` الموجود — نفس النمط المُستخدَم فيه أصلاً (uuid / nth-check / follow-redirects / node-forge…).

```diff
   "overrides": {
+    "form-data": ">=4.0.6",
     "uuid": ">=14.0.0",
```

## التحقق
- ✅ بعد الـ override: `cd frontend && npm audit --audit-level=high` يخرج **0** (لا ثغرات عالية)
- بقيت 19 متوسطة فقط (تحت عتبة البوابة؛ dompurify يعالجه dependabot #552)
- التغيير: سطر واحد في `package.json` + تحديث `package-lock.json`

يُكمل W1421 (backend) — معاً يُخضِّران بوابتي **Tests & Code Quality** + **Security Scanning** على مستوى المستودع.

🤖 Generated with [Claude Code](https://claude.com/claude-code)